### PR TITLE
Graphics page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,9 @@ const config = {
   publicRuntimeConfig: {
     apiHost: process.env.API_HOST,
   },
+  images: {
+    domains: ['s3.amazonaws.com'],
+  },
 };
 
 module.exports = withBundleAnalyzer(config);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,3 +10,4 @@ export type {
   IADSApiSearchResponse,
   IDocsEntity,
 } from './lib/search/types';
+export type { IADSApiGraphicsParams } from './lib/graphics/types';

--- a/src/api/lib/api.ts
+++ b/src/api/lib/api.ts
@@ -12,6 +12,7 @@ import { SearchService } from './search/search';
 import { IServiceConfig } from './service';
 import { UserService } from './user/user';
 import { VaultService } from './vault';
+import { GraphicsService } from './graphics/graphics';
 
 export class Adsapi {
   public search: SearchService;
@@ -19,6 +20,7 @@ export class Adsapi {
   public user: UserService;
   public reference: ReferenceService;
   public vault: VaultService;
+  public graphics: GraphicsService;
 
   constructor(config: IServiceConfig) {
     this.search = new SearchService(config);
@@ -26,6 +28,7 @@ export class Adsapi {
     this.user = new UserService(config);
     this.reference = new ReferenceService(config);
     this.vault = new VaultService(config);
+    this.graphics = new GraphicsService(config);
   }
 
   public static bootstrap(config: IServiceConfig = {}): Promise<Result<IUserData, Error>> {

--- a/src/api/lib/graphics/graphics.ts
+++ b/src/api/lib/graphics/graphics.ts
@@ -1,0 +1,27 @@
+import { IADSApiGraphicsParams } from '@api';
+import { AxiosError, AxiosRequestConfig } from 'axios';
+import { err, ok, Result } from 'neverthrow';
+import { ApiTargets } from '../models';
+import { Service } from '../service';
+import { IADSApiGraphicsResponse } from './types';
+
+export class GraphicsService extends Service {
+  async query(params: IADSApiGraphicsParams): Promise<Result<IADSApiGraphicsResponse, Error | AxiosError>> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: ApiTargets.GRAPHICS + '/' + params.bibcode,
+    };
+
+    return await new Promise((resolve) => {
+      this.request<IADSApiGraphicsResponse>(config).then(
+        (result) => {
+          result.match(
+            (response) => resolve(ok(response)),
+            (e: Error | AxiosError) => resolve(err(e)),
+          );
+        },
+        (e: Error | AxiosError) => resolve(err(e)),
+      );
+    });
+  }
+}

--- a/src/api/lib/graphics/graphics.ts
+++ b/src/api/lib/graphics/graphics.ts
@@ -9,14 +9,20 @@ export class GraphicsService extends Service {
   async query(params: IADSApiGraphicsParams): Promise<Result<IADSApiGraphicsResponse, Error | AxiosError>> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: ApiTargets.GRAPHICS + '/' + params.bibcode,
+      url: `${ApiTargets.GRAPHICS}/${params.bibcode}`,
     };
 
     return await new Promise((resolve) => {
       this.request<IADSApiGraphicsResponse>(config).then(
         (result) => {
           result.match(
-            (response) => resolve(ok(response)),
+            (response) => {
+              if (!response.Error) {
+                resolve(ok(response));
+              } else {
+                resolve(err(new Error(response.Error)));
+              }
+            },
             (e: Error | AxiosError) => resolve(err(e)),
           );
         },

--- a/src/api/lib/graphics/types.ts
+++ b/src/api/lib/graphics/types.ts
@@ -1,0 +1,24 @@
+export interface IADSApiGraphicsParams {
+  bibcode: string;
+}
+
+export interface IADSApiGraphicsResponse {
+  bibcode: string;
+  number: number;
+  pick: string;
+  header: string;
+  figures: [
+    {
+      figure_label: string;
+      figure_caption: string;
+      figure_type: string;
+      images: [
+        {
+          thumbnail: string;
+          highres: string;
+        },
+      ];
+    },
+  ];
+  Error: string;
+}

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -30,7 +30,7 @@ const CitationsPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps
             <em>Papers that cite</em> {originalDoc.title}
           </h2>
         </div>
-        <ResultList docs={docs} hideCheckboxes={true} showActions={false} />
+        {/* <ResultList docs={docs} hideCheckboxes={true} showActions={false} /> */}
       </article>
     </section>
   );

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -7,7 +7,7 @@ import { AbstractSideNav } from '@components';
 import { normalizeURLParams } from '@utils';
 import { IADSApiGraphicsResponse } from '@api/lib/graphics/types';
 import Link from 'next/link';
-
+import Image from 'next/image';
 interface IGraphicsPageProps {
   graphics: IADSApiGraphicsResponse;
   originalDoc: IDocsEntity;
@@ -41,8 +41,14 @@ const GraphicsPage: NextPage<IGraphicsPageProps> = (props: IGraphicsPageProps) =
                     className="flex flex-col items-center justify-between m-2 p-2 border-2 border-gray-100 rounded-lg"
                   >
                     <Link href={figure.images[0].highres}>
-                      <a target="_blank" rel="noreferrer noopener">
-                        <img src={figure.images[0].thumbnail} className="p-5" alt={figure.figure_label}></img>
+                      <a target="_blank" rel="noreferrer noopener" className="relative">
+                        <Image
+                          src={figure.images[0].thumbnail}
+                          width="150"
+                          height="150"
+                          className="p-5"
+                          alt={figure.figure_label}
+                        ></Image>
                       </a>
                     </Link>
                     <span aria-hidden="true">{figure.figure_label}</span>

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -1,0 +1,95 @@
+import AdsApi, { IADSApiGraphicsParams, IADSApiSearchParams, IDocsEntity, IUserData } from '@api';
+import { GetServerSideProps, NextPage } from 'next';
+import Head from 'next/head';
+import React from 'react';
+import { abstractPageNavDefaultQueryFields } from '@components/AbstractSideNav/model';
+import { AbstractSideNav } from '@components';
+import { normalizeURLParams } from '@utils';
+import { IADSApiGraphicsResponse } from '@api/lib/graphics/types';
+import Link from 'next/link';
+
+interface IGraphicsPageProps {
+  graphics: IADSApiGraphicsResponse;
+  originalDoc: IDocsEntity;
+  error?: string;
+}
+
+const GraphicsPage: NextPage<IGraphicsPageProps> = (props: IGraphicsPageProps) => {
+  const { originalDoc, graphics, error } = props;
+  return (
+    <section className="abstract-page-container">
+      <Head>
+        <title>Graphics | {originalDoc.title}</title>
+      </Head>
+      <AbstractSideNav doc={originalDoc} />
+      <article aria-labelledby="title" className="flex-1 my-8 px-4 py-8 w-full bg-white shadow sm:rounded-lg">
+        {error ? (
+          <div>No Graphics</div>
+        ) : (
+          <>
+            <div className="border-b border-gray-200 sm:pb-0 md:pb-3">
+              <h2 className="prose-xl text-gray-900 font-medium leading-6" id="title">
+                <em>Graphics from</em> <strong>{originalDoc.title}</strong>
+              </h2>
+              <div className="my-2" dangerouslySetInnerHTML={{ __html: graphics.header }}></div>
+            </div>
+            <div className="flex flex-wrap">
+              {graphics.figures.map((figure, index) => {
+                return (
+                  <div
+                    key={index}
+                    className="flex flex-col items-center justify-between m-2 p-2 border-2 border-gray-100 rounded-lg"
+                  >
+                    <Link href={figure.images[0].highres}>
+                      <a target="_blank" rel="noreferrer noopener">
+                        <img src={figure.images[0].thumbnail} className="p-5" alt={figure.figure_label}></img>
+                      </a>
+                    </Link>
+                    <span aria-hidden="true">{figure.figure_label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </article>
+    </section>
+  );
+};
+
+export default GraphicsPage;
+
+const getOriginalDoc = async (api: AdsApi, id: string) => {
+  const result = await api.search.query({
+    q: `identifier:${id}`,
+    fl: [...abstractPageNavDefaultQueryFields, 'title'],
+  });
+  return result.isOk() ? result.value.docs[0] : null;
+};
+
+export const getServerSideProps: GetServerSideProps<IGraphicsPageProps> = async (ctx) => {
+  const query = normalizeURLParams(ctx.query);
+  const request = ctx.req as typeof ctx.req & {
+    session: { userData: IUserData };
+  };
+  const userData = request.session.userData;
+  const params: IADSApiGraphicsParams = {
+    bibcode: query.id,
+  };
+  const adsapi = new AdsApi({ token: userData.access_token });
+  const result = await adsapi.graphics.query(params);
+  const originalDoc = await getOriginalDoc(adsapi, query.id);
+
+  if (result.isErr()) {
+    return { props: { graphics: [], originalDoc, error: result.error } };
+  } else if (result.value.Error) {
+    return { props: { graphics: [], originalDoc, error: result.value.Error } };
+  }
+
+  return {
+    props: {
+      graphics: result.value,
+      originalDoc,
+    },
+  };
+};

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -1,4 +1,4 @@
-import AdsApi, { IADSApiGraphicsParams, IADSApiSearchParams, IDocsEntity, IUserData } from '@api';
+import AdsApi, { IADSApiGraphicsParams, IDocsEntity, IUserData } from '@api';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import React from 'react';
@@ -82,8 +82,6 @@ export const getServerSideProps: GetServerSideProps<IGraphicsPageProps> = async 
 
   if (result.isErr()) {
     return { props: { graphics: [], originalDoc, error: result.error } };
-  } else if (result.value.Error) {
-    return { props: { graphics: [], originalDoc, error: result.value.Error } };
   }
 
   return {


### PR DESCRIPTION
### Check whether to enable or disable the graphic link requires a query. But with current implementation, each time the menu is re-rendered (queried again) when the page changes. Is it possible to change the implementation so that we only update the content and not the menu?

![Screen Shot 2021-09-24 at 5 15 39 PM](https://user-images.githubusercontent.com/636361/134740552-ca18199c-5d72-4ce9-86d7-c8d761f9d890.png)
