### PR TITLE
Facet url fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "neverthrow": "^4.2.1",
     "next": "12",
     "nprogress": "^0.2.0",
-    "qs": "^6.10.1",
+    "qs": "^6.11.0",
     "ramda": "^0.28.0",
     "react": "^17.0.2",
     "react-copy-to-clipboard": "^5.0.4",
@@ -75,7 +75,6 @@
     "zustand": "^3.6.9"
   },
   "devDependencies": {
-    "@types/lucene": "^2.1.4",
     "@babel/core": "^7.0.0-0",
     "@chakra-ui/storybook-addon": "^1.0.3",
     "@faker-js/faker": "^6.0.0",
@@ -108,6 +107,7 @@
     "@types/he": "^1.1.2",
     "@types/jest": "^26.0.23",
     "@types/katex": "^0.11.0",
+    "@types/lucene": "^2.1.4",
     "@types/node": "^14.17.17",
     "@types/nprogress": "^0.2.0",
     "@types/qs": "^6.9.7",

--- a/server/middlewares/api.ts
+++ b/server/middlewares/api.ts
@@ -52,7 +52,14 @@ export const api: Middleware = (req, res, next) => {
     baseURL: resolveApiBaseUrl(),
     withCredentials: true,
     timeout: 30000,
-    paramsSerializer: (params: PathLike) => qs.stringify(params, { indices: false, arrayFormat: 'comma' }),
+    paramsSerializer: (params: PathLike) =>
+      qs.stringify(params, {
+        indices: false,
+        arrayFormat: 'repeat',
+        format: 'RFC1738',
+        sort: (a, b) => a - b,
+        skipNulls: true,
+      }),
     headers: {
       common: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/__tests__/paper-form.test.tsx
+++ b/src/__tests__/paper-form.test.tsx
@@ -1,8 +1,5 @@
 import { handlers } from '@mocks/handlers';
-import { IsomorphicResponse } from '@mswjs/interceptors';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MockedRequest } from 'msw';
 import { setupServer } from 'msw/node';
 import { FC } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -27,15 +24,6 @@ const queryClient = new QueryClient({
 const wrapper: FC = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 
 const server = setupServer(...handlers);
-
-const setup = () => {
-  const user = userEvent.setup();
-  const onReq = jest.fn<never, Parameters<(req: MockedRequest) => void>>();
-  const onRes = jest.fn<never, Parameters<(res: IsomorphicResponse, requestId: string) => void>>();
-  server.events.on('request:start', onReq);
-  server.events.on('response:mocked', onRes);
-  return { onReq, onRes, user, ...render(<PaperForm />, { wrapper }) };
-};
 
 describe('Paper Form', () => {
   beforeAll(() => server.listen());

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -80,7 +80,14 @@ const defaultConfig: AxiosRequestConfig = {
   baseURL: resolveApiBaseUrl(),
   withCredentials: true,
   timeout: 30000,
-  paramsSerializer: (params: PathLike) => qs.stringify(params, { indices: false, arrayFormat: 'comma' }),
+  paramsSerializer: (params: PathLike) =>
+    qs.stringify(params, {
+      indices: false,
+      arrayFormat: 'repeat',
+      format: 'RFC1738',
+      sort: (a, b) => a - b,
+      skipNulls: true,
+    }),
   headers: {
     common: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/api/vis/vis.ts
+++ b/src/api/vis/vis.ts
@@ -1,4 +1,4 @@
-import api, { ADSQuery, ApiRequestConfig, IADSApiSearchParams } from '@api';
+import api, { ADSQuery, ApiRequestConfig } from '@api';
 import { ApiTargets } from '@api/models';
 import { Bibcode } from '@api/search';
 import { QueryFunction, useQuery } from 'react-query';
@@ -11,7 +11,7 @@ export const visKeys = {
   authorNetwork: (params: IADSApiVisParams) => ['vis/authorNetwork', { ...params }] as const,
 };
 
-const retryFn = (count: number, error: unknown) => {
+const retryFn = (count: number) => {
   if (count >= MAX_RETRIES) {
     return false;
   }

--- a/src/components/AbstractRefList/AbstractRefList.tsx
+++ b/src/components/AbstractRefList/AbstractRefList.tsx
@@ -19,7 +19,7 @@ export interface IAbstractRefListProps {
 export const AbstractRefList = (props: IAbstractRefListProps): ReactElement => {
   const { docs, onPageChange = noop, totalResults, searchLinkParams } = props;
   const router = useRouter();
-  const { p: page } = parseQueryFromUrl(router.query);
+  const { p: page } = parseQueryFromUrl(router.asPath);
   const params = { ...searchLinkParams, start: calculateStartIndex(page, APP_DEFAULTS.RESULT_PER_PAGE) };
 
   const handlePageChange = (page: number) => {

--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -172,7 +172,7 @@ const Item = (props: IItemProps) => {
     isDisabled = true;
   }
 
-  const { id: docId } = parseQueryFromUrl<{ id: string }>(router.query);
+  const docId = router.query.id as string;
   const active = router.asPath.indexOf(`/${route}`) > -1;
 
   return (
@@ -216,7 +216,7 @@ const TopMenuItem = (props: IItemProps) => {
   }
 
   const active = router.asPath.indexOf(`/${route}`) > -1;
-  const { id: docId } = parseQueryFromUrl<{ id: string }>(router.query);
+  const { id: docId } = parseQueryFromUrl<{ id: string }>(router.asPath);
 
   return (
     <MenuItem isDisabled={isDisabled} backgroundColor={active ? 'gray.100' : 'transparent'} mb={1}>

--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -18,7 +18,7 @@ import {
   UsersIcon,
 } from '@heroicons/react/solid';
 import { useIsClient } from '@hooks/useIsClient';
-import { noop, parseQueryFromUrl } from '@utils';
+import { noop } from '@utils';
 import NextLink, { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
 import { cloneElement, HTMLAttributes, ReactElement } from 'react';
@@ -216,7 +216,7 @@ const TopMenuItem = (props: IItemProps) => {
   }
 
   const active = router.asPath.indexOf(`/${route}`) > -1;
-  const { id: docId } = parseQueryFromUrl<{ id: string }>(router.asPath);
+  const docId = router.query.id as string;
 
   return (
     <MenuItem isDisabled={isDisabled} backgroundColor={active ? 'gray.100' : 'transparent'} mb={1}>

--- a/src/components/ResultList/ListActions.tsx
+++ b/src/components/ResultList/ListActions.tsx
@@ -92,7 +92,7 @@ export const ListActions = (props: IListActionsProps): ReactElement => {
   const handleOperationsLink = (operator: Operator) => {
     if (exploreAll) {
       // new search with operator
-      const query = parseQueryFromUrl(router.query);
+      const query = parseQueryFromUrl(router.asPath);
       const q = createOperatorQuery(operator, query.q);
       void router.push({ pathname: '', search: makeSearchParams({ q, sort: ['score desc'] }) });
     } else {

--- a/src/components/SearchFacet/FacetFilters.tsx
+++ b/src/components/SearchFacet/FacetFilters.tsx
@@ -14,7 +14,7 @@ export const FacetFilters = (props: BoxProps): ReactElement => {
 
   useEffect(() => {
     // Get the current query from the router
-    const parsedQuery = parseQueryFromUrl(router.query);
+    const parsedQuery = parseQueryFromUrl(router.asPath);
 
     // parse and generate the filters from the query, and set our sections
     setFilterSections(getFilters(parsedQuery));
@@ -24,7 +24,7 @@ export const FacetFilters = (props: BoxProps): ReactElement => {
     curryN(4, (clause: string, key: string, rawClauses: string[]) => {
       if (typeof key === 'string') {
         // Remove the clause from the current query
-        const query = parseQueryFromUrl(router.query);
+        const query = parseQueryFromUrl(router.asPath);
         const params = removeClauseFromFQ(`${PREFIX}${key}`, clause, rawClauses, query);
 
         // Update the router with the new query
@@ -38,14 +38,12 @@ export const FacetFilters = (props: BoxProps): ReactElement => {
   );
 
   const handleRemoveAllFiltersClick = () => {
-    const query = parseQueryFromUrl(router.query);
+    const query = parseQueryFromUrl(router.asPath);
     const params = clearFilters(query);
 
     if (isIADSSearchParams(params)) {
       const search = makeSearchParams(params);
-      void router
-        .push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true })
-        .then(() => setFilterSections([]));
+      void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
     }
   };
 

--- a/src/components/SearchFacet/SearchFacetTree.tsx
+++ b/src/components/SearchFacet/SearchFacetTree.tsx
@@ -212,6 +212,7 @@ const SearchFacetChildNode = (props: SearchFacetNodeProps) => {
       <Collapse in={isExpanded}>
         {/* Primary loading indicator */}
         {isFetching && treeData.length === 0 && <Spinner size="sm" />}
+        {!isFetching && treeData.length === 0 && <Text size="sm">No results</Text>}
 
         <Box pl="10" w="full" mb={isExpanded ? '3' : '0'}>
           {/* Render child tree */}

--- a/src/components/SearchFacet/SearchFacetTree.tsx
+++ b/src/components/SearchFacet/SearchFacetTree.tsx
@@ -84,8 +84,10 @@ export const SearchFacetTree = (props: ISearchFacetTreeProps): ReactElement => {
     return null;
   }
 
-  if (treeData.length === 0) {
+  if (treeData.length === 0 && isFetching) {
     return <Spinner size="sm" />;
+  } else if (treeData.length === 0 && !isFetching) {
+    return <Text size="sm">No results</Text>;
   }
 
   const initialRoots = map(head, treeData) as string[];

--- a/src/components/SearchFacet/store.tsx
+++ b/src/components/SearchFacet/store.tsx
@@ -15,8 +15,6 @@ export interface IFacetTreeState {
 }
 
 const createStore = (initialRoots: string[], name: string) => () => {
-  // console.log('init store', initialRoots, initTree(initialRoots));
-
   return create<
     IFacetTreeState,
     SetState<IFacetTreeState>,
@@ -24,7 +22,7 @@ const createStore = (initialRoots: string[], name: string) => () => {
     Mutate<StoreApi<IFacetTreeState>, [['zustand/devtools', never]]>
   >(
     devtools(
-      (set, get) => ({
+      (set) => ({
         selectedKeys: [],
         tree: initialRoots ? initTree<FacetNodeTree>(initialRoots) : {},
 

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -160,7 +160,7 @@ const SortSelect = ({
 // non-native type, used in search results
 const NoJsSort = (): ReactElement => {
   const router = useRouter();
-  const query = parseQueryFromUrl(router.query);
+  const query = parseQueryFromUrl(router.asPath);
   const [sortby, dir] = query.sort[0].split(' ') as [SolrSortField, SolrSortDirection];
 
   const getToggledDir = (dir: SolrSortDirection) => {

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -9,12 +9,11 @@ import { Alert, Input, Link, Textarea } from '@chakra-ui/react';
 import { BibstemPicker } from '@components';
 import { useErrorMessage } from '@hooks/useErrorMessage';
 import { useIsClient } from '@hooks/useIsClient';
-import { setupApiSSR } from '@utils';
+import { setupApiSSR, stringifySearchParams } from '@utils';
 import DOMPurify from 'isomorphic-dompurify';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import qs from 'qs';
 import { any, head, isEmpty, join, map, not, omit, pipe, reject, toPairs, values } from 'ramda';
 import { FormEventHandler, useCallback } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -383,14 +382,11 @@ const createQuery = pipe<
 );
 
 const stringifyQuery = (q: string) => {
-  return qs.stringify(
-    {
-      q,
-      sort: ['date desc', 'bibcode desc'],
-      p: 1,
-    },
-    { arrayFormat: 'comma', indices: false, format: 'RFC3986' },
-  );
+  return stringifySearchParams({
+    q,
+    sort: ['date desc', 'bibcode desc'],
+    p: 1,
+  });
 };
 
 const journalQueryNotEmpty = pipe<

--- a/src/pages/search/author_network.tsx
+++ b/src/pages/search/author_network.tsx
@@ -7,7 +7,7 @@ export const AuthorNetworkPage: NextPage = () => {
   const router = useRouter();
 
   // get original query q, used to 'navigate back' to the original search
-  const { qid, ...originalQuery } = parseQueryFromUrl<{ qid: string }>(router.query);
+  const { qid, ...originalQuery } = parseQueryFromUrl<{ qid: string }>(router.asPath);
 
   // get the new query q that will be used to fetch author network
   // this could be the qid or the modified original query

--- a/src/pages/search/exportcitation/[format].tsx
+++ b/src/pages/search/exportcitation/[format].tsx
@@ -103,7 +103,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     p,
     format,
     ...query
-  } = parseQueryFromUrl<{ qid: string; format: string }>(ctx.query, { sortPostfix: 'id asc' });
+  } = parseQueryFromUrl<{ qid: string; format: string }>(ctx.req.url, { sortPostfix: 'id asc' });
 
   if (!query && !qid) {
     return {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -71,7 +71,7 @@ const SearchPage: NextPage = () => {
   const numFound = queries.length > 1 ? path<number>(['1', 'response', 'numFound'], last(queries)) : null;
 
   // parse the query params from the URL, this should match what the server parsed
-  const parsedParams = parseQueryFromUrl(router.query);
+  const parsedParams = parseQueryFromUrl(router.asPath);
   const params = {
     ...defaultParams,
     ...parsedParams,
@@ -254,9 +254,8 @@ const NoResultsMsg = ({ query = '' }: { query: string }) => (
     }
   />
 );
-
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { p: page, ...query } = parseQueryFromUrl<{ p: string }>(ctx.query);
+  const { p: page, ...query } = parseQueryFromUrl<{ p: string }>(ctx.req.url);
   setupApiSSR(ctx);
   const queryClient = new QueryClient();
 

--- a/src/pages/search/metrics.tsx
+++ b/src/pages/search/metrics.tsx
@@ -33,7 +33,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const BATCH_SIZE = 1000;
   setupApiSSR(ctx);
   const { qid: _qid, ...originalQuery } = ctx.query;
-  const { qid = null, p, ...query } = parseQueryFromUrl<{ qid: string }>(ctx.query, { sortPostfix: 'id asc' });
+  const { qid = null, p, ...query } = parseQueryFromUrl<{ qid: string }>(ctx.req.url, { sortPostfix: 'id asc' });
 
   // TODO: figure out why this clears the cache on transition
   // const queryClient = new QueryClient();

--- a/src/pages/search/overview.tsx
+++ b/src/pages/search/overview.tsx
@@ -1,17 +1,17 @@
-import { OverviewPageContainer, VizPageLayout } from '@components';
-import { NextPage } from 'next';
-import { makeSearchParams, parseQueryFromUrl } from '@utils';
 import { IADSApiSearchParams } from '@api';
+import { OverviewPageContainer, VizPageLayout } from '@components';
 import { FacetField } from '@components/Visualizations/types';
-import { useRouter } from 'next/router';
 import { getQueryWithCondition } from '@components/Visualizations/utils';
+import { makeSearchParams, parseQueryFromUrl } from '@utils';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 
 const OverviewPage: NextPage = () => {
   const router = useRouter();
 
-  const { qid: _qid, ...originalQuery } = parseQueryFromUrl<{ qid: string }>(router.query);
+  const { qid: _qid, ...originalQuery } = parseQueryFromUrl<{ qid: string }>(router.asPath);
 
-  const { qid, p, ...query } = parseQueryFromUrl<{ qid: string }>(router.query, { sortPostfix: 'id asc' });
+  const { qid, p, ...query } = parseQueryFromUrl<{ qid: string }>(router.asPath, { sortPostfix: 'id asc' });
 
   const bibsQuery: IADSApiSearchParams = qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13484,10 +13484,17 @@ qs@6.9.7:
   resolved "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
   integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
-qs@^6.10.0, qs@^6.10.1:
+qs@^6.10.0:
   version "6.10.3"
   resolved "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
We had conflicting URL parsing rules and in places were re-parsing.  This update changes the param for the `parseQueryFromUrl` util to take a string URL.

So in components now we should be doing:  
```
const params = parseQueryFromUrl(router.asPath);
```
or in server-side handlers: 
```
const params = parseQueryFromUrl(ctx.req.url);
```

`qs` encodes commas when using `format: 'RFC1738'` but we have to use this format to get proper non-encoding of `+` so the solution is to use the `arrayFormat: 'repeat'` which has more native support but makes URL longer.

The original bug was to fix an issue with `fq` getting parsed as a single string and not an array of elements. This fixes this issue and I hope solidifies our query parsing setup.

Also fixes some linting issues and a bug with the `remove all` button

TODO: 
- Figure out a better place to put the `qs` config since it's repeated in 3 places right now.