### PR TITLE
Get keyformat working for export

### DIFF
--- a/src/api/export/types.ts
+++ b/src/api/export/types.ts
@@ -50,6 +50,7 @@ export interface IExportApiParams {
   bibcode: IDocsEntity['bibcode'][];
   sort?: IADSApiSearchParams['sort'];
   authorcutoff?: [number];
+  keyformat?: [string];
   journalformat?: [ExportApiJournalFormat];
   maxauthor?: [number];
 }

--- a/src/components/CitationExporter/CitationExporter.machine.ts
+++ b/src/components/CitationExporter/CitationExporter.machine.ts
@@ -40,6 +40,11 @@ interface SetFormat {
   payload: ExportApiFormatKey;
 }
 
+interface SetKeyFormat {
+  type: 'SET_KEY_FORMAT';
+  payload: string;
+}
+
 interface SetRange {
   type: 'SET_RANGE';
   payload: number;
@@ -75,6 +80,7 @@ export type CitationExporterEvent =
   | SetMaxAuthor
   | SetJournalFormat
   | SetIsCustomFormat
+  | SetKeyFormat
   | { type: 'SUBMIT' }
   | { type: 'FORCE_SUBMIT' }
   | { type: 'DONE' };
@@ -88,6 +94,7 @@ export const getExportCitationDefaultContext = (props: IUseCitationExporterProps
     authorcutoff: [BIBTEX_DEFAULT_AUTHOR_CUTOFF],
     customFormat: null,
     journalformat: [ExportApiJournalFormat.AASTeXMacros],
+    keyformat: [''],
     maxauthor: [
       format === ExportApiFormatKey.bibtex
         ? BIBTEX_DEFAULT_MAX_AUTHOR
@@ -138,6 +145,11 @@ export const generateMachine = ({ format, records, singleMode, sort }: IUseCitat
               }),
             },
           ],
