### PR TITLE
Print layout for results page

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Container, Flex } from '@chakra-ui/layout';
 import { SkipNavLink } from '@chakra-ui/skip-nav';
+import { useMediaQuery } from '@chakra-ui/react';
 import { LandingTabs } from '@components';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -10,20 +11,22 @@ import { NavBar } from '../NavBar';
 export const Layout: FC = ({ children }) => {
   const router = useRouter();
   const isLandingPages = /^(\/|\/(classic|paper)-form.*)$/.exec(router.asPath);
+  const [isPrint] = useMediaQuery('print'); // use to hide elements when printing
+
   return (
     <Flex direction="column">
       <Head>
         <title>NASA Science Explorer</title>
       </Head>
       <SkipNavLink id="main-content">Skip to content</SkipNavLink>
-      <NavBar />
+      {isPrint || <NavBar />}
       <main>
         {isLandingPages && <LandingTabs />}
         <Container maxW={isLandingPages ? 'container.md' : 'container.xl'} id="main-content">
           {children}
         </Container>
       </main>
-      <Footer />
+      {isPrint || <Footer />}
     </Flex>
   );
 };

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@api';
 import { CheckCircleIcon } from '@chakra-ui/icons';
 import { Box, Flex, List, ListIcon, ListItem, Stack } from '@chakra-ui/layout';
-import { Alert, AlertIcon, Button, Code, Heading, Portal, VisuallyHidden } from '@chakra-ui/react';
+import { Alert, AlertIcon, Button, Code, Heading, Portal, useMediaQuery, VisuallyHidden } from '@chakra-ui/react';
 import {
   CustomInfoMessage,
   ISearchFacetsProps,
@@ -90,6 +90,8 @@ const SearchPage: NextPage = () => {
 
   const { data, isSuccess, isLoading, error } = useSearch(omitP(params));
 
+  const [isPrint] = useMediaQuery('print'); // use to hide elements when printing
+
   // on Sort change handler
   const handleSortChange = (sort: SolrSort[]) => {
     const query = store.getState().query;
@@ -144,18 +146,20 @@ const SearchPage: NextPage = () => {
         <title>{params.q} | NASA Science Explorer - Search Results</title>
       </Head>
       <Stack direction="row" aria-labelledby="search-form-title" my={12} spacing="4">
-        <SearchFacetFilters params={params} />
+        {isPrint || <SearchFacetFilters params={params} />}
         <Box>
-          <form method="get" action="/search" onSubmit={handleOnSubmit}>
-            <Flex direction="column" width="full">
-              <SearchBar isLoading={isLoading} />
-              <NumFound count={data?.numFound} isLoading={isLoading} />
-            </Flex>
-            <FacetFilters mt="2" />
-            <Box mt={5}>
-              {isSuccess && !isLoading && data?.numFound > 0 && <ListActions onSortChange={handleSortChange} />}
-            </Box>
-          </form>
+          {isPrint || (
+            <form method="get" action="/search" onSubmit={handleOnSubmit} className="print-hidden">
+              <Flex direction="column" width="full">
+                <SearchBar isLoading={isLoading} />
+                <NumFound count={data?.numFound} isLoading={isLoading} />
+              </Flex>
+              <FacetFilters mt="2" />
+              <Box mt={5}>
+                {isSuccess && !isLoading && data?.numFound > 0 && <ListActions onSortChange={handleSortChange} />}
+              </Box>
+            </form>
+          )}
 
           <VisuallyHidden as="h2" id="search-form-title">
             Search Results


### PR DESCRIPTION
Hide header, footer, search bar and facets in print layout

![Screen Shot 2022-10-25 at 4 57 11 PM](https://user-images.githubusercontent.com/636361/197880435-ddf387b3-25d8-4b59-bbf3-433d41966bf0.png)
