### PR TITLE
Some Improvements to ORCiD Profile page

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,5 +38,6 @@ const search = new URLSearchParams({
 export const ORCID_LOGIN_URL = `${process.env.NEXT_PUBLIC_ORCID_API_URL}/oauth/authorize?${search.toString()}`;
 
 export const ORCID_ADS_SOURCE_NAME = 'NASA Astrophysics Data System';
+export const ORCID_ADS_SOURCE_NAME_SHORT = 'NASA ADS';
 export const ORCID_BULK_DELETE_CHUNK_SIZE = 4;
 export const ORCID_BULK_DELETE_DELAY = 1000;

--- a/src/lib/orcid/useOrcidProfile.ts
+++ b/src/lib/orcid/useOrcidProfile.ts
@@ -1,0 +1,24 @@
+import { AppState, useStore } from '@store';
+import { useOrcidGetProfile } from '@api/orcid';
+import { isValidIOrcidUser } from '@api/orcid/models';
+
+const isAuthenticatedSelector = (state: AppState) => state.orcid.isAuthenticated;
+const orcidUserSelector = (state: AppState) => state.orcid.user;
+
+export const useOrcidProfile = (options?: Parameters<typeof useOrcidGetProfile>[1]) => {
+  const isAuthenticated = useStore(isAuthenticatedSelector);
+  const user = useStore(orcidUserSelector);
+
+  const { data: profile, ...result } = useOrcidGetProfile(
+    { user, full: true, update: true },
+    {
+      enabled: !!options.enabled || (isAuthenticated && isValidIOrcidUser(user)),
+      ...options,
+    },
+  );
+
+  return {
+    profile,
+    ...result,
+  };
+};


### PR DESCRIPTION
Converts the table loading/error state to use error boundary and suspense.
	Adds an error message with retry button
Make sure that time is shown properly within the updated tooltips
Fix the null-state for the source column
Shorten the NASA ADS source name for showing on the table (expanded name seen in tooltip)

Adds simple hook for just getting profile, since that is a typical usecase.