### PR TITLE
Small fixes

### DIFF
--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -23,21 +23,21 @@ export interface IAbstractSideNavProps extends HTMLAttributes<HTMLDivElement> {
 
 export const AbstractSideNav = ({ doc }: IAbstractSideNavProps): ReactElement => {
   const router = useRouter();
+  const isClient = useIsClient();
   const { basePath } = useBaseRouterPath();
   const subPage = last(basePath.split('/'));
   const hasGraphics = useHasGraphics(doc.bibcode);
   const hasMetrics = useHasMetrics(doc.bibcode);
   const hasToc = doc.property ? doc.property.indexOf('TOC') > -1 : false;
   const useCount = [Routes.CITATIONS, Routes.REFERENCES];
-  const isClient = useIsClient();
 
   const items = navigation.map((item) => {
     const MenuIcon = item.icon || DocumentIcon;
     const current = item.href === subPage;
     const count =
       item.href === Routes.EXPORT ||
-      (item.href === Routes.GRAPHICS && hasGraphics) ||
-      (item.href === Routes.METRICS && hasMetrics) ||
+      (item.href === Routes.GRAPHICS && (hasGraphics || !isClient)) ||
+      (item.href === Routes.METRICS && (hasMetrics || !isClient)) ||
       (item.href === Routes.VOLUMECONTENT && hasToc)
         ? 1
         : getCount(item.href, doc);

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -165,7 +165,12 @@ const NoJsSort = (): ReactElement => {
 
   return (
     <HStack spacing={0}>
-      <SimpleLinkDropdown items={options} label={sortby} minListWidth="300px" minLabelWidth="300px" />
+      <SimpleLinkDropdown
+        items={options}
+        label={sortOptions.find((o) => o.id === sortby).label}
+        minListWidth="300px"
+        minLabelWidth="300px"
+      />
       <NextLink
         href={{ query: { ...router.query, p: 1, sort: `${sortby} ${getToggledDir(dir as SolrSortDirection)}` } }}
         passHref

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -1,5 +1,4 @@
 import { IADSApiSearchResponse } from '@api';
-import { Alert, AlertIcon } from '@chakra-ui/alert';
 import { Box, Flex, Link } from '@chakra-ui/layout';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
@@ -11,11 +10,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import NextImage from 'next/image';
 import NextLink from 'next/link';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import { dehydrate, DehydratedState, hydrate, QueryClient } from 'react-query';
-import { toast } from 'react-toastify';
-
 interface IGraphicsPageProps {
   id: string;
   error?: {
@@ -26,36 +21,26 @@ interface IGraphicsPageProps {
 
 const GraphicsPage: NextPage<IGraphicsPageProps> = (props: IGraphicsPageProps) => {
   const { id } = props;
-  const router = useRouter();
 
   const doc = useGetAbstractDoc(id);
 
-  const {
-    data: graphics,
-    isError,
-    isSuccess,
-    error,
-  } = useGetGraphics(doc.bibcode, { keepPreviousData: true, retry: false });
-
-  useEffect(() => {
-    if (isError) {
-      void router.replace('/abs/[id]/abstract', `/abs/${id}/abstract`);
-      toast(error, { type: 'error' });
-    }
-  }, [isError]);
-
+  const { data: graphics, isError, isSuccess } = useGetGraphics(doc.bibcode, { keepPreviousData: true, retry: false });
   return (
     <AbsLayout doc={doc} titleDescription="Graphics from">
       <Head>
         <title>NASA Science Explorer - Graphics - {doc.title[0]}</title>
       </Head>
-      {error && (
-        <Alert status="error">
-          <AlertIcon />
-          {error}
-        </Alert>
+      {isError && (
+        <Box mt={5} fontSize="xl">
+          Unable to fetch graphics
+        </Box>
       )}
-      {isSuccess && (
+      {!isError && !graphics && (
+        <Box mt={5} fontSize="xl">
+          No graphics
+        </Box>
+      )}
+      {isSuccess && graphics && (
         <>
           <Box dangerouslySetInnerHTML={{ __html: graphics.header }}></Box>
           <Flex wrap="wrap">


### PR DESCRIPTION
* Always enable 'metrics' and 'graphics' in Abstract nav menu for non-JS
  * Display no data on these pages if no metrics/graphics
* Fix sort label for non-js