### PR TITLE
Scix 195 Author/paper networks: Use same results view (as in search) for listing papers

### DIFF
--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -30,6 +30,7 @@ export interface IItemProps {
   showHighlights?: boolean;
   isFetchingHighlights?: boolean;
   highlights?: string[];
+  extraInfo?: string;
 }
 
 export const Item = (props: IItemProps): ReactElement => {
@@ -42,6 +43,7 @@ export const Item = (props: IItemProps): ReactElement => {
     showHighlights,
     isFetchingHighlights,
     highlights,
+    extraInfo,
   } = props;
   const { bibcode, pubdate, title = ['Untitled'], author = [], bibstem = [], author_count } = doc;
   const formattedPubDate = getFomattedNumericPubdate(pubdate);
@@ -114,6 +116,8 @@ export const Item = (props: IItemProps): ReactElement => {
             {formattedBibstem}
             {cite && (formattedPubDate || formattedBibstem) ? <span className="px-2">·</span> : null}
             {cite}
+            {cite && extraInfo && '; '}
+            {extraInfo}
           </Text>
           {showHighlights && <Highlights highlights={highlights} isFetchingHighlights={isFetchingHighlights} />}
           <AbstractPreview bibcode={bibcode} />

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -31,6 +31,7 @@ export interface IItemProps {
   isFetchingHighlights?: boolean;
   highlights?: string[];
   extraInfo?: string;
+  linkNewTab?: boolean;
 }
 
 export const Item = (props: IItemProps): ReactElement => {
@@ -44,6 +45,7 @@ export const Item = (props: IItemProps): ReactElement => {
     isFetchingHighlights,
     highlights,
     extraInfo,
+    linkNewTab = false,
   } = props;
   const { bibcode, pubdate, title = ['Untitled'], author = [], bibstem = [], author_count } = doc;
   const formattedPubDate = getFomattedNumericPubdate(pubdate);
@@ -61,7 +63,7 @@ export const Item = (props: IItemProps): ReactElement => {
         as={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
         passHref
       >
-        <Link>
+        <Link target={linkNewTab ? '_blank' : '_self'} rel={linkNewTab ? 'noopener noreferrer' : ''}>
           <Text>cited(n): {doc.citation_count_norm}</Text>
         </Link>
       </NextLink>
@@ -72,7 +74,9 @@ export const Item = (props: IItemProps): ReactElement => {
       as={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
       passHref
     >
-      <Link>cited: {doc.citation_count}</Link>
+      <Link target={linkNewTab ? '_blank' : '_self'} rel={linkNewTab ? 'noopener noreferrer' : ''}>
+        cited: {doc.citation_count}
+      </Link>
     </NextLink>
   ) : null;
 
@@ -100,7 +104,11 @@ export const Item = (props: IItemProps): ReactElement => {
       <Stack direction="column" width="full" spacing={0} mx={3} mt={2}>
         <Flex justifyContent="space-between">
           <NextLink href={`/abs/[id]/abstract`} as={`/abs/${bibcode}/abstract`} passHref>
-            <Link fontWeight="semibold">
+            <Link
+              fontWeight="semibold"
+              target={linkNewTab ? '_blank' : '_self'}
+              rel={linkNewTab ? 'noopener noreferrer' : ''}
+            >
               <span dangerouslySetInnerHTML={{ __html: title[0] }}></span>
             </Link>
           </NextLink>

--- a/src/components/Visualizations/Containers/PaperNetworkPageContainer.tsx
+++ b/src/components/Visualizations/Containers/PaperNetworkPageContainer.tsx
@@ -178,7 +178,7 @@ export const PaperNetworkPageContainer = ({ query }: IPaperNetworkPageContainerP
   const handleApplyFilters = () => {
     const bibcodes = uniq(
       state.filters.reduce(
-        (acc, node) => [...acc, ...node.allPapers.reduce((acc1, paper) => [...acc1, paper.node_name], [] as string[])],
+        (acc, node) => [...acc, ...node.papers.reduce((acc1, paper) => [...acc1, paper.bibcode], [] as string[])],
         [] as string[],
       ), // filters to a list of papers
     );

--- a/src/components/Visualizations/Panes/NetworkDetails/AuthorNetworkDetailsPane.tsx
+++ b/src/components/Visualizations/Panes/NetworkDetails/AuthorNetworkDetailsPane.tsx
@@ -96,6 +96,7 @@ const PapersList = ({ papers }: { papers: IAuthorNetworkNodeDetails['papers'] })
               ? `${doc.groupAuthorCount} author${doc.groupAuthorCount > 1 ? 's' : ''} from this group`
               : null
           }
+          linkNewTab={true}
         />
       ))}
     </Flex>

--- a/src/components/Visualizations/Panes/NetworkDetails/AuthorNetworkDetailsPane.tsx
+++ b/src/components/Visualizations/Panes/NetworkDetails/AuthorNetworkDetailsPane.tsx
@@ -1,21 +1,19 @@
-import { Box, List, ListItem, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from '@chakra-ui/react';
-import { SimpleLink } from '@components/SimpleLink';
+import { IDocsEntity } from '@api';
+import { Flex, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import { Item } from '@components/ResultList/Item';
 import { ILineGraph } from '@components/Visualizations/types';
 import { ReactElement, useEffect, useState } from 'react';
 import { NodeDetailPane } from './NodeDetailsPane';
 import { SummaryPane } from './SummaryPane';
 
+interface Paper extends IDocsEntity {
+  groupAuthorCount?: number;
+}
+
 export interface IAuthorNetworkNodeDetails {
   type: 'author' | 'group';
   name: string;
-  papers: {
-    bibcode: string;
-    title: string;
-    authors: string[];
-    citation_count: number;
-    read_count: number;
-    groupAuthorCount?: number;
-  }[];
+  papers: Paper[];
   mostRecentYear: string;
 }
 
@@ -84,27 +82,22 @@ export const AuthorNetworkDetailsPane = ({
 
 const PapersList = ({ papers }: { papers: IAuthorNetworkNodeDetails['papers'] }): ReactElement => {
   return (
-    <Box mt={5}>
-      <List spacing={3}>
-        {papers.map((paper) => (
-          <ListItem key={paper.bibcode}>
-            <SimpleLink href={`/abs/${paper.bibcode}`} newTab={true}>
-              <Text fontWeight="bold" as="span" dangerouslySetInnerHTML={{ __html: paper.title }} />
-            </SimpleLink>{' '}
-            <Text as="span" fontSize="sm">
-              {paper.citation_count && paper.citation_count > 0 ? (
-                <>{paper.citation_count} citations</>
-              ) : (
-                <>no citations</>
-              )}
-
-              {paper.groupAuthorCount && (
-                <>{`, ${paper.groupAuthorCount} author${paper.groupAuthorCount > 1 ? 's' : ''} from this group`}</>
-              )}
-            </Text>
-          </ListItem>
-        ))}
-      </List>
-    </Box>
+    <Flex as="section" aria-label="Papers List" direction="column">
+      {papers.map((doc, index) => (
+        <Item
+          doc={doc}
+          key={doc.bibcode}
+          index={index + 1}
+          hideCheckbox={true}
+          hideActions={true}
+          showHighlights={false}
+          extraInfo={
+            doc.groupAuthorCount
+              ? `${doc.groupAuthorCount} author${doc.groupAuthorCount > 1 ? 's' : ''} from this group`
+              : null
+          }
+        />
+      ))}
+    </Flex>
   );
 };

--- a/src/components/Visualizations/Panes/NetworkDetails/PaperNetworkDetailsPane.tsx
+++ b/src/components/Visualizations/Panes/NetworkDetails/PaperNetworkDetailsPane.tsx
@@ -1,4 +1,4 @@
-import { IADSApiPaperNetworkSummaryGraphNode, IADSApiPaperNetworkFullGraphNode } from '@api';
+import { IADSApiPaperNetworkSummaryGraphNode, IDocsEntity } from '@api';
 import {
   Text,
   Tab,
@@ -7,14 +7,14 @@ import {
   TabPanels,
   Tabs,
   Box,
-  List,
-  ListItem,
   Table,
   Thead,
   Tr,
   Th,
   Tbody,
+  Flex,
 } from '@chakra-ui/react';
+import { Item } from '@components/ResultList/Item';
 import { SimpleLink } from '@components/SimpleLink';
 import { ILineGraph } from '@components/Visualizations/types';
 import { ReactElement, useEffect, useState } from 'react';
@@ -22,7 +22,7 @@ import { NodeDetailPane } from './NodeDetailsPane';
 import { SummaryPane } from './SummaryPane';
 
 export interface IPaperNetworkNodeDetails extends IADSApiPaperNetworkSummaryGraphNode {
-  allPapers: IADSApiPaperNetworkFullGraphNode[];
+  papers: IDocsEntity[];
   titleWords: string[];
   topCommonReferences: {
     bibcode: string;
@@ -105,27 +105,26 @@ export const PaperNetworkDetailsPane = ({
 };
 
 const PapersList = ({ node }: { node: IPaperNetworkNodeDetails }): ReactElement => {
-  const { allPapers, topCommonReferences } = node;
+  const { papers, topCommonReferences } = node;
+  const topNPapers = 30;
   return (
     <Box mt={5}>
-      <Text fontWeight="bold">{allPapers.length > 30 ? 'Top 30 papers from this group' : 'Papers in this group'}</Text>
-      <List spacing={3} mt={5}>
-        {allPapers.slice(0, 30).map((paper) => (
-          <ListItem key={`paper-${paper.id}`}>
-            <SimpleLink href={`/abs/${paper.node_name}`} newTab={true}>
-              <Text fontWeight="bold" as="span" dangerouslySetInnerHTML={{ __html: paper.title }} />
-            </SimpleLink>
-            <Text as="span">{paper.first_author}</Text>
-            <Text as="span" fontSize="sm">
-              {paper.citation_count && paper.citation_count > 0 ? (
-                <> ({paper.citation_count} citations)</>
-              ) : (
-                <> (no citations)</>
-              )}
-            </Text>
-          </ListItem>
+      <Text fontWeight="bold">
+        {papers.length > topNPapers ? `Top ${topNPapers} papers from this group` : 'Papers in this group'}
+      </Text>
+      <Flex as="section" aria-label="Papers List" direction="column">
+        {papers.map((doc, index) => (
+          <Item
+            doc={doc}
+            key={doc.bibcode}
+            index={index + 1}
+            hideCheckbox={true}
+            hideActions={true}
+            showHighlights={false}
+          />
         ))}
-      </List>
+      </Flex>
+      {/* Probably not going to keep this, only bibcodes, not very useful 
       <Text fontWeight="bold" mt={5}>
         Papers highly referenced by papers in this group:
       </Text>
@@ -142,7 +141,7 @@ const PapersList = ({ node }: { node: IPaperNetworkNodeDetails }): ReactElement 
               <Text>cited by {r.percent}% of papers in this group</Text>
             </ListItem>
           ))}
-      </List>
+      </List> */}
     </Box>
   );
 };

--- a/src/components/Visualizations/Panes/NetworkDetails/PaperNetworkDetailsPane.tsx
+++ b/src/components/Visualizations/Panes/NetworkDetails/PaperNetworkDetailsPane.tsx
@@ -121,6 +121,7 @@ const PapersList = ({ node }: { node: IPaperNetworkNodeDetails }): ReactElement 
             hideCheckbox={true}
             hideActions={true}
             showHighlights={false}
+            linkNewTab={true}
           />
         ))}
       </Flex>
@@ -167,7 +168,9 @@ const ReferencesList = ({ link }: { link: IPaperNetworkLinkDetails }): ReactElem
           {papers.map((p) => (
             <Tr key={`ref-${p.bibcode}`}>
               <Th>
-                <SimpleLink href={`/abs/${p.bibcode}`}>{p.bibcode}</SimpleLink>
+                <SimpleLink href={`/abs/${p.bibcode}`} newTab={true}>
+                  {p.bibcode}
+                </SimpleLink>
               </Th>
               <Th>{`${p.percent1.toFixed(2)}%`}</Th>
               <Th>{`${p.percent2.toFixed(2)}%`}</Th>

--- a/src/components/Visualizations/utils/graphUtils.ts
+++ b/src/components/Visualizations/utils/graphUtils.ts
@@ -453,9 +453,10 @@ export const getAuthorNetworkNodeDetails = (
     const papers = bibcodes.map((bibcode) => ({
       ...bibcode_dict[bibcode],
       bibcode,
+      author: bibcode_dict[bibcode].authors,
       title: Array.isArray(bibcode_dict[bibcode].title)
-        ? decode(bibcode_dict[bibcode].title[0])
-        : decode(bibcode_dict[bibcode].title as string),
+        ? (bibcode_dict[bibcode].title as string[]).map((t) => decode(t))
+        : [decode(bibcode_dict[bibcode].title as string)],
     }));
 
     // sort by citation count
@@ -512,9 +513,10 @@ export const getAuthorNetworkNodeDetails = (
     let papers = bibcodes.map((bibcode) => ({
       ...bibcode_dict[bibcode],
       bibcode,
+      author: bibcode_dict[bibcode].authors,
       title: Array.isArray(bibcode_dict[bibcode].title)
-        ? decode(bibcode_dict[bibcode].title[0])
-        : decode(bibcode_dict[bibcode].title as string),
+        ? (bibcode_dict[bibcode].title as string[]).map((t) => decode(t))
+        : [decode(bibcode_dict[bibcode].title as string)],
       groupAuthorCount: authorCount[bibcode],
     }));
 

--- a/src/components/Visualizations/utils/graphUtils.ts
+++ b/src/components/Visualizations/utils/graphUtils.ts
@@ -515,7 +515,7 @@ export const getAuthorNetworkNodeDetails = (
       bibcode,
       author: bibcode_dict[bibcode].authors,
       title: Array.isArray(bibcode_dict[bibcode].title)
-        ? (bibcode_dict[bibcode].title as string[]).map((t) => decode(t))
+        ? (bibcode_dict[bibcode].title as string[]).map(decode)
         : [decode(bibcode_dict[bibcode].title as string)],
       groupAuthorCount: authorCount[bibcode],
     }));

--- a/src/components/Visualizations/utils/graphUtils.ts
+++ b/src/components/Visualizations/utils/graphUtils.ts
@@ -608,8 +608,14 @@ export const getPaperNetworkNodeDetails = (
     .sort((a, b) => parseInt(b.percent) - parseInt(a.percent));
 
   const allPapers = sortBy(prop('citation_count'), filteredNodes).reverse();
+  const papers = allPapers.map((p) => ({
+    bibcode: p.node_name,
+    title: [p.title],
+    citation_count: p.citation_count,
+    author: [p.first_author],
+  }));
 
-  return { ...node, titleWords, allPapers, topCommonReferences };
+  return { ...node, titleWords, papers, topCommonReferences };
 };
 
 const getPaperNetworkLinks = (id: number, fullGraph: IADSApiPaperNetworkFullGraph) => {


### PR DESCRIPTION
Depends on #239 
* Update author and paper networks to use the item list similar to results
* Update Item component with option to open in new tab
<img width="1276" alt="Screen Shot 2022-09-06 at 2 46 49 PM" src="https://user-images.githubusercontent.com/636361/188714687-ebde3e9b-6aac-4b91-9ccb-b4bab2de90f9.png">
<img width="1216" alt="Screen Shot 2022-09-06 at 2 47 12 PM" src="https://user-images.githubusercontent.com/636361/188714746-ba616535-8831-483b-a712-8b9df67e0da6.png">
