### PR TITLE
Don't show toast message if fetch error is due to has no graphics or has no metrics

### DIFF
--- a/src/_api/graphics/graphics.ts
+++ b/src/_api/graphics/graphics.ts
@@ -35,7 +35,7 @@ export const useHasGraphics: ADSQuery<IDocsEntity['bibcode'], IADSApiGraphicsRes
     queryKey: graphicsKeys.primary(bibcode),
     queryFn: fetchGraphics,
     retry: retryFn,
-    meta: { params },
+    meta: { params, skipGlobalErrorHandler: true },
     ...options,
   });
 

--- a/src/_api/metrics/metrics.ts
+++ b/src/_api/metrics/metrics.ts
@@ -34,7 +34,7 @@ export const useHasMetrics: ADSQuery<IDocsEntity['bibcode'], IADSApiMetricsRespo
     queryKey: metricsKeys.primary(bibcode),
     queryFn: fetchMetrics,
     retry: retryFn,
-    meta: { params },
+    meta: { params, skipGlobalErrorHandler: true },
     ...options,
   });
 

--- a/src/hooks/useCreateQueryClient.ts
+++ b/src/hooks/useCreateQueryClient.ts
@@ -20,7 +20,11 @@ export const useCreateQueryClient = () => {
         },
         queryCache: new QueryCache({
           onError: (error) => {
-            if (axios.isAxiosError(error) || error instanceof Error) {
+            if (
+              (axios.isAxiosError(error) || error instanceof Error) &&
+              !error.message.startsWith('No database entry') && // no graphics
+              !error.message.startsWith('No data available') // no metrics
+            ) {
               toast({
                 title: 'Error',
                 description: error.message,

--- a/src/hooks/useCreateQueryClient.ts
+++ b/src/hooks/useCreateQueryClient.ts
@@ -19,12 +19,13 @@ export const useCreateQueryClient = () => {
           },
         },
         queryCache: new QueryCache({
-          onError: (error) => {
-            if (
-              (axios.isAxiosError(error) || error instanceof Error) &&
-              !error.message.startsWith('No database entry') && // no graphics
-              !error.message.startsWith('No data available') // no metrics
-            ) {
+          onError: (error, query) => {
+            // check if we should skip handling the error here
+            if (query.meta?.skipGlobalErrorHandler) {
+              return;
+            }
+
+            if (axios.isAxiosError(error) || error instanceof Error) {
               toast({
                 title: 'Error',
                 description: error.message,


### PR DESCRIPTION
In abstract page, we get toast message if fetching getHasMetrics and getHasGraphics return negative. Here I added a check to see if the error messages match no graphics or no metrics error. I don't really like doing it this way. @thostetler do you have any suggestions?