### PR TITLE
expose removeFQ from query utils

### DIFF
--- a/src/__tests__/query-utils.test.ts
+++ b/src/__tests__/query-utils.test.ts
@@ -103,3 +103,15 @@ describe('parseQuery()', () => {
     expect(query.parseQuery({})).toEqual({});
   });
 });
+
+describe('removeFQ', () => {
+  test('works', () => {
+    const q = query.setFQ('foo', 'A', { q: '' });
+    expect(q).toEqual({
+      q: '',
+      fq: ['{!type=aqp v=$fq_foo}'],
+      fq_foo: '(A)'
+    })
+    expect(query.removeFQ('foo', q)).toEqual({ q: '' })
+  })
+})

--- a/src/query-utils.ts
+++ b/src/query-utils.ts
@@ -45,10 +45,6 @@ const applyFQPrefix = (v: string) => `${FQPrefix}${v}`;
 const makeFQHeader = (name: string) => `{!type=aqp v=$${applyFQPrefix(name)}}`;
 const fQHeaderLens = lensProp<Query>('fq') as Lens<Query, string[]>;
 const fQPrefixedLens = (key: string) => lensProp<Query>(applyFQPrefix(key)) as Lens<Query, string>;
-const removeFQ = curry((key: string, query: Query) =>
-  pipe<[Query], Query, Query>(dissoc(applyFQPrefix(key)), removeFQHeader(key))(query),
-);
-
 const setFQHeader = curry((name: string, query: Query) =>
   over(fQHeaderLens, pipe(append(makeFQHeader(name)), uniq), query),
 );
@@ -62,6 +58,13 @@ const removeFQHeader = curry(
       // if fq is now empty, remove the whole prop from the query
       when(propSatisfies(isEmptyArray, 'fq'), dissoc('fq')),
     )(query),
+);
+
+/**
+ *  Removes an FQ from the passed in query
+ */
+export const removeFQ = curry((key: string, query: Query) =>
+  pipe<[Query], Query, Query>(dissoc(applyFQPrefix(key)), removeFQHeader(key))(query),
 );
 
 /**


### PR DESCRIPTION
- Update facet to include the hidden list
- Drag and drop between visible and hidden facets
- Expand hidden list when item being dragged into the container
- Some code improvement
- Fix vault query params
- Add chevron icon for hidden facets section
- Expose `removeFQ` from query-utils and test
