### PR TITLE
A couple of small fixes

### DIFF
--- a/src/components/ResultList/ListActions.tsx
+++ b/src/components/ResultList/ListActions.tsx
@@ -21,7 +21,7 @@ import { ISortProps, Sort } from '@components/Sort';
 import { sections } from '@components/Visualizations';
 import { useIsClient } from '@hooks/useIsClient';
 import { AppState, useStore, useStoreApi } from '@store';
-import { noop } from '@utils';
+import { makeSearchParams, noop } from '@utils';
 import { useRouter } from 'next/router';
 import { curryN } from 'ramda';
 import { MouseEventHandler, ReactElement, useEffect, useState } from 'react';
@@ -95,7 +95,7 @@ export const ListActions = (props: IListActionsProps): ReactElement => {
     if (exploreAll) {
       // new search with operator
       const q = `${operator}(${router.query.q as string})`;
-      void router.push({ pathname: '', query: { q, sort: ['score desc', 'bibcode desc'] } });
+      void router.push({ pathname: '', query: makeSearchParams({ q, sort: ['score desc'] }) });
     } else {
       setPath({ operator });
     }

--- a/src/components/Visualizations/GraphPanes/YearsGraphPane.tsx
+++ b/src/components/Visualizations/GraphPanes/YearsGraphPane.tsx
@@ -12,7 +12,6 @@ import {
   Button,
 } from '@chakra-ui/react';
 import { BarGraph } from '@components';
-import { BarDatum } from '@nivo/bar';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { IBarGraph, YearDatum } from '../types';

--- a/src/pages/search/overview.tsx
+++ b/src/pages/search/overview.tsx
@@ -16,9 +16,10 @@ const OverviewPage: NextPage = () => {
   const bibsQuery: IADSApiSearchParams = qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query;
 
   const handleApplyQueryCondition = (facet: FacetField, cond: string) => {
-    const q = getQueryWithCondition(originalQuery.q, facet, cond);
-    const newQuery = { ...originalQuery, q };
-    void router.push({ pathname: '/search', query: makeSearchParams(newQuery) });
+    // Run new query by appending condition to the original query or to the qid
+    const tmpQuery = qid ? `docs(${qid})` : originalQuery.q;
+    const q = getQueryWithCondition(tmpQuery, facet, cond);
+    void router.push({ pathname: '/search', query: makeSearchParams({ q }) });
   };
 
   return (


### PR DESCRIPTION
* When doing a new search after filter is applied from overview graphs, use qid if that's available.
* Fix operator links (use `makeSearchParams`)