### PR TITLE
SCIX-208 fix bug where selecting group 1 shows outline around all groups

### DIFF
--- a/src/components/Visualizations/Graphs/PaperNetworkGraph.tsx
+++ b/src/components/Visualizations/Graphs/PaperNetworkGraph.tsx
@@ -115,7 +115,7 @@ export const PaperNetworkGraph = ({
       top_common_references: {},
       total_reads: 0,
       stable_index: 0,
-      id: 0,
+      id: 99999,
       children: nodesData,
     }),
     [nodesData],


### PR DESCRIPTION
# The problem
In paper network, sometimes selecting a group from the pie will results in highlighting of the whole pie. As seen in the screen capture.
<img width="1350" alt="Screen Shot 2022-11-10 at 4 10 56 PM" src="https://user-images.githubusercontent.com/636361/207698068-abbe8709-128d-43e4-8aff-04f397f271c8.png">
# The cause
The pie is created using a fake 'root' with id=0. When the actual data group also has a group of id=0, selecting group 0 will also select the root.
# The solution
Changed the fake root id to an unlikely number.