### PR TITLE
Scix 317 Fix viz bugs

### DIFF
--- a/src/components/Visualizations/Containers/ConceptCloudPageContainer.tsx
+++ b/src/components/Visualizations/Containers/ConceptCloudPageContainer.tsx
@@ -115,7 +115,7 @@ export const ConceptCloudPageContainer = ({ query }: IConceptCloudPageContainerP
     const values = state.filters.join(' OR ');
 
     const search = makeSearchParams({ ...query, fq: fqs, fq_wordcloud: `(${values})`, p: 1 });
-    void router.push({ pathname: '/search', search }, null, { scroll: false, shallow: true });
+    void router.push({ pathname: '/search', search }, null, { scroll: false });
   };
 
   // slider value changed

--- a/src/components/Visualizations/Containers/OverviewPageContainer.tsx
+++ b/src/components/Visualizations/Containers/OverviewPageContainer.tsx
@@ -41,7 +41,7 @@ export const OverviewPageContainer = ({ query, onApplyQueryCondition }: IOvervie
 
     // tigger search
     const search = makeSearchParams({ ...newQuery, p: 1 });
-    void router.push({ pathname: '/search', search }, null, { scroll: false, shallow: true });
+    void router.push({ pathname: '/search', search }, null, { scroll: false });
   };
 
   const handleApplyCitationCondition = (cond: string) => {

--- a/src/components/Visualizations/Graphs/useAuthorNetworkGraph.tsx
+++ b/src/components/Visualizations/Graphs/useAuthorNetworkGraph.tsx
@@ -53,21 +53,8 @@ export const useAuthorNetworkGraph = (
     [keyToUseAsValue],
   );
 
-  // color function returns color based on domain
-  const color = useMemo(() => {
-    return d3
-      .scaleOrdinal<string>()
-      .domain(['0', '1', '2', '3', '4', '5', '6'])
-      .range([
-        'hsla(282, 60%, 52%, 1)',
-        'hsla(349, 61%, 47%, 1)',
-        'hsla(26, 95%, 67%, 1)',
-        'hsla(152, 60%, 40%, 1)',
-        'hsla(193, 64%, 61%, 1)',
-        'hsla(220, 70%, 56%, 1)',
-        'hsla(250, 50%, 47%, 1)',
-      ]);
-  }, []);
+  // use the same color scheme (category10) as Nivo graphs so they will match the corresponding line graph
+  const color = d3.scaleOrdinal(d3.schemeCategory10);
 
   const noGroupColor = '#a6a6a6';
 

--- a/src/components/Visualizations/Graphs/usePaperNetworkGraph.tsx
+++ b/src/components/Visualizations/Graphs/usePaperNetworkGraph.tsx
@@ -31,18 +31,8 @@ export const usePaperNetworkGraph = (
     .innerRadius(innerRadius)
     .outerRadius(outerRadius);
 
-  const color = d3
-    .scaleOrdinal<string>()
-    .domain(['0', '1', '2', '3', '4', '5', '6'])
-    .range([
-      'hsla(282, 60%, 52%, 1)',
-      'hsla(349, 61%, 47%, 1)',
-      'hsla(26, 95%, 67%, 1)',
-      'hsla(152, 60%, 40%, 1)',
-      'hsla(193, 64%, 61%, 1)',
-      'hsla(220, 70%, 56%, 1)',
-      'hsla(250, 50%, 47%, 1)',
-    ]);
+  // use the same color scheme (category10) as Nivo graphs so they will match the corresponding line graph
+  const color = d3.scaleOrdinal(d3.schemeCategory10);
 
   const noGroupColor = '#a6a6a6';
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -98,8 +98,8 @@
   padding: 1.25rem;
   margin: 0;
   border-radius: 0.25rem;
-  color: #F9FAFB;
-  background-color: #1F2937;
+  color: #f9fafb;
+  background-color: #1f2937;
 }
 
 .bubble-plot-svg .paper-circle {
@@ -108,7 +108,7 @@
 }
 
 .bubble-plot-svg .paper-circle:hover {
-  opacity: .9;
+  opacity: 0.9;
 }
 
 .bubble-plot-svg .paper-circle.selected {
@@ -125,8 +125,8 @@
   padding: 0.25rem;
   margin: 0;
   border-radius: 0.25rem;
-  color: #F9FAFB;
-  background-color: #1F2937;
+  color: #f9fafb;
+  background-color: #1f2937;
 }
 
 /* ReCAPTCHA badge*/
@@ -135,9 +135,13 @@
 }
 
 /* Remove x for the main searchbar */
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-results-button,
-input[type="search"]::-webkit-search-results-decoration {
-  -webkit-appearance:none;
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
Fix a few bugs in visualizations:
### 1. Make author and paper network group color match the colors of the line graph groups (by using the same color scheme)
<img width="1262" alt="Screen Shot 2023-11-22 at 11 06 26 AM" src="https://github.com/adsabs/nectar/assets/636361/0b8c05f3-30f3-41f4-96d1-ff3eb99fb62f">

### 2. Hide labels of paper network group that are too small
<img width="549" alt="Screen Shot 2023-11-22 at 11 07 49 AM" src="https://github.com/adsabs/nectar/assets/636361/30db5541-9bda-4240-a8c1-44e625bd4733">

### 3. Fix 'search' from word cloud and overview 