### PR TITLE
Fix highlight result ordering

### DIFF
--- a/src/api/search/search.ts
+++ b/src/api/search/search.ts
@@ -41,8 +41,12 @@ export const responseSelector = (data: IADSApiSearchResponse): IADSApiSearchResp
 export const statsSelector = (data: IADSApiSearchResponse): IADSApiSearchResponse['stats'] => data.stats;
 export const facetCountSelector = (data: IADSApiSearchResponse): IADSApiSearchResponse['facet_counts'] =>
   data.facet_counts;
-export const highlightingSelector = (data: IADSApiSearchResponse): IADSApiSearchResponse['highlighting'] =>
-  data.highlighting;
+export const highlightingSelector = (
+  data: IADSApiSearchResponse,
+): { docs: IADSApiSearchResponse['response']['docs']; highlighting: IADSApiSearchResponse['highlighting'] } => ({
+  docs: data.response.docs,
+  highlighting: data.highlighting,
+});
 export const facetFieldSelector = (data: IADSApiSearchResponse): IADSApiSearchResponse['facets'] => data.facets;
 
 type SearchKeyProps =
@@ -102,10 +106,10 @@ type SubPageQuery = SearchADSQuery<{ bibcode: IDocsEntity['bibcode']; start?: IA
 /**
  * Get highlights based on a search query
  */
-export const useGetHighlights: SearchADSQuery<IADSApiSearchParams, IADSApiSearchResponse['highlighting']> = (
-  params,
-  options,
-) => {
+export const useGetHighlights: SearchADSQuery<
+  IADSApiSearchParams,
+  { docs: IADSApiSearchResponse['response']['docs']; highlighting: IADSApiSearchResponse['highlighting'] }
+> = (params, options) => {
   const highlightParams = getHighlightParams(params);
   return useQuery({
     queryKey: searchKeys.highlight(omitParams(highlightParams)),

--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -58,7 +58,7 @@ export interface IADSApiSearchResponse {
   responseHeader?: IADSApiSearchResponseHeader;
   error?: IADSApiSearchResponseError;
   nextCursorMark?: string;
-  highlighting?: Record<number, Partial<Record<string, string[]>>>;
+  highlighting?: Record<string, Partial<Record<string, string[]>>>;
 }
 
 export interface IHighlight {

--- a/src/components/ResultList/SimpleResultList.tsx
+++ b/src/components/ResultList/SimpleResultList.tsx
@@ -20,12 +20,7 @@ const propTypes = {
 };
 
 export const SimpleResultList = (props: ISimpleResultListProps): ReactElement => {
-  const {
-    docs = [],
-    hideCheckboxes = false,
-    indexStart = 0,
-    ...divProps
-  } = props;
+  const { docs = [], hideCheckboxes = false, indexStart = 0, ...divProps } = props;
 
   const isClient = useIsClient();
   const start = indexStart + 1;
@@ -52,7 +47,7 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
           hideCheckbox={!isClient ? true : hideCheckboxes}
           hideActions={false}
           showHighlights={showHighlights}
-          highlights={highlights[index]}
+          highlights={highlights?.[index] ?? []}
           isFetchingHighlights={isFetchingHighlights}
         />
       ))}

--- a/src/components/ResultList/useHighlights.ts
+++ b/src/components/ResultList/useHighlights.ts
@@ -16,8 +16,7 @@ import { flatten, map, pipe, reduce, values } from 'ramda';
  * ---> [["foo"], ["bar", "baz ©"]]
  */
 const decoder = pipe<[Record<string, string[]>], string[][], string[], string[]>(values, flatten, map(decode));
-const transformHighlights = pipe<[IADSApiSearchResponse['highlighting']], Record<string, string[]>[], string[][]>(
-  values,
+const transformHighlights = pipe<[Record<string, string[]>[]], string[][]>(
   reduce((acc, value) => [...acc, [...decoder(value)]], [] as string[][]),
 );
 
@@ -52,5 +51,8 @@ export const useHighlights = () => {
     });
   }
 
-  return { showHighlights, highlights: transformHighlights(data), isFetchingHighlights: isFetching };
+  // Do this first to maintain results ordering
+  const highlights = data?.docs.map(({ id }) => data.highlighting[id]) ?? [];
+
+  return { showHighlights, highlights: transformHighlights(highlights), isFetchingHighlights: isFetching };
 };


### PR DESCRIPTION
In search results, highlights were mapped to the wrong articles because `highlightings` is an object, and has no ordering. This fix maps highlights to array in the same order as the search results first.