### PR TITLE
Fix runtime config vars

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,6 @@
-API_HOST=https://devapi.adsabs.harvard.edu/v1
+BASE_CANONICAL_URL=https://ui.adsabs.harvard.edu
+API_HOST_CLIENT=https://devapi.adsabs.harvard.edu/v1
+API_HOST_SERVER=https://devapi.adsabs.harvard.edu/v1
+
 PORT=8000
 COOKIE_SECRET=G7Kfbufs9QkrnLRFPPGnciaLY3JLH3r9BL6nAKNdRPEzLAA5wcpmT6gF8hMVjY9n
-NEXT_PUBLIC_BASE_URL=https://ui.adsabs.harvard.edu

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,11 @@ const config = {
     ];
   },
   publicRuntimeConfig: {
-    apiHost: process.env.API_HOST,
+    apiHost: process.env.API_HOST_CLIENT,
+  },
+  serverRuntimeConfig: {
+    apiHost: process.env.API_HOST_SERVER,
+    baseCanonicalUrl: process.env.BASE_CANONICAL_URL,
   },
   images: {
     domains: ['s3.amazonaws.com'],

--- a/server/middlewares/api.ts
+++ b/server/middlewares/api.ts
@@ -10,7 +10,6 @@ export const api: Middleware = async (req, res, next) => {
   if (Adsapi.checkUserData(currentUserData)) {
     return next();
   }
-
   const bootstrapResponse = await Adsapi.bootstrap();
   if (bootstrapResponse.isOk()) {
     const { data, headers } = bootstrapResponse.value;

--- a/src/api/lib/api.ts
+++ b/src/api/lib/api.ts
@@ -1,8 +1,6 @@
-import { AppRuntimeConfig } from '@types';
 import axios from 'axios';
 import { isPast, parseISO } from 'date-fns';
 import { err, ok, Result } from 'neverthrow';
-import getConfig from 'next/config';
 import { isNil } from 'ramda';
 import { IADSApiBootstrapResponse, IUserData } from './bootstrap/types';
 import { ExportService } from './export';
@@ -14,6 +12,7 @@ import { ReferenceService } from './reference';
 import { SearchService } from './search/search';
 import { IServiceConfig } from './service';
 import { UserService } from './user/user';
+import { resolveApiBaseUrl } from './utils';
 import { VaultService } from './vault';
 export class Adsapi {
   public search: SearchService;
@@ -37,15 +36,11 @@ export class Adsapi {
   }
 
   public static bootstrap(config: IServiceConfig = {}): Promise<Result<IADSApiBootstrapResponse, Error>> {
-    const { publicRuntimeConfig } = (getConfig() as AppRuntimeConfig) || {
-      publicRuntimeConfig: {
-        apiHost: process.env.API_HOST,
-      },
-    };
+    const baseURL = resolveApiBaseUrl();
 
     return new Promise((resolve) => {
       axios
-        .create({ ...config, baseURL: publicRuntimeConfig.apiHost })
+        .create({ baseURL, ...config })
         .request<IUserData>({
           method: 'get',
           url: ApiTargets.BOOTSTRAP,

--- a/src/api/lib/api.ts
+++ b/src/api/lib/api.ts
@@ -53,7 +53,13 @@ export class Adsapi {
   }
 
   static isValid(userData?: IUserData): userData is IUserData {
-    return !isNil(userData) && typeof userData.access_token === 'string' && typeof userData.expire_in === 'string';
+    return (
+      !isNil(userData) &&
+      typeof userData.access_token === 'string' &&
+      typeof userData.expire_in === 'string' &&
+      userData.access_token.length > 0 &&
+      userData.expire_in.length > 0
+    );
   }
 
   static isExpired(userData: IUserData): boolean {

--- a/src/api/lib/service.ts
+++ b/src/api/lib/service.ts
@@ -1,27 +1,20 @@
-import { AppRuntimeConfig } from '@types';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import * as AxiosLogger from 'axios-logger';
 import { RequestLogConfig } from 'axios-logger/lib/common/types';
 import { PathLike } from 'fs';
 import { err, ok, Result } from 'neverthrow';
-import getConfig from 'next/config';
 import qs from 'qs';
 import { mergeDeepLeft } from 'ramda';
+import { resolveApiBaseUrl } from './utils';
 
 export interface IServiceConfig extends AxiosRequestConfig {
   debug?: boolean;
   token?: string;
 }
 
-const {
-  publicRuntimeConfig: { apiHost },
-} = (getConfig() as AppRuntimeConfig) || {
-  publicRuntimeConfig: { apiHost: process.env.API_HOST },
-};
-
 const baseConfig: IServiceConfig = {
   token: undefined,
-  baseURL: apiHost,
+  baseURL: resolveApiBaseUrl(),
   withCredentials: true,
   timeout: 30000,
   paramsSerializer: (params: PathLike) => qs.stringify(params, { indices: false }),
@@ -46,7 +39,7 @@ export class Service {
 
   constructor(config: IServiceConfig) {
     // recursively merge configurations
-    const { token, debug, ...cfg } = (mergeDeepLeft as MDL)(config, baseConfig) || {};
+    const { token, debug, ...cfg } = (mergeDeepLeft as MDL)(config, baseConfig);
     this.service = axios.create(cfg);
 
     this.service.interceptors.request.use((request: AxiosRequestConfig) => {

--- a/src/api/lib/utils.ts
+++ b/src/api/lib/utils.ts
@@ -1,0 +1,16 @@
+import getConfig from 'next/config';
+/**
+ * Figure out which config to pick, based on the current environment
+ */
+export const resolveApiBaseUrl = (defaultBaseUrl = ''): string => {
+  const config = getConfig();
+
+  if (typeof config === 'undefined') {
+    return defaultBaseUrl;
+  }
+
+  if (typeof window === 'undefined') {
+    return config.serverRuntimeConfig?.apiHost ?? defaultBaseUrl;
+  }
+  return config.publicRuntimeConfig?.apiHost ?? defaultBaseUrl;
+};

--- a/src/augment.d.ts
+++ b/src/augment.d.ts
@@ -1,0 +1,12 @@
+declare module 'next/config' {
+  interface AppRuntimeConfig {
+    publicRuntimeConfig: {
+      apiHost: string;
+    };
+    serverRuntimeConfig: {
+      apiHost: string;
+      baseCanonicalUrl: string;
+    };
+  }
+  export default function getConfig(): AppRuntimeConfig;
+}

--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -4,7 +4,6 @@ import { ItemType } from '@components/Dropdown/types';
 import { DocumentIcon } from '@heroicons/react/outline';
 import { ChevronDownIcon } from '@heroicons/react/solid';
 import { useViewport, Viewport } from '@hooks';
-import { useAppCtx } from '@store';
 import { useBaseRouterPath } from '@utils';
 import clsx from 'clsx';
 import Link from 'next/link';
@@ -25,10 +24,6 @@ export const AbstractSideNav = ({ doc }: IAbstractSideNavProps): ReactElement =>
   const viewport = useViewport();
   const hasGraphics = useHasGraphics(doc);
   const hasMetrics = useHasMetrics(doc);
-
-  const {
-    state: { user },
-  } = useAppCtx();
 
   const useCount = [Routes.CITATIONS, Routes.REFERENCES];
 
@@ -79,7 +74,7 @@ export const AbstractSideNav = ({ doc }: IAbstractSideNavProps): ReactElement =>
         disabled: count === 0 && item.href !== Routes.ABSTRACT,
       };
     });
-    const currentItem = navigation.find((item) => item.href === subPage);
+    const currentItem = navigation.find((item) => item.href === subPage) ?? navigation[0];
     const Icon = currentItem.icon || DocumentIcon;
     const count = getCount(currentItem.href, doc);
     const showCount = count > 0 && currentItem.href !== Routes.SIMILAR;

--- a/src/components/AbstractSideNav/queries.ts
+++ b/src/components/AbstractSideNav/queries.ts
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 export const useHasGraphics = (doc: IDocsEntity): boolean => {
   const { api } = useAPI();
 
-  const { data: hasGraphics } = useQuery(['hasGraphics', doc.bibcode], () => fetchHasGraphics(api, doc.bibcode), {
+  const { data: hasGraphics } = useQuery(['hasGraphics', doc?.bibcode], () => fetchHasGraphics(api, doc.bibcode), {
     enabled: !!doc,
   });
 
@@ -15,7 +15,7 @@ export const useHasGraphics = (doc: IDocsEntity): boolean => {
 
 export const useHasMetrics = (doc: IDocsEntity): boolean => {
   const { api } = useAPI();
-  const { data: hasMetrics } = useQuery(['hasMetrics', doc.bibcode], () => fetchHasMetrics(api, doc.bibcode), {
+  const { data: hasMetrics } = useQuery(['hasMetrics', doc?.bibcode], () => fetchHasMetrics(api, doc.bibcode), {
     enabled: !!doc,
   });
 

--- a/src/components/Layout/AbsLayout.tsx
+++ b/src/components/Layout/AbsLayout.tsx
@@ -1,6 +1,7 @@
 import { IDocsEntity } from '@api';
 import { AbstractSideNav } from '@components';
 import { Metatags } from '@components/Metatags/Metatags';
+import { isBrowser } from '@utils';
 import Head from 'next/head';
 import { FC } from 'react';
 
@@ -12,10 +13,12 @@ export const AbsLayout: FC<IAbsLayoutProps> = ({ children, doc }) => {
   return (
     <>
       <section className="abstract-page-container">
-        <Head>
-          <title>{doc ? doc.title : ''}</title>
-        </Head>
-        <Metatags doc={doc} />
+        {!isBrowser() && (
+          <Head>
+            <title>{doc?.title ?? ''}</title>
+            <Metatags doc={doc} />
+          </Head>
+        )}
         <AbstractSideNav doc={doc} />
         {children}
       </section>

--- a/src/components/Metatags/Metatags.tsx
+++ b/src/components/Metatags/Metatags.tsx
@@ -1,12 +1,19 @@
 import { IDocsEntity } from '@api';
 import { Esources } from '@api/lib/search/types';
 import { getFomattedNumericPubdate } from '@utils';
-import Head from 'next/head';
+import getConfig from 'next/config';
 import { ReactElement } from 'react';
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+const getBaseUrl = () => {
+  try {
+    return getConfig().serverRuntimeConfig?.baseCanonicalUrl ?? '';
+  } catch (e) {
+    return '';
+  }
+};
 
-const LINKGWAY_BASE_URL = `${BASE_URL}/link_gateway`;
+const baseUrl = getBaseUrl();
+const LINKGWAY_BASE_URL = `${baseUrl}/link_gateway`;
 interface IMetatagsProps {
   doc: IDocsEntity;
 }
@@ -53,9 +60,9 @@ export const Metatags = (props: IMetatagsProps): ReactElement => {
 
   const title = doc.title ? doc.title.join('; ') : '';
 
-  const url = `${BASE_URL}/abs/${doc.bibcode}/abstract`;
+  const url = `${baseUrl}/abs/${doc.bibcode}/abstract`;
 
-  const logo = `${BASE_URL}/styles/img/transparent_logo.svg`;
+  const logo = `${baseUrl}/styles/img/transparent_logo.svg`;
 
   const formatted_numeric_pubdate = doc.pubdate ? getFomattedNumericPubdate(doc.pubdate) ?? '' : '';
 
@@ -66,8 +73,8 @@ export const Metatags = (props: IMetatagsProps): ReactElement => {
   const authors = doc.author ? doc.author.slice(0, 50) : [];
 
   return (
-    <Head>
-      <link rel="canonical" href={`${BASE_URL}/abs/${doc.bibcode}/abstract`} />
+    <>
+      <link rel="canonical" href={`${baseUrl}/abs/${doc.bibcode}/abstract`} />
 
       <meta name="description" content={doc.abstract} />
 
@@ -174,6 +181,6 @@ export const Metatags = (props: IMetatagsProps): ReactElement => {
       <meta name="twitter:image:src" content={logo} />
 
       <meta name="twitter:creator" content="@adsabs" />
-    </Head>
+    </>
   );
 };

--- a/src/components/__stories__/Export.stories.tsx
+++ b/src/components/__stories__/Export.stories.tsx
@@ -1,7 +1,6 @@
 import Adsapi, { IADSApiSearchResponse } from '@api';
 import { IExportApiParams, IExportApiResponse } from '@api/lib/export';
 import * as fixtures from '@components/__mocks__/exportMock';
-import { mockSession } from '@components/__mocks__/session';
 import { ApiProvider } from '@providers/api';
 import { AppProvider } from '@store';
 import { Meta, Story } from '@storybook/react';
@@ -32,7 +31,7 @@ const meta: Meta<IExportProps> = {
   },
   decorators: [
     (story): ReactElement => (
-      <AppProvider session={mockSession} initialStore={{ query: fixtures.mockQuery }}>
+      <AppProvider initialStore={{ query: fixtures.mockQuery }}>
         <ApiProvider overrideInstance={api}>
           <ToastContainer />
           {story()}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import { ApiProvider } from '@providers/api';
 import { AppProvider, useAppCtx } from '@store';
 import { Theme } from '@types';
 import { isBrowser } from '@utils';
-import { AppProps } from 'next/app';
+import App, { AppContext, AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import 'nprogress/nprogress.css';
@@ -60,6 +60,11 @@ const ThemeRouter = (): ReactElement => {
   }, [state.theme, router.asPath]);
 
   return <></>;
+};
+
+NectarApp.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext);
+  return { ...appProps };
 };
 
 export default NectarApp;

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -2,7 +2,9 @@ import Adsapi, { IUserData } from '@api';
 import { useQuery } from 'react-query';
 
 export const useBootstrap = (onSuccess: (data: IUserData) => void): void => {
-  useQuery<IUserData>(['bootstrap'], fetchBootstrap, { onSuccess });
+  useQuery<IUserData>(['bootstrap'], fetchBootstrap, {
+    onSuccess,
+  });
 };
 
 const fetchBootstrap = async (): Promise<IUserData> => {

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -1,9 +1,10 @@
 import Adsapi, { IUserData } from '@api';
 import { useQuery } from 'react-query';
 
-export const useBootstrap = (onSuccess: (data: IUserData) => void): void => {
+export const useBootstrap = (userData: IUserData, onSuccess: (data: IUserData) => void): void => {
   useQuery<IUserData>(['bootstrap'], fetchBootstrap, {
     onSuccess,
+    enabled: !Adsapi.isValid(userData),
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,5 @@
 import { IUserData } from '@api';
 
-export interface AppRuntimeConfig {
-  publicRuntimeConfig: {
-    apiHost: string;
-  };
-  serverRuntimeConfig: Record<string, string>;
-}
-
 export enum Theme {
   GENERAL = 'GENERAL',
   ASTROPHYSICS = 'ASTROPHYSICS',
@@ -14,16 +7,6 @@ export enum Theme {
   PLANET_SCIENCE = 'PLANET_SCIENCE',
   EARTH_SCIENCE = 'EARTH_SCIENCE',
   BIO_PHYSICAL = 'BIO_PHYSICAL_SCIENCE',
-}
-
-interface SessionData {
-  userData: IUserData;
-}
-
-declare module 'http' {
-  interface IncomingMessage {
-    session: SessionData;
-  }
 }
 
 export enum AppErrorCode {
@@ -44,4 +27,14 @@ export interface AppError {
     code: AppErrorCode;
     innererror?: InnerError;
   };
+}
+
+export interface SessionData {
+  userData: IUserData;
+}
+
+declare module 'http' {
+  interface IncomingMessage {
+    session: SessionData;
+  }
 }


### PR DESCRIPTION
This removes the `next/config` dep from individual components
load it at the top and pass it as a store property

We can then use it for api calls globally

Make Metatags run only server-side, this eliminates the need to hold the baseUrl prop in store