### PR TITLE
Search when input is empty

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -215,7 +215,13 @@ export const SearchBar = forwardRef<Partial<HTMLInputElement>, ISearchBarProps>(
       </Flex>
 
       {/* @TODO: fix this magic number */}
-      <Button type="submit" h="40px" borderLeftRadius="none" data-testid="primary-search-submit">
+      <Button
+        type="submit"
+        h="40px"
+        borderLeftRadius="none"
+        data-testid="primary-search-submit"
+        isDisabled={props.isLoading}
+      >
         {props.isLoading ? (
           <>
             <Spinner />

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -215,13 +215,7 @@ export const SearchBar = forwardRef<Partial<HTMLInputElement>, ISearchBarProps>(
       </Flex>
 
       {/* @TODO: fix this magic number */}
-      <Button
-        type="submit"
-        h="40px"
-        borderLeftRadius="none"
-        data-testid="primary-search-submit"
-        isDisabled={props.isLoading || !query || query.trim() === ''}
-      >
+      <Button type="submit" h="40px" borderLeftRadius="none" data-testid="primary-search-submit">
         {props.isLoading ? (
           <>
             <Spinner />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,7 +25,9 @@ const HomePage: NextPage = () => {
   const handleOnSubmit: ChangeEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     const { q, sort } = store.getState().query;
-    void router.push({ pathname: '/search', query: { q, sort, p: 1 } });
+    if (q && q.trim().length > 0) {
+      void router.push({ pathname: '/search', query: { q, sort, p: 1 } });
+    }
   };
 
   const handleExampleSelect = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { useStore, useStoreApi } from '@store';
 import { NextPage } from 'next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { ChangeEventHandler, useEffect, useRef } from 'react';
+import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
 
 const SearchExamples = dynamic<ISearchExamplesProps>(
   () => import('@components/SearchExamples').then((m) => m.SearchExamples),
@@ -16,6 +16,7 @@ const HomePage: NextPage = () => {
   const resetQuery = useStore((state) => state.resetQuery);
   const router = useRouter();
   const input = useRef<HTMLInputElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => resetQuery(), []);
 
@@ -26,6 +27,7 @@ const HomePage: NextPage = () => {
     e.preventDefault();
     const { q, sort } = store.getState().query;
     if (q && q.trim().length > 0) {
+      setIsLoading(true);
       void router.push({ pathname: '/search', query: { q, sort, p: 1 } });
     }
   };
@@ -45,7 +47,7 @@ const HomePage: NextPage = () => {
         </Text>
         <Flex direction="column">
           <Box my={2}>
-            <SearchBar ref={input} />
+            <SearchBar ref={input} isLoading={isLoading} />
           </Box>
           <Box mb={2} mt={5}>
             <SearchExamples onSelect={handleExampleSelect} />

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -69,7 +69,7 @@ const JournalQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; isC
         void onSubmit(values);
       }}
     >
-      {({ isSubmitting, handleReset, setFieldValue, dirty }) => {
+      {({ isSubmitting, handleReset, setFieldValue }) => {
         const handleBibstemUpdate = (bibstem: string) => setFieldValue('bibstem', bibstem, false);
 
         return (
@@ -115,7 +115,7 @@ const JournalQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; isC
                 </GridItem>
               </Grid>
               <Stack direction="row" mt={5}>
-                <Button size="sm" isDisabled={isSubmitting || !dirty} type="submit" isLoading={isSubmitting}>
+                <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
                   Search
                 </Button>
                 {isClient && (
@@ -140,7 +140,7 @@ const ReferenceQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; i
         void onSubmit(values);
       }}
     >
-      {({ isSubmitting, handleReset, dirty }) => (
+      {({ isSubmitting, handleReset }) => (
         <Box
           aria-labelledby="form-title"
           backgroundColor="gray.50"
@@ -162,7 +162,7 @@ const ReferenceQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; i
             />
             <ErrorMessage name="reference" component="div" />
             <Stack direction="row" mt={5}>
-              <Button size="sm" isDisabled={isSubmitting || !dirty} type="submit" isLoading={isSubmitting}>
+              <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
                 Search
               </Button>
               {isClient && (
@@ -186,7 +186,7 @@ const BibcodeQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; isC
         void onSubmit(values);
       }}
     >
-      {({ isSubmitting, handleReset, dirty }) => (
+      {({ isSubmitting, handleReset }) => (
         <Box
           aria-labelledby="form-title"
           backgroundColor="gray.50"
@@ -211,7 +211,7 @@ const BibcodeQueryForm = ({ onSubmit, isClient }: { onSubmit: SubmitHandler; isC
               )}
             </Field>
             <Stack direction="row" mt={5}>
-              <Button size="sm" isDisabled={isSubmitting || !dirty} type="submit" isLoading={isSubmitting}>
+              <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
                 Search
               </Button>
               {isClient && (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -53,6 +53,7 @@ const useSearchQuery = (submitted: boolean, query: IADSApiSearchParams) => {
 };
 
 const SearchPage: NextPage<ISearchPageProps> = () => {
+  const store = useStoreApi();
   const updateQuery = useStore((state) => state.updateQuery);
   const query = useStoreApi().getState().query;
 
@@ -105,12 +106,14 @@ const SearchPage: NextPage<ISearchPageProps> = () => {
   const clearSelectedDocs = useStore((state) => state.clearSelected);
   const handleOnSubmit = (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const { q } = store.getState().query;
+    if (q && q.trim().length > 0) {
+      updateAndSubmit();
 
-    updateAndSubmit();
-
-    // resets the page to 1
-    pagination.dispatch({ type: 'RESET' });
-    clearSelectedDocs();
+      // resets the page to 1
+      pagination.dispatch({ type: 'RESET' });
+      clearSelectedDocs();
+    }
   };
 
   // trigger new search on sort change


### PR DESCRIPTION
Change how to handle empty search. Rather than disable search, check if query is empty on submit, don't handle submit if it is empty. This way we don't disable search in JS disabled browsers.

Also use loading indicator on submitting search on landing page.