### PR TITLE
Add author modal to results

### DIFF
--- a/src/components/AllAuthorsModal/AllAuthorsModal.tsx
+++ b/src/components/AllAuthorsModal/AllAuthorsModal.tsx
@@ -33,6 +33,7 @@ import { SearchQueryLink } from '@components/SearchQueryLink';
 import { useDebounce } from '@hooks/useDebounce';
 import { saveAs } from 'file-saver';
 import { matchSorter } from 'match-sorter';
+import { useRouter } from 'next/router';
 import {
   ChangeEventHandler,
   forwardRef,
@@ -54,6 +55,15 @@ export const AllAuthorsModal = ({ bibcode, label }: IAllAuthorsModalProps): Reac
   const { isOpen, onOpen, onClose } = useDisclosure();
   const initialRef = useRef<HTMLInputElement>(null);
   const toast = useToast();
+  const router = useRouter();
+
+  // on history change (or url params), close the modal
+  useEffect(() => {
+    router.events.on('beforeHistoryChange', onClose);
+    return () => {
+      router.events.off('beforeHistoryChange', onClose);
+    };
+  }, [onClose]);
 
   // to avoid having to play with the forwarded ref, just focus here
   const handleSearchClear = () => {
@@ -196,7 +206,7 @@ const AuthorsTable = forwardRef<HTMLInputElement, { doc: IDocsEntity; onSearchCl
                       aria-label={`author "${author}", search by name`}
                       flexShrink="0"
                     >
-                      {author}
+                      <>{author}</>
                     </SearchQueryLink>
                   )}
                 </Td>

--- a/src/components/AllAuthorsModal/AllAuthorsModal.tsx
+++ b/src/components/AllAuthorsModal/AllAuthorsModal.tsx
@@ -33,12 +33,21 @@ import { SearchQueryLink } from '@components/SearchQueryLink';
 import { useDebounce } from '@hooks/useDebounce';
 import { saveAs } from 'file-saver';
 import { matchSorter } from 'match-sorter';
-import { ChangeEventHandler, forwardRef, MouseEventHandler, ReactElement, useEffect, useRef, useState } from 'react';
+import {
+  ChangeEventHandler,
+  forwardRef,
+  MouseEventHandler,
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useGetAuthors } from './useGetAuthors';
 
 export interface IAllAuthorsModalProps {
   bibcode: IDocsEntity['bibcode'];
-  label: string;
+  label: ReactNode;
 }
 
 export const AllAuthorsModal = ({ bibcode, label }: IAllAuthorsModalProps): ReactElement => {

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -1,7 +1,9 @@
 import { IDocsEntity } from '@api';
 import { Checkbox, CheckboxProps } from '@chakra-ui/checkbox';
 import { Box, Flex, Link, Stack, Text } from '@chakra-ui/layout';
-import { CircularProgress, Fade, useTimeout } from '@chakra-ui/react';
+import { BoxProps, CircularProgress, Fade, useTimeout } from '@chakra-ui/react';
+import { AllAuthorsModal } from '@components/AllAuthorsModal';
+import { APP_DEFAULTS } from '@config';
 import { useIsClient } from '@hooks/useIsClient';
 import { useStore } from '@store';
 import { getFomattedNumericPubdate } from '@utils';
@@ -105,17 +107,7 @@ export const Item = (props: IItemProps): ReactElement => {
           </Flex>
         </Flex>
         <Flex direction="column">
-          {author.length > 0 && (
-            <Box fontSize="sm">
-              {author.slice(0, 10).join('; ')}
-              {author_count > 10 && (
-                <Text as="span" fontStyle="italic">
-                  {' '}
-                  and {author_count - 10} more
-                </Text>
-              )}
-            </Box>
-          )}
+          <AuthorList author={author} authorCount={author_count} bibcode={doc.bibcode} />
           <Text fontSize="xs" mt={0.5}>
             {formattedPubDate}
             {formattedPubDate && formattedBibstem ? <span className="px-2">·</span> : ''}
@@ -199,5 +191,36 @@ const ItemCheckbox = (props: IItemCheckboxProps) => {
       data-testid="results-checkbox"
       {...checkboxProps}
     />
+  );
+};
+
+interface IAuthorListProps extends BoxProps {
+  author: IDocsEntity['author'];
+  authorCount: IDocsEntity['author_count'];
+  bibcode: IDocsEntity['bibcode'];
+}
+
+const MAX_AUTHORS = APP_DEFAULTS.RESULTS_MAX_AUTHORS;
+
+/**
+ * Displays author list and includes a button to open all authors modal
+ */
+const AuthorList = (props: IAuthorListProps): ReactElement => {
+  const { author, authorCount, bibcode, ...boxProps } = props;
+
+  if (authorCount === 0) {
+    return null;
+  }
+
+  return (
+    <Box fontSize="sm" {...boxProps}>
+      {author.slice(0, MAX_AUTHORS).join('; ')}
+      {'; '}
+      {authorCount > MAX_AUTHORS ? (
+        <AllAuthorsModal bibcode={bibcode} label={`and ${authorCount - MAX_AUTHORS} more`} />
+      ) : (
+        <AllAuthorsModal bibcode={bibcode} label={'see all'} />
+      )}
+    </Box>
   );
 };

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -201,7 +201,6 @@ interface IAuthorListProps extends BoxProps {
 }
 
 const MAX_AUTHORS = APP_DEFAULTS.RESULTS_MAX_AUTHORS;
-
 /**
  * Displays author list and includes a button to open all authors modal
  */
@@ -219,7 +218,7 @@ const AuthorList = (props: IAuthorListProps): ReactElement => {
       {authorCount > MAX_AUTHORS ? (
         <AllAuthorsModal bibcode={bibcode} label={`and ${authorCount - MAX_AUTHORS} more`} />
       ) : (
-        <AllAuthorsModal bibcode={bibcode} label={'see all'} />
+        <AllAuthorsModal bibcode={bibcode} label={'show list'} />
       )}
     </Box>
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { SolrSort } from '@api';
 
 export const APP_DEFAULTS = {
   DETAILS_MAX_AUTHORS: 50 as const,
+  RESULTS_MAX_AUTHORS: 10 as const,
   RESULT_PER_PAGE: 10 as const,
   PER_PAGE_OPTIONS: [10, 25, 50, 100] as const,
   SORT: ['date desc', 'bibcode desc'] as SolrSort[],

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -92,7 +92,7 @@ const AbstractPage: NextPage<IAbstractPageProps> = (props: IAbstractPageProps) =
                 {doc.author_count > MAX ? (
                   <AllAuthorsModal bibcode={doc.bibcode} label={`and ${doc.author_count - MAX} more`} />
                 ) : (
-                  <AllAuthorsModal bibcode={doc.bibcode} label={'see all'} />
+                  <AllAuthorsModal bibcode={doc.bibcode} label={'show list'} />
                 )}
               </Flex>
             ) : (


### PR DESCRIPTION
Adds all-author-modal component to results list.  This applies to main results and other lists like citations/references

Small change to wording, from 'see all' to 'see list', since 'see all' seems to imply we aren't showing the full list.  But open to suggestions if that doesn't make sense!

![all_authors_on_results](https://user-images.githubusercontent.com/6970899/177418795-676accda-b0df-4df5-a07f-8b975c417463.gif)
