### PR TITLE
Check for undefined doc when fetching

### DIFF
--- a/src/api/search/models.ts
+++ b/src/api/search/models.ts
@@ -63,7 +63,7 @@ export const getSimilarParams = (bibcode: IDocsEntity['bibcode'], start: number)
 });
 
 export const getTocParams = (bibcode: IDocsEntity['bibcode'], start: number): IADSApiSearchParams => {
-  const volumeId = bibcode[13] === 'E' ? `${bibcode.substring(0, 14)}*` : `${bibcode.substring(0, 13)}*`;
+  const volumeId = bibcode?.[13] === 'E' ? `${bibcode?.substring(0, 14)}*` : `${bibcode?.substring(0, 13)}*`;
 
   return {
     ...defaultParams,

--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -128,8 +128,8 @@ export interface IAbstractSideNavProps extends HTMLAttributes<HTMLDivElement> {
 
 export const AbstractSideNav = (props: IAbstractSideNavProps): ReactElement => {
   const { doc } = props;
-  const hasGraphics = useHasGraphics(doc.bibcode);
-  const hasMetrics = useHasMetrics(doc.bibcode);
+  const hasGraphics = useHasGraphics(doc?.bibcode);
+  const hasMetrics = useHasMetrics(doc?.bibcode);
   const { menuItems, activeItem } = useGetItems({ doc, hasGraphics, hasMetrics });
 
   return (

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -21,16 +21,12 @@ export interface ICoreadsPageProps {
 
 const CoreadsPage: NextPage<ICoreadsPageProps> = (props: ICoreadsPageProps) => {
   const { id, error } = props;
-  const {
-    data: {
-      docs: [doc],
-    },
-  } = useGetAbstract({ id });
+  const { data: { docs: [doc] } = { docs: [] } } = useGetAbstract({ id });
 
-  const { getParams, onPageChange } = useGetAbstractParams(doc.bibcode);
+  const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
   const { data, isSuccess } = useGetCoreads(getParams(), { keepPreviousData: true });
-  const coreadsParams = getCoreadsParams(doc.bibcode, 0);
+  const coreadsParams = getCoreadsParams(doc?.bibcode, 0);
   const title = unwrapStringValue(doc?.title);
 
   return (

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -10,6 +10,7 @@ import Head from 'next/head';
 import NextImage from 'next/legacy/image';
 import NextLink from 'next/link';
 import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
+import { LoadingMessage } from '@components';
 
 interface IGraphicsPageProps {
   id: string;
@@ -25,7 +26,12 @@ const GraphicsPage: NextPage<IGraphicsPageProps> = (props: IGraphicsPageProps) =
   const doc = useGetAbstractDoc(id);
   const title = unwrapStringValue(doc?.title);
 
-  const { data: graphics, isError, isSuccess } = useGetGraphics(doc.bibcode, { keepPreviousData: true, retry: false });
+  const {
+    data: graphics,
+    isLoading,
+    isError,
+    isSuccess,
+  } = useGetGraphics(doc?.bibcode, { enabled: !!doc?.bibcode, keepPreviousData: true, retry: false });
   return (
     <AbsLayout doc={doc} titleDescription="Graphics from">
       <Head>
@@ -36,11 +42,12 @@ const GraphicsPage: NextPage<IGraphicsPageProps> = (props: IGraphicsPageProps) =
           Unable to fetch graphics
         </Box>
       )}
-      {!isError && !graphics && (
+      {!isError && !isLoading && !graphics && (
         <Box mt={5} fontSize="xl">
           No graphics
         </Box>
       )}
+      {isLoading && <LoadingMessage message="Loading" />}
       {isSuccess && graphics && (
         <>
           <Box dangerouslySetInnerHTML={{ __html: graphics.header }}></Box>

--- a/src/pages/abs/[id]/metrics.tsx
+++ b/src/pages/abs/[id]/metrics.tsx
@@ -10,7 +10,7 @@ import {
   useGetMetrics,
 } from '@api';
 import { Box } from '@chakra-ui/react';
-import { MetricsPane } from '@components';
+import { LoadingMessage, MetricsPane } from '@components';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
 import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
@@ -33,7 +33,12 @@ const MetricsPage: NextPage<IMetricsPageProps> = (props: IMetricsPageProps) => {
 
   const doc = useGetAbstractDoc(id);
 
-  const { data: metrics, isError, isSuccess } = useGetMetrics(doc.bibcode, { keepPreviousData: true });
+  const {
+    data: metrics,
+    isError,
+    isLoading,
+    isSuccess,
+  } = useGetMetrics(doc?.bibcode, { enabled: !!doc?.bibcode, keepPreviousData: true });
 
   const hasCitations = isSuccess && metrics && metrics[MetricsResponseKey.CS][CitationsStatsKey.TNC] > 0;
   const hasReads = isSuccess && metrics && metrics[MetricsResponseKey.BS][BasicStatsKey.TNR] > 0;
@@ -49,12 +54,12 @@ const MetricsPage: NextPage<IMetricsPageProps> = (props: IMetricsPageProps) => {
           Unable to fetch metrics
         </Box>
       )}
-      {!isError && !hasCitations && !hasReads ? (
+      {!isError && !isLoading && !hasCitations && !hasReads ? (
         <Box mt={5} fontSize="xl">
           No metrics data
         </Box>
       ) : (
-        <MetricsPane metrics={metrics} isAbstract={true} />
+        <>{isLoading ? <LoadingMessage message="Loading" /> : <MetricsPane metrics={metrics} isAbstract={true} />} </>
       )}
     </AbsLayout>
   );

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -24,9 +24,9 @@ const ReferencesPage: NextPage<IReferencesPageProps> = (props: IReferencesPagePr
   const { id, error } = props;
   const doc = useGetAbstractDoc(id);
 
-  const { getParams, onPageChange } = useGetAbstractParams(doc.bibcode);
+  const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
   const { data, isSuccess } = useGetReferences(getParams(), { keepPreviousData: true });
-  const referencesParams = getReferencesParams(doc.bibcode, 0);
+  const referencesParams = getReferencesParams(doc?.bibcode, 0);
   const title = unwrapStringValue(doc?.title);
 
   return (

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -24,10 +24,10 @@ const SimilarPage: NextPage<ISimilarPageProps> = (props: ISimilarPageProps) => {
   const { id, error } = props;
   const doc = useGetAbstractDoc(id);
 
-  const { getParams, onPageChange } = useGetAbstractParams(doc.bibcode);
+  const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
   const { data, isSuccess } = useGetSimilar(getParams(), { keepPreviousData: true });
-  const similarParams = getSimilarParams(doc.bibcode, 0);
+  const similarParams = getSimilarParams(doc?.bibcode, 0);
   const title = unwrapStringValue(doc?.title);
 
   return (

--- a/src/pages/abs/[id]/toc.tsx
+++ b/src/pages/abs/[id]/toc.tsx
@@ -10,6 +10,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
 import { composeNextGSSP } from '@ssr-utils';
+import { useMemo } from 'react';
 
 interface IVolumePageProps {
   id: string;
@@ -23,10 +24,19 @@ const VolumePage: NextPage<IVolumePageProps> = (props: IVolumePageProps) => {
   const { id, error } = props;
   const doc = useGetAbstractDoc(id);
 
-  const { getParams, onPageChange } = useGetAbstractParams(doc.bibcode);
+  const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
-  const { data, isSuccess } = useGetToc(getParams(), { keepPreviousData: true });
-  const tocParams = getTocParams(doc.bibcode, 0);
+  const { data, isSuccess } = useGetToc(getParams(), {
+    enabled: !!getParams && !!doc?.bibcode,
+    keepPreviousData: true,
+  });
+
+  const tocParams = useMemo(() => {
+    if (doc?.bibcode) {
+      return getTocParams(doc.bibcode, 0);
+    }
+  }, [doc]);
+
   const title = unwrapStringValue(doc?.title);
 
   return (


### PR DESCRIPTION
Abstract pages were having 'undefined' errors if loading pages directly, while data is being fetched. This PR make sure those are checked.