### PR TITLE
Simple result list not updating bug

### DIFF
--- a/src/components/ResultList/SimpleResultList.tsx
+++ b/src/components/ResultList/SimpleResultList.tsx
@@ -5,7 +5,7 @@ import { useMachine } from '@xstate/react';
 import { useRouter } from 'next/router';
 import PT from 'prop-types';
 import qs from 'qs';
-import { HTMLAttributes, ReactElement } from 'react';
+import { HTMLAttributes, ReactElement, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { assign, ContextFrom, DoneInvokeEvent } from 'xstate';
 import { createModel } from 'xstate/lib/model';
@@ -68,6 +68,10 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
     }),
   );
 
+  useEffect(() => {
+    send('updateContext', { docs, page: p ? p : 1 });
+  }, [query]);
+
   const handlePaginationChange = (page: number) => {
     send('updatePage', { page });
   };
@@ -109,6 +113,7 @@ const createResultListMachine = ({
   const model = createModel(initialContext, {
     events: {
       updatePage: (page: number) => ({ page }),
+      updateContext: (page: number, docs: IDocsEntity[]) => ({ page, docs }),
     },
   });
 
@@ -124,6 +129,13 @@ const createResultListMachine = ({
               updatePage: {
                 target: '#result-machine.fetching',
                 actions: model.assign({ page: (_, ev) => ev.page }),
+              },
+              updateContext: {
+                target: '#result-machine.idle.standby',
+                actions: model.assign({
+                  page: (_, ev) => ev.page,
+                  docs: (_, ev) => ev.docs,
+                }),
               },
             },
           },

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -89,7 +89,7 @@ const Form = (props: IFormProps): ReactElement => {
               <SearchBarWrapper searchService={searchService} />
             </div>
           </div>
-          <NumFound searchService={searchService} count={result.numFound} />
+          {typeof serverError !== 'string' && <NumFound searchService={searchService} count={result.numFound} />}
           {/* <Filters /> */}
         </div>
         <div className="col-span-6">


### PR DESCRIPTION
### To reproduce the bug:
Go to https://playground.adsabs.harvard.edu/abs/2021MNRAS.508.4202Z/citations
Click on the second item’s citations link (cited: 71)
The results list didn’t get updated

### Cause
In `SimpleResultList`, when page is updated,  `useMachine()` doesn't create a new machine with new state, but instead uses the previous state. My guess is that the during the lifetime of the component, the machine does not get re-created and we must update the machine's state through events. 

### Solution
Check when `query` is changed, send an event to update the machine's state with new docs. Also added `query` and `basePath` to the state which are used for fetching.