### PR TITLE
Prevent unnecessary repaint of histogram.

### DIFF
--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -7,7 +7,7 @@ import { getYearsGraph } from '@components/Visualizations/utils';
 import { fqNameYearRange } from '@query';
 import { getFQValue, removeFQ, setFQ } from '@query-utils';
 import { useStore } from '@store';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 export interface IYearHistogramSliderProps {
   onQueryUpdate: ISearchFacetProps['onQueryUpdate'];
@@ -17,88 +17,84 @@ export interface IYearHistogramSliderProps {
   height: number;
 }
 
-export const YearHistogramSlider = ({
-  onQueryUpdate,
-  isExpanded,
-  onToggleExpand,
-  width,
-  height,
-}: IYearHistogramSliderProps) => {
-  const query = useStore((state) => state.latestQuery);
+export const YearHistogramSlider = memo(
+  ({ onQueryUpdate, isExpanded, onToggleExpand, width, height }: IYearHistogramSliderProps) => {
+    const query = useStore((state) => state.latestQuery);
 
-  // query without the year range filter, to show all years on the histogram
-  const cleanedQuery = useMemo(() => {
-    const q = JSON.parse(JSON.stringify(query)) as IADSApiSearchParams;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return q.fq ? (removeFQ(fqNameYearRange, q) as IADSApiSearchParams) : q;
-  }, [query]);
+    // query without the year range filter, to show all years on the histogram
+    const cleanedQuery = useMemo(() => {
+      const q = JSON.parse(JSON.stringify(query)) as IADSApiSearchParams;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      return q.fq ? (removeFQ(fqNameYearRange, q) as IADSApiSearchParams) : q;
+    }, [query]);
 
-  const fqRange = useMemo(() => {
-    return getFQValue(fqNameYearRange, query);
-  }, [query]);
+    const fqRange = useMemo(() => {
+      return getFQValue(fqNameYearRange, query);
+    }, [query]);
 
-  const { data, isLoading } = useGetSearchFacetCounts(getSearchFacetYearsParams(cleanedQuery), {
-    enabled: !!cleanedQuery && cleanedQuery.q.trim().length > 0,
-  });
+    const { data, isLoading } = useGetSearchFacetCounts(getSearchFacetYearsParams(cleanedQuery), {
+      enabled: !!cleanedQuery && cleanedQuery.q.trim().length > 0,
+    });
 
-  const histogramData = useMemo(() => {
-    if (data) {
-      return getYearsGraph(data).data.map((d) => ({
-        x: d.year,
-        y: d.notrefereed + d.refereed,
-      }));
-    }
-  }, [data]);
-
-  // Selected range
-  // - If the query has range fq, set range to that
-  // - if no range fq, use histogram min and max
-  const selectedRange: [number, number] = useMemo(() => {
-    if (fqRange) {
-      const range = /year:([0-9]{4})-([0-9]{4})/gm.exec(fqRange);
-      if (range.length === 3) {
-        return [parseInt(range[1]), parseInt(range[2])];
+    const histogramData = useMemo(() => {
+      if (data) {
+        return getYearsGraph(data).data.map((d) => ({
+          x: d.year,
+          y: d.notrefereed + d.refereed,
+        }));
       }
-    } else if (histogramData) {
-      return [histogramData[0].x, histogramData[histogramData.length - 1].x];
-    }
-    return null;
-  }, [fqRange, histogramData]);
+    }, [data]);
 
-  const handleApply = (values: number[]) => {
-    // add year range fq
-    const newQuery = setFQ(fqNameYearRange, `year:${values[0]}-${values[1]}`, cleanedQuery);
-    onQueryUpdate(newQuery);
-  };
+    // Selected range
+    // - If the query has range fq, set range to that
+    // - if no range fq, use histogram min and max
+    const selectedRange: [number, number] = useMemo(() => {
+      if (fqRange && histogramData) {
+        const range = /year:([0-9]{4})-([0-9]{4})/gm.exec(fqRange);
+        if (range.length === 3) {
+          return [parseInt(range[1]), parseInt(range[2])];
+        }
+      } else if (histogramData) {
+        return [histogramData[0].x, histogramData[histogramData.length - 1].x];
+      }
+      return null;
+    }, [fqRange, histogramData]);
 
-  const handleToggleExpand = () => {
-    onToggleExpand();
-  };
+    const handleApply = (values: number[]) => {
+      // add year range fq
+      const newQuery = setFQ(fqNameYearRange, `year:${values[0]}-${values[1]}`, cleanedQuery);
+      onQueryUpdate(newQuery);
+    };
 
-  return (
-    <Box>
-      {isLoading && <CircularProgress isIndeterminate />}
-      {histogramData && selectedRange && (
-        <Box height="170" position="relative" mt={5}>
-          <IconButton
-            aria-label="expand"
-            icon={isExpanded ? <ArrowsInIcon /> : <ArrowsOutIcon />}
-            position="absolute"
-            top={0}
-            left={0}
-            colorScheme="gray"
-            variant="outline"
-            onClick={handleToggleExpand}
-          />
-          <HistogramSlider
-            data={histogramData}
-            selectedRange={selectedRange}
-            width={width}
-            height={height}
-            onValuesChanged={handleApply}
-          />
-        </Box>
-      )}
-    </Box>
-  );
-};
+    const handleToggleExpand = () => {
+      onToggleExpand();
+    };
+
+    return (
+      <Box>
+        {isLoading && <CircularProgress isIndeterminate />}
+        {histogramData && selectedRange && (
+          <Box height="170" position="relative" mt={5}>
+            <IconButton
+              aria-label="expand"
+              icon={isExpanded ? <ArrowsInIcon /> : <ArrowsOutIcon />}
+              position="absolute"
+              top={0}
+              left={0}
+              colorScheme="gray"
+              variant="outline"
+              onClick={handleToggleExpand}
+            />
+            <HistogramSlider
+              data={histogramData}
+              selectedRange={selectedRange}
+              width={width}
+              height={height}
+              onValuesChanged={handleApply}
+            />
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -184,7 +184,7 @@ const SearchPage: NextPage = () => {
           )}
         </Box>
         {/* if histogram is expanded, show it below the search bar, otherwise it should be part of the facets */}
-        {!isPrint && isClient && data?.docs.length > 0 && histogramExpanded && (
+        {!isPrint && isClient && (!data || data.docs.length > 0) && histogramExpanded && (
           <Flex justifyContent="center">
             <YearHistogramSlider
               onQueryUpdate={handleSearchFacetSubmission}
@@ -198,7 +198,7 @@ const SearchPage: NextPage = () => {
         <Flex direction="row" gap={10}>
           <Box display={{ base: 'none', lg: 'block' }}>
             {/* hide facets if screen is too small */}
-            {!isPrint && isClient && data?.docs.length > 0 && (
+            {!isPrint && isClient && (!data || data.docs.length > 0) && (
               <SearchFacetFilters
                 showHistogram={!histogramExpanded}
                 onExpandHistogram={handleToggleExpand}


### PR DESCRIPTION
While loading the results page and there is no query data available, the histogram should still be allowed to be shown. This way histogram will not disappear when new filters are applied.