### PR TITLE
Add math rendering to titles

### DIFF
--- a/src/components/Layout/AbsLayout.tsx
+++ b/src/components/Layout/AbsLayout.tsx
@@ -5,6 +5,7 @@ import { Button, Link } from '@chakra-ui/react';
 import { AbstractSideNav, Metatags } from '@components';
 import { useBackToSearchResults } from '@hooks/useBackToSearchResults';
 import { unwrapStringValue } from '@utils';
+import { MathJax } from 'better-react-mathjax';
 import Head from 'next/head';
 import NextLink from 'next/link';
 import { FC } from 'react';
@@ -45,7 +46,7 @@ export const AbsLayout: FC<IAbsLayoutProps> = ({ children, doc, titleDescription
             <Text as="span" fontSize="xl">
               {titleDescription}
             </Text>{' '}
-            <Text dangerouslySetInnerHTML={{ __html: title }} />
+            <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
           </Heading>
           {children}
         </Stack>

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -7,6 +7,7 @@ import { APP_DEFAULTS } from '@config';
 import { useIsClient } from '@hooks/useIsClient';
 import { useStore } from '@store';
 import { getFomattedNumericPubdate, unwrapStringValue } from '@utils';
+import { MathJax } from 'better-react-mathjax';
 import dynamic from 'next/dynamic';
 import NextLink from 'next/link';
 import { ChangeEvent, ReactElement, useCallback, useEffect, useState } from 'react';
@@ -62,7 +63,8 @@ export const Item = (props: IItemProps): ReactElement => {
         href={{ pathname: `/abs/[id]/citations`, search: 'p=1' }}
         as={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
         passHref
-        legacyBehavior>
+        legacyBehavior
+      >
         <Link target={linkNewTab ? '_blank' : '_self'} rel={linkNewTab ? 'noopener noreferrer' : ''}>
           <Text>cited(n): {doc.citation_count_norm}</Text>
         </Link>
@@ -73,7 +75,8 @@ export const Item = (props: IItemProps): ReactElement => {
       href={{ pathname: `/abs/[id]/citations`, search: 'p=1' }}
       as={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
       passHref
-      legacyBehavior>
+      legacyBehavior
+    >
       <Link target={linkNewTab ? '_blank' : '_self'} rel={linkNewTab ? 'noopener noreferrer' : ''}>
         cited: {doc.citation_count}
       </Link>
@@ -103,17 +106,13 @@ export const Item = (props: IItemProps): ReactElement => {
       </Flex>
       <Stack direction="column" width="full" spacing={0} mx={3} mt={2}>
         <Flex justifyContent="space-between">
-          <NextLink
-            href={`/abs/[id]/abstract`}
-            as={`/abs/${bibcode}/abstract`}
-            passHref
-            legacyBehavior>
+          <NextLink href={`/abs/[id]/abstract`} as={`/abs/${bibcode}/abstract`} passHref legacyBehavior>
             <Link
               fontWeight="semibold"
               target={linkNewTab ? '_blank' : '_self'}
               rel={linkNewTab ? 'noopener noreferrer' : ''}
             >
-              <span dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }}></span>
+              <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
             </Link>
           </NextLink>
           <Flex alignItems="start" ml={1}>


### PR DESCRIPTION
- Render result titles with mathjax
- add math rendering to abstract-sub-page titles

![image](https://user-images.githubusercontent.com/6970899/210865850-c5eea390-aff0-45a2-bb43-3cd0e50d20a0.png)

from:
![image](https://user-images.githubusercontent.com/6970899/210866094-02cbb51d-13b2-4014-8357-6e99759cf926.png)
to:
![image](https://user-images.githubusercontent.com/6970899/210866067-73b6adf8-8e37-40c8-9287-b14f41de93b3.png)