### PR TITLE
Minor UI issues

### DIFF
--- a/src/components/NumFound/NumFound.tsx
+++ b/src/components/NumFound/NumFound.tsx
@@ -1,6 +1,6 @@
 import { useGetSearchStats } from '@api';
 import { Text } from '@chakra-ui/layout';
-import { SkeletonText } from '@chakra-ui/react';
+import { Box, SkeletonText } from '@chakra-ui/react';
 import { useStore } from '@store';
 import { truncateDecimal } from '@utils';
 import { ReactElement } from 'react';
@@ -19,19 +19,25 @@ export const NumFound = (props: INumFoundProps): ReactElement => {
   const { count = 0, isLoading } = props;
 
   if (isLoading) {
-    return <SkeletonText noOfLines={1} w="40" mt="1" />;
+    return (
+      <Box h={5}>
+        <SkeletonText noOfLines={1} w="40" mt="1" skeletonHeight={2} />
+      </Box>
+    );
   }
 
   const countString = typeof count === 'number' ? sanitizeNum(count) : '0';
 
   return (
-    <Text role="status" fontSize="xs">
-      Your search returned{' '}
-      <Text as="span" fontWeight="bold">
-        {countString}
-      </Text>{' '}
-      results <SortStats />
-    </Text>
+    <Box h={5}>
+      <Text role="status" fontSize="xs">
+        Your search returned{' '}
+        <Text as="span" fontWeight="bold">
+          {countString}
+        </Text>{' '}
+        results <SortStats />
+      </Text>
+    </Box>
   );
 };
 

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -93,6 +93,7 @@ export const Item = (props: IItemProps): ReactElement => {
         mr="2"
         px="2"
         borderLeftRadius="md"
+        className="print-hidden"
       >
         <Text
           color={isChecked ? 'white' : 'initial'}

--- a/src/components/SearchBar/AllSearchTermsDropdown.tsx
+++ b/src/components/SearchBar/AllSearchTermsDropdown.tsx
@@ -1,5 +1,17 @@
 import { ChevronDownIcon } from '@chakra-ui/icons';
-import { Box, Code, Flex, IconButton, Input, ListItem, Text, UnorderedList, usePopper } from '@chakra-ui/react';
+import {
+  Box,
+  Code,
+  Flex,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  ListItem,
+  Text,
+  UnorderedList,
+  usePopper,
+} from '@chakra-ui/react';
 import { useCombobox } from 'downshift';
 import { matchSorter } from 'match-sorter';
 import { forwardRef, ReactElement, useEffect, useState } from 'react';
@@ -21,7 +33,7 @@ export const AllSearchTermsDropdown = ({ onSelect }: IAllSearchTermsDropdown): R
 
   const { popperRef: tooltipPopperRef, referenceRef: tooltipReferenceRef } = usePopper({
     placement: 'right-start',
-    offset: [40, 20],
+    offset: [40, 5],
   });
 
   const {
@@ -106,39 +118,40 @@ export const AllSearchTermsDropdown = ({ onSelect }: IAllSearchTermsDropdown): R
           return el;
         },
       })}
-      w="fit-content"
+      w="200px"
     >
       <Flex>
