### PR TITLE
Show 'no metrics' as info alert on metrics page

### DIFF
--- a/src/components/Visualizations/Containers/MetricsPageContainer.tsx
+++ b/src/components/Visualizations/Containers/MetricsPageContainer.tsx
@@ -88,13 +88,36 @@ const MetricsComponent = ({ bibcodes }: { bibcodes: Bibcode[] }): ReactElement =
     <Box my={5}>
       {bibcodes && bibcodes.length > 0 ? (
         <>
-          {isErrorMetrics ? (
-            <Alert status="error" my={5}>
-              <AlertIcon />
-              <AlertTitle mr={2}>Error fetching metrics!</AlertTitle>
-              <AlertDescription>{axios.isAxiosError(errorMetrics) && errorMetrics.message}</AlertDescription>
-            </Alert>
-          ) : (
+          {/* No metrics warning or Fetching error */}
+          {isErrorMetrics && (
+            <>
+              {errorMetrics instanceof Error && errorMetrics.message.startsWith('No data available') ? (
+                <Alert
+                  status="info"
+                  my={5}
+                  variant="subtle"
+                  flexDirection="column"
+                  justifyContent="center"
+                  height="200px"
+                  backgroundColor="transparent"
+                >
+                  <AlertIcon boxSize="40px" />
+                  <AlertTitle mt={4} mb={1} fontSize="lg">
+                    Metrics not available
+                  </AlertTitle>
+                  <AlertDescription>{errorMetrics.message}</AlertDescription>
+                </Alert>
+              ) : (
+                <Alert status="error" my={5}>
+                  <AlertIcon />
+                  <AlertTitle mr={2}>Error fetching metrics!</AlertTitle>
+                  <AlertDescription>{axios.isAxiosError(errorMetrics) && errorMetrics.message}</AlertDescription>
+                </Alert>
+              )}
+            </>
+          )}
+          {/* Successfully fetched metrics */}
+          {!isErrorMetrics && (
             <>
               <Text my={5}>
                 {isLoading ? 'Loading' : 'Showing'} metrics for <b>{bibcodes.length}</b> records


### PR DESCRIPTION
Show 'no metrics' as info alert on metrics page instead of error.
<img width="988" alt="Screen Shot 2022-06-14 at 10 10 34 AM" src="https://user-images.githubusercontent.com/636361/173598131-88e73d85-f1fb-4381-979c-a010e16bd1ec.png">