+          SET_KEY_FORMAT: {
+            actions: assign<ICitationExporterState, SetKeyFormat>({
+              params: (ctx, evt) => ({ ...ctx.params, keyformat: [evt.payload] }),
+            }),
+          },
           SET_RANGE: {
             actions: assign<ICitationExporterState, SetRange>({
               range: (_ctx, evt) => [0, evt.payload],

--- a/src/components/CitationExporter/CitationExporter.machine.ts
+++ b/src/components/CitationExporter/CitationExporter.machine.ts
@@ -94,7 +94,7 @@ export const getExportCitationDefaultContext = (props: IUseCitationExporterProps
     authorcutoff: [BIBTEX_DEFAULT_AUTHOR_CUTOFF],
     customFormat: null,
     journalformat: [ExportApiJournalFormat.AASTeXMacros],
-    keyformat: [''],
+    keyformat: ['%R'],
     maxauthor: [
       format === ExportApiFormatKey.bibtex
         ? BIBTEX_DEFAULT_MAX_AUTHOR

--- a/src/components/CitationExporter/CitationExporter.tsx
+++ b/src/components/CitationExporter/CitationExporter.tsx
@@ -229,7 +229,7 @@ const AdvancedControls = ({
           <Stack spacing="4">
             <Divider />
             <JournalFormatSelect journalformat={params.journalformat} dispatch={dispatch} />
-            <KeyFormatInput />
+            <KeyFormatInput keyformat={params.keyformat} dispatch={dispatch} />
             <AuthorCutoffSlider authorcutoff={params.authorcutoff} dispatch={dispatch} />
             <MaxAuthorsSlider maxauthor={params.maxauthor} dispatch={dispatch} />
           </Stack>

--- a/src/components/CitationExporter/components/CustomFormatSelect.tsx
+++ b/src/components/CitationExporter/components/CustomFormatSelect.tsx
@@ -4,6 +4,7 @@ import { CitationExporterEvent } from '../CitationExporter.machine';
 export interface ICustomFormatSelectProps {
   dispatch: Sender<CitationExporterEvent>;
 }
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const CustomFormatSelect = (props: ICustomFormatSelectProps) => {
   return <div>Coming soon!</div>;
 };

--- a/src/components/CitationExporter/components/KeyFormatInput.tsx
+++ b/src/components/CitationExporter/components/KeyFormatInput.tsx
@@ -1,7 +1,22 @@
+import { IExportApiParams } from '@api';
 import { Box, Code, FormControl, FormLabel, Input } from '@chakra-ui/react';
+import { Sender } from '@xstate/react/lib/types';
+import { ChangeEventHandler, useCallback } from 'react';
+import { CitationExporterEvent } from '../CitationExporter.machine';
 import { DescriptionCollapse } from './DescriptionCollapse';
 
-export const KeyFormatInput = () => {
+interface IKeyFormatInputProps {
+  keyformat: IExportApiParams['keyformat'];
+  dispatch: Sender<CitationExporterEvent>;
+}
+
+export const KeyFormatInput = (props: IKeyFormatInputProps) => {
+  const { keyformat, dispatch } = props;
+
+  const handleOnChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+    dispatch({ type: 'SET_KEY_FORMAT', payload: e.currentTarget.value });
+  }, []);
+
   return (
     <FormControl>
       <DescriptionCollapse
@@ -13,7 +28,7 @@ export const KeyFormatInput = () => {
           <Box>
             <FormLabel fontSize={['sm', 'md']}>Key Format {btn}</FormLabel>
             {content}
-            <Input defaultValue="%R" size="md" borderRadius="sm" />
+            <Input value={keyformat} size="md" borderRadius="sm" onChange={handleOnChange} />
           </Box>
         )}
       </DescriptionCollapse>

--- a/src/components/__tests__/CitationExporter.test.tsx
+++ b/src/components/__tests__/CitationExporter.test.tsx
@@ -38,11 +38,13 @@ const checkOutput = (
     numRecords: 1,
     format: ExportApiFormatKey.bibtex,
     sort: ['date desc', 'bibcode desc'],
+    keyformat: [''],
     authorcutoff: [200],
     journalformat: [1],
     maxauthor: [10],
   };
-  expect(el).toHaveValue(JSON.stringify({ ...defaultParams, ...params }, null, 2));
+  const expected = { ...defaultParams, ...params };
+  expect(el).toHaveValue(JSON.stringify(expected, Object.keys(expected).sort(), 2));
 };
 
 const setup = (component: JSX.Element) => {
@@ -58,7 +60,7 @@ describe('CitationExporter', () => {
       setup(<SingleMode />);
     });
     test('has proper output', async () => {
-      const { getByTestId, debug } = setup(<SingleMode />);
+      const { getByTestId } = setup(<SingleMode />);
       await waitFor(() => checkOutput(getByTestId('export-output') as HTMLTextAreaElement));
     });
   });

--- a/src/components/__tests__/CitationExporter.test.tsx
+++ b/src/components/__tests__/CitationExporter.test.tsx
@@ -38,7 +38,7 @@ const checkOutput = (
     numRecords: 1,
     format: ExportApiFormatKey.bibtex,
     sort: ['date desc', 'bibcode desc'],
-    keyformat: [''],
+    keyformat: ['%R'],
     authorcutoff: [200],
     journalformat: [1],
     maxauthor: [10],

--- a/src/hooks/useCreateQueryClient.ts
+++ b/src/hooks/useCreateQueryClient.ts
@@ -1,10 +1,8 @@
-import { useToast } from '@chakra-ui/react';
 import axios from 'axios';
 import { useState } from 'react';
 import { QueryCache, QueryClient } from 'react-query';
 
 export const useCreateQueryClient = () => {
-  const toast = useToast();
   const queryCache = new QueryCache({
     onError: (error, query) => {
       // check if we should skip handling the error here

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -134,11 +134,13 @@ export const handlers = [
     const { bibcode, ...body } = req.body;
     const { format } = req.params;
 
+    const value = { numRecords: bibcode.length, format, ...body };
+
     return res(
       ctx.delay(200),
       ctx.status(200),
       ctx.json({
-        export: `${JSON.stringify({ numRecords: bibcode.length, format, ...body }, null, 2)}`,
+        export: `${JSON.stringify(value, Object.keys(value).sort(), 2)}`,
       }),
     );
   }),


### PR DESCRIPTION
`keyformat` works now for export component
Now properly escapes/cleans input from `keyformat`

Adds a purify utility for doing this type of escaping, still a little wip since I wasn't able to get types to work perfectly