-        <Input
-          placeholder="all search terms"
-          {...getInputProps({
-            ref: (el: HTMLInputElement) => {
-              dropdownReferenceRef(el);
-              return el;
-            },
-            onKeyDown: (event) => {
-              if (event.key === 'Enter') {
-                if (items.length === 0 || !isOpen) {
-                  // Prevent Downshift's default 'Enter' behavior if invalid input or no input
-                  (
-                    event.nativeEvent as typeof event.nativeEvent & { preventDownshiftDefault: boolean }
-                  ).preventDownshiftDefault = true;
-                  event.preventDefault(); // this will prevent entering for search
-                  closeMenu();
+        <InputGroup>
+          <Input
+            placeholder="all search terms"
+            fontSize="md"
+            {...getInputProps({
+              ref: (el: HTMLInputElement) => {
+                dropdownReferenceRef(el);
+                return el;
+              },
+              onKeyDown: (event) => {
+                if (event.key === 'Enter') {
+                  if (items.length === 0 || !isOpen) {
+                    // Prevent Downshift's default 'Enter' behavior if invalid input or no input
+                    (
+                      event.nativeEvent as typeof event.nativeEvent & { preventDownshiftDefault: boolean }
+                    ).preventDownshiftDefault = true;
+                    event.preventDefault(); // this will prevent entering for search
+                    closeMenu();
+                  }
                 }
-              }
-            },
-          })}
-          onClick={toggleIsOpen}
-          data-testid="allSearchTermsInput"
-        />
-        <IconButton
-          icon={<ChevronDownIcon />}
-          {...getToggleButtonProps()}
-          borderLeftRadius={0}
-          tabIndex={0}
-          data-testid="allSearchTermsMenuToggle"
-        />
+              },
+            })}
+            onClick={toggleIsOpen}
+            data-testid="allSearchTermsInput"
+          />
+          <InputRightElement
+            children={<ChevronDownIcon />}
+            data-testid="allSearchTermsMenuToggle"
+            {...getToggleButtonProps()}
+          />
+        </InputGroup>
       </Flex>
       <UnorderedList
         zIndex={10}

--- a/src/components/SearchBar/AllSearchTermsDropdown.tsx
+++ b/src/components/SearchBar/AllSearchTermsDropdown.tsx
@@ -147,7 +147,7 @@ export const AllSearchTermsDropdown = ({ onSelect }: IAllSearchTermsDropdown): R
             data-testid="allSearchTermsInput"
           />
           <InputRightElement
-            children={<ChevronDownIcon />}
+            children={<ChevronDownIcon boxSize={6} color="gray.200" />}
             data-testid="allSearchTermsMenuToggle"
             {...getToggleButtonProps()}
           />

--- a/src/components/SearchFacet/FacetFilters.tsx
+++ b/src/components/SearchFacet/FacetFilters.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading } from '@chakra-ui/layout';
+import { Box, Flex, Text } from '@chakra-ui/layout';
 import {
   BoxProps,
   Button,
@@ -63,20 +63,14 @@ export const FacetFilters = (props: BoxProps): ReactElement => {
   }
 
   return (
-    <Box {...props} mb="2" borderWidth="thin" borderColor="gray.100" borderRadius={5} p={2}>
-      <VisuallyHidden as="h2">Applied Filters</VisuallyHidden>
-      {filterSections.map(([label, cleanClauses, rawClauses]) => (
-        <Wrap aria-labelledby={`${label} applied filters`} spacing="0.5" key={label}>
-          <WrapItem alignItems="center">
-            <Heading as="h3" fontSize="sm" id={`${label} applied filters`}>
-              {label}:
-            </Heading>
-          </WrapItem>
-          {cleanClauses.map((clause, index) => (
-            <WrapItem key={clause}>
-              <Tag size="sm" my="0.5" fontSize="sm" maxWidth="200">
+    <Box {...props} my="3">
+      <Flex {...props} mb="1" gap={2} wrap="wrap">
+        {filterSections.map(([label, cleanClauses, rawClauses]) => (
+          <span key={label}>
+            {cleanClauses.map((clause, index) => (
+              <Tag key={clause} size="sm" my="0.5" fontSize="sm" maxWidth="200">
                 <TagLabel isTruncated noOfLines={1}>
-                  <Tooltip label={clause}>{clause}</Tooltip>
+                  <Tooltip label={`${label}: ${clause}`}>{`${label}: ${clause}`}</Tooltip>
                 </TagLabel>
                 <TagCloseButton
                   data-value={clause}
@@ -84,12 +78,12 @@ export const FacetFilters = (props: BoxProps): ReactElement => {
                   onClick={handleRemoveFilterClick(rawClauses[index], label)}
                 />
               </Tag>
-            </WrapItem>
-          ))}
-        </Wrap>
-      ))}
+            ))}
+          </span>
+        ))}
+      </Flex>
       <Button variant="link" fontSize="xs" onClick={handleRemoveAllFiltersClick}>
-        Remove all
+        Remove all filters
       </Button>
     </Box>
   );

--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -1,8 +1,6 @@
 import { getSearchFacetYearsParams, IADSApiSearchParams, useGetSearchFacetCounts } from '@api';
-import { Box, CircularProgress, Flex, IconButton } from '@chakra-ui/react';
+import { Box, CircularProgress, Flex } from '@chakra-ui/react';
 import { HistogramSlider, ISearchFacetProps } from '@components';
-import { ArrowsInIcon } from '@components/icons/ArrowsIn';
-import { ArrowsOutIcon } from '@components/icons/ArrowsOut';
 import { getYearsGraph } from '@components/Visualizations/utils';
 import { fqNameYearRange } from '@query';
 import { getFQValue, removeFQ, setFQ } from '@query-utils';
@@ -11,94 +9,76 @@ import { memo, useMemo } from 'react';
 
 export interface IYearHistogramSliderProps {
   onQueryUpdate: ISearchFacetProps['onQueryUpdate'];
-  isExpanded: boolean;
-  onToggleExpand: () => void;
   width: number;
   height: number;
 }
 
-export const YearHistogramSlider = memo(
-  ({ onQueryUpdate, isExpanded, onToggleExpand, width, height }: IYearHistogramSliderProps) => {
-    const query = useStore((state) => state.latestQuery);
+export const YearHistogramSlider = memo(({ onQueryUpdate, width, height }: IYearHistogramSliderProps) => {
+  const query = useStore((state) => state.latestQuery);
 
-    // query without the year range filter, to show all years on the histogram
-    const cleanedQuery = useMemo(() => {
-      const q = JSON.parse(JSON.stringify(query)) as IADSApiSearchParams;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      return q.fq ? (removeFQ(fqNameYearRange, q) as IADSApiSearchParams) : q;
-    }, [query]);
+  // query without the year range filter, to show all years on the histogram
+  const cleanedQuery = useMemo(() => {
+    const q = JSON.parse(JSON.stringify(query)) as IADSApiSearchParams;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    return q.fq ? (removeFQ(fqNameYearRange, q) as IADSApiSearchParams) : q;
+  }, [query]);
 
-    const fqRange = useMemo(() => {
-      return getFQValue(fqNameYearRange, query);
-    }, [query]);
+  const fqRange = useMemo(() => {
+    return getFQValue(fqNameYearRange, query);
+  }, [query]);
 
-    const { data, isLoading } = useGetSearchFacetCounts(getSearchFacetYearsParams(cleanedQuery), {
-      enabled: !!cleanedQuery && cleanedQuery.q.trim().length > 0,
-    });
+  const { data, isLoading } = useGetSearchFacetCounts(getSearchFacetYearsParams(cleanedQuery), {
+    enabled: !!cleanedQuery && cleanedQuery.q.trim().length > 0,
+  });
 
-    const histogramData = useMemo(() => {
-      if (data) {
-        return getYearsGraph(data).data.map((d) => ({
-          x: d.year,
-          y: d.notrefereed + d.refereed,
-        }));
+  const histogramData = useMemo(() => {
+    if (data) {
+      return getYearsGraph(data).data.map((d) => ({
+        x: d.year,
+        y: d.notrefereed + d.refereed,
+      }));
+    }
+  }, [data]);
+
+  // Selected range
+  // - If the query has range fq, set range to that
+  // - if no range fq, use histogram min and max
+  const selectedRange: [number, number] = useMemo(() => {
+    if (fqRange && histogramData) {
+      const range = /year:([0-9]{4})-([0-9]{4})/gm.exec(fqRange);
+      if (range.length === 3) {
+        return [parseInt(range[1]), parseInt(range[2])];
       }
-    }, [data]);
+    } else if (histogramData) {
+      return [histogramData[0].x, histogramData[histogramData.length - 1].x];
+    }
+    return null;
+  }, [fqRange, histogramData]);
 
-    // Selected range
-    // - If the query has range fq, set range to that
-    // - if no range fq, use histogram min and max
-    const selectedRange: [number, number] = useMemo(() => {
-      if (fqRange && histogramData) {
-        const range = /year:([0-9]{4})-([0-9]{4})/gm.exec(fqRange);
-        if (range.length === 3) {
-          return [parseInt(range[1]), parseInt(range[2])];
-        }
-      } else if (histogramData) {
-        return [histogramData[0].x, histogramData[histogramData.length - 1].x];
-      }
-      return null;
-    }, [fqRange, histogramData]);
+  const handleApply = (values: number[]) => {
+    // add year range fq
+    const newQuery = setFQ(fqNameYearRange, `year:${values[0]}-${values[1]}`, cleanedQuery);
+    onQueryUpdate(newQuery);
+  };
 
-    const handleApply = (values: number[]) => {
-      // add year range fq
-      const newQuery = setFQ(fqNameYearRange, `year:${values[0]}-${values[1]}`, cleanedQuery);
-      onQueryUpdate(newQuery);
-    };
-
-    const handleToggleExpand = () => {
-      onToggleExpand();
-    };
-
-    return (
-      <Box>
-        {isLoading && (
-          <Flex direction="column" justifyContent="center" alignItems="center" height="170" position="relative" mt={5}>
-            <CircularProgress isIndeterminate />
-          </Flex>
-        )}
-        {histogramData && selectedRange && (
-          <Box height="170" position="relative" mt={5}>
-            <IconButton
-              aria-label="expand"
-              icon={isExpanded ? <ArrowsInIcon /> : <ArrowsOutIcon />}
-              position="absolute"
-              top={0}
-              left={0}
-              colorScheme="gray"
-              variant="outline"
-              onClick={handleToggleExpand}
-            />
-            <HistogramSlider
-              data={histogramData}
-              selectedRange={selectedRange}
-              width={width}
-              height={height}
-              onValuesChanged={handleApply}
-            />
-          </Box>
-        )}
-      </Box>
-    );
-  },
-);
+  return (
+    <Box>
+      {isLoading && (
+        <Flex direction="column" justifyContent="center" alignItems="center" height="170" position="relative" mt={5}>
+          <CircularProgress isIndeterminate />
+        </Flex>
+      )}
+      {histogramData && selectedRange && (
+        <Box height="170" position="relative" mt={5}>
+          <HistogramSlider
+            data={histogramData}
+            selectedRange={selectedRange}
+            width={histogramData.length === 1 ? 50 : width}
+            height={height}
+            onValuesChanged={handleApply}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+});

--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -1,5 +1,5 @@
 import { getSearchFacetYearsParams, IADSApiSearchParams, useGetSearchFacetCounts } from '@api';
-import { Box, CircularProgress, IconButton } from '@chakra-ui/react';
+import { Box, CircularProgress, Flex, IconButton } from '@chakra-ui/react';
 import { HistogramSlider, ISearchFacetProps } from '@components';
 import { ArrowsInIcon } from '@components/icons/ArrowsIn';
 import { ArrowsOutIcon } from '@components/icons/ArrowsOut';
@@ -72,7 +72,11 @@ export const YearHistogramSlider = memo(
 
     return (
       <Box>
-        {isLoading && <CircularProgress isIndeterminate />}
+        {isLoading && (
+          <Flex direction="column" justifyContent="center" alignItems="center" height="170" position="relative" mt={5}>
+            <CircularProgress isIndeterminate />
+          </Flex>
+        )}
         {histogramData && selectedRange && (
           <Box height="170" position="relative" mt={5}>
             <IconButton

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -193,15 +193,13 @@ const SearchPage: NextPage = () => {
       </Head>
       <Stack direction="column" aria-labelledby="search-form-title" spacing="10" ref={ref}>
         <Box pt={10}>
-          {isPrint || (
-            <form method="get" action="/search" onSubmit={handleOnSubmit} className="print-hidden">
-              <Flex direction="column" width="full">
-                <SearchBar isLoading={isLoading} />
-                <NumFound count={data?.numFound} isLoading={isLoading} />
-              </Flex>
-              <FacetFilters mt="2" />
-            </form>
-          )}
+          <form method="get" action="/search" onSubmit={handleOnSubmit} className="print-hidden">
+            <Flex direction="column" width="full">
+              <SearchBar isLoading={isLoading} />
+              <NumFound count={data?.numFound} isLoading={isLoading} />
+            </Flex>
+            <FacetFilters mt="2" />
+          </form>
         </Box>
         {/* if histogram is expanded, show it below the search bar, otherwise it should be part of the facets */}
         {!isPrint && isClient && (!data || data.docs.length > 0) && histogramExpanded && (
@@ -233,7 +231,7 @@ const SearchPage: NextPage = () => {
             )}
           </Box>
           <Box flexGrow={2}>
-            {isLoading || (isSuccess && data?.numFound > 0) ? (
+            {!isPrint && (isLoading || (isSuccess && data?.numFound > 0)) ? (
               <form>
                 <fieldset disabled={isLoading}>
                   <ListActions onSortChange={handleSortChange} />
@@ -250,12 +248,14 @@ const SearchPage: NextPage = () => {
             {data && (
               <>
                 <SimpleResultList docs={data.docs} indexStart={params.start} />
-                <Pagination
-                  numPerPage={storeNumPerPage}
-                  page={params.p}
-                  totalResults={data.numFound}
-                  onPerPageSelect={handlePerPageChange}
-                />
+                {!isPrint && (
+                  <Pagination
+                    numPerPage={storeNumPerPage}
+                    page={params.p}
+                    totalResults={data.numFound}
+                    onPerPageSelect={handlePerPageChange}
+                  />
+                )}
               </>
             )}
             {error && (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -22,6 +22,7 @@ import {
   Icon,
   IconButton,
   Portal,
+  Skeleton,
   Tooltip,
   useMediaQuery,
   VisuallyHidden,
@@ -60,7 +61,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { last, omit, path } from 'ramda';
 import { FormEventHandler, useEffect, useRef, useState } from 'react';
-import { dehydrate, QueryClient, useQueryClient } from 'react-query';
+import { dehydrate, isError, QueryClient, useQueryClient } from 'react-query';
 
 const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
   () => import('@components/SearchFacet/YearHistogramSlider').then((mod) => mod.YearHistogramSlider),
@@ -225,9 +226,13 @@ const SearchPage: NextPage = () => {
             )}
           </Box>
           <Box flexGrow={2}>
-            <Box>
-              {isSuccess && !isLoading && data?.numFound > 0 && <ListActions onSortChange={handleSortChange} />}
-            </Box>
+            {isLoading || (isSuccess && data?.numFound > 0) ? (
+              <form>
+                <fieldset disabled={isLoading}>
+                  <ListActions onSortChange={handleSortChange} />
+                </fieldset>
+              </form>
+            ) : null}
             <VisuallyHidden as="h2" id="search-form-title">
               Search Results
             </VisuallyHidden>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -22,7 +22,6 @@ import {
   Icon,
   IconButton,
   Portal,
-  Skeleton,
   Tooltip,
   useMediaQuery,
   VisuallyHidden,
@@ -41,6 +40,8 @@ import {
 import { calculateStartIndex } from '@components/ResultList/Pagination/usePagination';
 import { FacetFilters } from '@components/SearchFacet/FacetFilters';
 import { IYearHistogramSliderProps } from '@components/SearchFacet/YearHistogramSlider';
+import { ArrowsInIcon } from '@components/icons/ArrowsIn';
+import { ArrowsOutIcon } from '@components/icons/ArrowsOut';
 import { APP_DEFAULTS } from '@config';
 import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { useIsClient } from '@hooks';
@@ -61,7 +62,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { last, omit, path } from 'ramda';
 import { FormEventHandler, useEffect, useRef, useState } from 'react';
-import { dehydrate, isError, QueryClient, useQueryClient } from 'react-query';
+import { dehydrate, QueryClient, useQueryClient } from 'react-query';
 
 const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
   () => import('@components/SearchFacet/YearHistogramSlider').then((mod) => mod.YearHistogramSlider),
@@ -204,15 +205,21 @@ const SearchPage: NextPage = () => {
         </Box>
         {/* if histogram is expanded, show it below the search bar, otherwise it should be part of the facets */}
         {!isPrint && isClient && (!data || data.docs.length > 0) && histogramExpanded && (
-          <Flex justifyContent="center">
-            <YearHistogramSlider
-              onQueryUpdate={handleSearchFacetSubmission}
-              isExpanded={histogramExpanded}
-              onToggleExpand={handleToggleExpand}
-              width={width}
-              height={125}
+          <Box position="relative" aria-label="Year Histogram">
+            <IconButton
+              aria-label="expand"
+              icon={<ArrowsInIcon />}
+              position="absolute"
+              top={0}
+              left={0}
+              colorScheme="gray"
+              variant="outline"
+              onClick={handleToggleExpand}
             />
-          </Flex>
+            <Flex justifyContent="center">
+              <YearHistogramSlider onQueryUpdate={handleSearchFacetSubmission} width={width} height={125} />
+            </Flex>
+          </Box>
         )}
         <Flex direction="row" gap={10}>
           <Box display={{ base: 'none', lg: 'block' }}>
@@ -276,7 +283,7 @@ const SearchFacetFilters = (props: {
   if (showFilters) {
     return (
       <Flex as="aside" aria-labelledby="search-facets" minWidth="250px" direction="column">
-        <Flex>
+        <Flex mb={5}>
           <Heading as="h2" id="search-facets" fontSize="normal" flex="1">
             Filters
           </Heading>
@@ -321,15 +328,23 @@ const SearchFacetFilters = (props: {
           </Tooltip>
         </Flex>
         {showHistogram && (
-          <Flex justifyContent="center">
-            <YearHistogramSlider
-              onQueryUpdate={onSearchFacetSubmission}
-              isExpanded={false}
-              onToggleExpand={onExpandHistogram}
-              width={200}
-              height={125}
-            />
-          </Flex>
+          <Box aria-label="Year Histogram">
+            <Box position="relative">
+              <IconButton
+                aria-label="expand"
+                position="absolute"
+                icon={<ArrowsOutIcon />}
+                top={0}
+                left={0}
+                colorScheme="gray"
+                variant="outline"
+                onClick={onExpandHistogram}
+              />
+              <Flex justifyContent="center">
+                <YearHistogramSlider onQueryUpdate={onSearchFacetSubmission} width={200} height={125} />
+              </Flex>
+            </Box>
+          </Box>
         )}
         <SearchFacets onQueryUpdate={onSearchFacetSubmission} />
       </Flex>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -16,6 +16,12 @@
     @apply text-xl;
   }
 
+  @media print {
+    .print-hidden {
+      display: none;
+    }
+  }
+
   .default-text-color {
     @apply text-gray-600;
   }


### PR DESCRIPTION
### 1 Spacing while loading
Make the loading skeleton size consistent with content, so that there is less (or no) shifting of content switching from content to loading

https://user-images.githubusercontent.com/636361/230126132-ca53bb66-9da1-426b-988f-02501e1792fe.mov


### 2 Update the filter list to horizontal
<img width="867" alt="Screen Shot 2023-04-05 at 11 18 03 AM" src="https://user-images.githubusercontent.com/636361/230126395-e65196e7-094d-4f5e-af32-020518903a54.png">

### 3 Histogram: if only one year
Make it look a little more like a histogram by changing the bar width. Not appending more years because this might happen when using `year:` in the query, and the histogram implies other years were empty, which would be wrong.

<img width="269" alt="Screen Shot 2023-04-05 at 11 19 29 AM" src="https://user-images.githubusercontent.com/636361/230126783-3eac0821-4b94-4cf4-ac31-22dca00b6631.png">

### 4 All search term dropdown
Make it more consistent with the rest of the page
<img width="1291" alt="Screen Shot 2023-04-05 at 11 22 09 AM" src="https://user-images.githubusercontent.com/636361/230127513-f6b408e6-d83e-4f19-a7e7-333325e2ba5c.png">

### 5 For printing, remove checkboxes and controls
<img width="490" alt="Screen Shot 2023-04-05 at 11 23 28 AM" src="https://user-images.githubusercontent.com/636361/230127875-394fd0a5-cc2b-4e50-b06e-2b6d24d600c1.png">
