### PR TITLE
Add view as search results links in citations, coreads, references, similar

### DIFF
--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -9,7 +9,7 @@ import { useBaseRouterPath } from '@utils';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { last } from 'ramda';
+import { composeP, last } from 'ramda';
 import { HTMLAttributes, ReactElement } from 'react';
 import { navigation, Routes } from './model';
 import { useHasGraphics, useHasMetrics } from './queries';
@@ -21,7 +21,7 @@ export interface IAbstractSideNavProps extends HTMLAttributes<HTMLDivElement> {
 export const AbstractSideNav = ({ doc }: IAbstractSideNavProps): ReactElement => {
   const router = useRouter();
   const { basePath } = useBaseRouterPath();
-  const subPage = last(basePath);
+  const subPage = last(basePath.split('/'));
   const viewport = useViewport();
   const hasGraphics = useHasGraphics(doc);
   const hasMetrics = useHasMetrics(doc);

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -9,6 +9,8 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient } from 'react-query';
 import { normalizeURLParams } from 'src/utils';
+import Link from 'next/link';
+import qs from 'qs';
 export interface ICitationsPageProps {
   docs: IDocsEntity[];
   originalDoc: IDocsEntity;
@@ -52,12 +54,19 @@ const CitationsPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps
         {error ? (
           <div className="flex items-center justify-center w-full h-full text-xl">{error}</div>
         ) : (
-          <SimpleResultList
-            query={getQueryParams(query.id)}
-            numFound={originalDoc['[citations]'].num_citations}
-            docs={docs}
-            hideCheckboxes={true}
-          />
+          <>
+            <Link
+              href={`/search?${qs.stringify({ q: `citations(bibcode:${originalDoc.bibcode})`, sort: 'date desc' })}`}
+            >
+              <a className="link text-sm">View as search results</a>
+            </Link>
+            <SimpleResultList
+              query={getQueryParams(query.id)}
+              numFound={originalDoc['[citations]'].num_citations}
+              docs={docs}
+              hideCheckboxes={true}
+            />
+          </>
         )}
       </article>
     </AbsLayout>

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -8,6 +8,9 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient } from 'react-query';
 import { normalizeURLParams } from 'src/utils';
+import Link from 'next/link';
+import qs from 'qs';
+
 export interface ICitationsPageProps {
   docs: IDocsEntity[];
   originalDoc: IDocsEntity;
@@ -51,12 +54,22 @@ const CoreadsPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps) 
         {error ? (
           <div className="flex items-center justify-center w-full h-full text-xl">{error}</div>
         ) : (
-          <SimpleResultList
-            docs={docs}
-            query={getQueryParams(query.id)}
-            numFound={parseInt(originalDoc.read_count) ?? 0}
-            hideCheckboxes={true}
-          />
+          <>
+            <Link
+              href={`/search?${qs.stringify({
+                q: `trending(bibcode:${originalDoc.bibcode}) -bibcode:${originalDoc.bibcode}`,
+                sort: 'score desc',
+              })}`}
+            >
+              <a className="link text-sm">View as search results</a>
+            </Link>
+            <SimpleResultList
+              docs={docs}
+              query={getQueryParams(query.id)}
+              numFound={parseInt(originalDoc.read_count) ?? 0}
+              hideCheckboxes={true}
+            />
+          </>
         )}
       </article>
     </AbsLayout>

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -8,6 +8,8 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient } from 'react-query';
 import { normalizeURLParams } from 'src/utils';
+import Link from 'next/link';
+import qs from 'qs';
 export interface ICitationsPageProps {
   docs: IDocsEntity[];
   originalDoc: IDocsEntity;
@@ -32,7 +34,7 @@ const getQueryParams = (id: string | string[]): IADSApiSearchParams => {
       'property',
       'data',
     ],
-    sort: ['date desc'],
+    sort: ['first_author asc'],
   };
 };
 
@@ -51,12 +53,22 @@ const ReferencesPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProp
         {error ? (
           <div className="flex items-center justify-center w-full h-full text-xl">{error}</div>
         ) : (
-          <SimpleResultList
-            numFound={originalDoc['[citations]'].num_references}
-            query={getQueryParams(query.id)}
-            docs={docs}
-            hideCheckboxes={true}
-          />
+          <>
+            <Link
+              href={`/search?${qs.stringify({
+                q: `references(bibcode:${originalDoc.bibcode})`,
+                sort: 'first_author asc',
+              })}`}
+            >
+              <a className="link text-sm">View as search results</a>
+            </Link>
+            <SimpleResultList
+              numFound={originalDoc['[citations]'].num_references}
+              query={getQueryParams(query.id)}
+              docs={docs}
+              hideCheckboxes={true}
+            />
+          </>
         )}
       </article>
     </AbsLayout>

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -8,6 +8,8 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient } from 'react-query';
 import { normalizeURLParams } from 'src/utils';
+import Link from 'next/link';
+import qs from 'qs';
 export interface ICitationsPageProps {
   docs: IDocsEntity[];
   originalDoc: IDocsEntity;
@@ -51,7 +53,22 @@ const SimilarPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps) 
         {error ? (
           <div className="flex items-center justify-center w-full h-full text-xl">{error}</div>
         ) : (
-          <SimpleResultList numFound={docs.length} query={getQueryParams(query.id)} docs={docs} hideCheckboxes={true} />
+          <>
+            <Link
+              href={`/search?${qs.stringify({
+                q: `similar(bibcode:${originalDoc.bibcode})`,
+                sort: 'score desc',
+              })}`}
+            >
+              <a className="link text-sm">View as search results</a>
+            </Link>
+            <SimpleResultList
+              numFound={docs.length}
+              query={getQueryParams(query.id)}
+              docs={docs}
+              hideCheckboxes={true}
+            />
+          </>
         )}
       </article>
     </AbsLayout>


### PR DESCRIPTION
Use a simple link
* citation: q: citations(bibcode:XXX), sort: date desc
* references: q: references(bibcode:XXX), sort: first_author asc
* coreads: trending(bibcode:XXX) -bibcode:XXX, sort: score desc
* similar: similar(bibcode:XXX), sort: score desc
![Screen Shot 2021-11-05 at 4 33 04 PM](https://user-images.githubusercontent.com/636361/140574975-1c9d4989-0577-4a40-bff1-4db2a809e079.png)

