### PR TITLE
Fix switching citation count and normalized citation count bug

### DIFF
--- a/src/components/ResultList/ListActions.tsx
+++ b/src/components/ResultList/ListActions.tsx
@@ -11,9 +11,6 @@ interface IListActionProp {
   service?: ISearchMachine;
   selectedCount: number;
   totalCount: number;
-  query: string;
-  sort: SolrSort[];
-  page: number;
   onSortChange: () => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
@@ -26,9 +23,6 @@ export const ListActions = (props: IListActionProp): ReactElement => {
     service: searchService,
     selectedCount,
     totalCount,
-    query,
-    sort: [sort, ...otherSorts],
-    page,
     onSelectAll,
     onSelectNone,
     onLimitedTo,
@@ -36,6 +30,19 @@ export const ListActions = (props: IListActionProp): ReactElement => {
   } = props;
 
   const [showHighlight, setShowHighlight] = useState<boolean>(false);
+
+  const page = useSelector(searchService, (state) => {
+    return state.context.pagination.page;
+  });
+
+  const query = useSelector(searchService, (state) => {
+    return state.context.params.q;
+  });
+
+  const sort = useSelector(searchService, (state) => {
+    const params = state.context.params;
+    return params.sort;
+  });
 
   const toggleShowHighlight = () => setShowHighlight(!showHighlight);
   const handleSelectAll = () => onSelectAll();
@@ -51,7 +58,7 @@ export const ListActions = (props: IListActionProp): ReactElement => {
     <>
       {!isBrowser() ? (
         <span>
-          <SimpleSortDropdown query={query} selected={sort} page={page} />
+          <SimpleSortDropdown query={query} selected={sort[0]} page={page} />
         </span>
       ) : (
         <>

--- a/src/components/ResultList/ResultList.tsx
+++ b/src/components/ResultList/ResultList.tsx
@@ -1,4 +1,4 @@
-import { IDocsEntity, SolrSort } from '@api';
+import { IDocsEntity } from '@api';
 import { ISearchMachine, TransitionType } from '@machines/lib/search/types';
 import { isBrowser } from '@utils';
 import { useSelector } from '@xstate/react';
@@ -14,9 +14,6 @@ export interface IResultListProps extends HTMLAttributes<HTMLDivElement> {
   isLoading?: boolean;
   service?: ISearchMachine;
   showActions: boolean;
-  query: string;
-  sort: SolrSort[];
-  page: number;
 }
 
 interface ISelection {
@@ -38,9 +35,6 @@ export const ResultList = (props: IResultListProps): ReactElement => {
     hideCheckboxes = !isBrowser(),
     service: searchService,
     showActions,
-    query,
-    sort,
-    page,
     ...divProps
   } = props;
 
@@ -86,6 +80,11 @@ export const ResultList = (props: IResultListProps): ReactElement => {
     return page === pages ? t % numPerPage : numPerPage;
   });
 
+  const sort = useSelector(searchService, (state) => {
+    const params = state.context.params;
+    return params.sort;
+  });
+
   useEffect(() => {
     setSelection({
       selectAll: false,
@@ -107,9 +106,6 @@ export const ResultList = (props: IResultListProps): ReactElement => {
             onSelectNone={handleSelectNone}
             onLimitedTo={handleLimitedTo}
             onExclude={handleExclude}
-            query={query}
-            sort={sort}
-            page={page}
           />
         )}
       </div>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -102,9 +102,6 @@ const Form = (props: IFormProps): ReactElement => {
               docs={result.docs as IDocsEntity[]}
               service={searchService}
               showActions={true}
-              query={query}
-              sort={sort}
-              page={page}
             />
           )}
         </div>


### PR DESCRIPTION
In the results list, when changing the sort to normalized citation count, the items did not change to show normalized citation count, but showed citation count. The fix was to get the sorting from search service context instead of from parent, which did not updated sort when sorting is changed by user.