### PR TITLE
Fix Details Page SSR Issue

### DIFF
--- a/src/api/graphics/graphics.ts
+++ b/src/api/graphics/graphics.ts
@@ -28,7 +28,7 @@ export const useHasGraphics: ADSQuery<IDocsEntity['bibcode'], IADSApiGraphicsRes
 ) => {
   const params = { bibcode };
 
-  const { isSuccess } = useQuery({
+  const { data } = useQuery({
     queryKey: graphicsKeys.primary(bibcode),
     queryFn: fetchGraphics,
     retry: retryFn,
@@ -36,7 +36,7 @@ export const useHasGraphics: ADSQuery<IDocsEntity['bibcode'], IADSApiGraphicsRes
     ...options,
   });
 
-  return isSuccess;
+  return !isNil(data);
 };
 
 /**
@@ -63,12 +63,8 @@ export const fetchGraphics: QueryFunction<IADSApiGraphicsResponse> = async ({ me
 
   const { data: graphics } = await api.request<IADSApiGraphicsResponse>(config);
 
-  if (isNil(graphics)) {
-    throw new Error('No Graphics');
-  }
-
-  if (graphics.Error) {
-    throw new Error(graphics['Error Info'] ? graphics['Error Info'] : 'No Graphics');
+  if (isNil(graphics) || graphics.Error) {
+    return null;
   }
 
   return graphics;

--- a/src/api/metrics/metrics.ts
+++ b/src/api/metrics/metrics.ts
@@ -44,7 +44,7 @@ export const useHasMetrics: ADSQuery<Bibcode, IADSApiMetricsResponse, null, bool
 
   const metrics = data as IADSApiMetricsResponse;
 
-  if (isError) {
+  if (isError || isNil(data)) {
     return false;
   }
 
@@ -100,12 +100,9 @@ export const fetchMetrics: QueryFunction<IADSApiMetricsResponse> = async ({ meta
 
   const { data: metrics } = await api.request<IADSApiMetricsResponse>(config);
 
-  if (isNil(metrics)) {
-    throw new Error('No Metrics');
+  if (isNil(metrics) || metrics[MetricsResponseKey.E]) {
+    return null;
   }
 
-  if (metrics[MetricsResponseKey.E]) {
-    throw new Error(metrics[MetricsResponseKey.EI] ? metrics[MetricsResponseKey.EI] : 'No Metrics');
-  }
   return metrics;
 };

--- a/src/api/resolver/resolver.ts
+++ b/src/api/resolver/resolver.ts
@@ -9,7 +9,7 @@ export enum ResolverKeys {
 }
 
 export const resolverKeys = {
-  links: (params: IADSApiResolverParams) => [params] as const,
+  links: (params: IADSApiResolverParams) => [ResolverKeys.LINKS, params] as const,
 };
 
 export const useResolverQuery: ADSQuery<IADSApiResolverParams, IADSApiResolverResponse> = (params, options) => {
@@ -27,8 +27,10 @@ export const fetchLinks: QueryFunction<IADSApiResolverResponse> = async ({ meta 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.RESOLVER}/${params.bibcode}/${params.link_type}`,
+    validateStatus: (status) => status === 200 || status === 404,
   };
 
   const { data } = await api.request<IADSApiResolverResponse>(config);
+
   return data;
 };

--- a/src/api/resolver/types.ts
+++ b/src/api/resolver/types.ts
@@ -18,4 +18,5 @@ export interface IADSApiResolverResponse {
       },
     ];
   };
+  error?: string;
 }

--- a/src/components/AbstractSources/AbstractSources.tsx
+++ b/src/components/AbstractSources/AbstractSources.tsx
@@ -4,12 +4,12 @@ import {
   HStack,
   Menu,
   MenuButton,
+  MenuDivider,
+  MenuGroup,
   MenuItem,
   MenuList,
-  VStack,
   Text,
-  MenuGroup,
-  MenuDivider,
+  VStack,
 } from '@chakra-ui/react';
 import { ChevronDownIcon, LockIcon, UnlockIcon } from '@chakra-ui/icons';
 import { SimpleLinkList } from '@components';
@@ -42,7 +42,7 @@ export const AbstractSources = ({ doc }: IAbstractSourcesProps): ReactElement =>
 
   const relatedWorks = useMemo(() => {
     const res = [] as IRelatedWorks[];
-    if (relatedWorksResp && relatedWorksResp.links.count > 0) {
+    if (relatedWorksResp && !relatedWorksResp.error && relatedWorksResp.links.count > 0) {
       for (const link of relatedWorksResp.links.records) {
         res.push({ url: link.url, name: link.title, description: link.type });
       }

--- a/src/components/CitationExporter/CitationExporter.machine.ts
+++ b/src/components/CitationExporter/CitationExporter.machine.ts
@@ -84,22 +84,32 @@ export type CitationExporterEvent =
   | { type: 'FORCE_SUBMIT' }
   | { type: 'DONE' };
 
+export const getMaxAuthor = (format: ExportApiFormatKey) => {
+  switch (format) {
+    case ExportApiFormatKey.bibtex:
+      return APP_DEFAULTS.BIBTEX_DEFAULT_MAX_AUTHOR;
+    case ExportApiFormatKey.bibtexabs:
+      return APP_DEFAULTS.BIBTEX_ABS_DEFAULT_MAX_AUTHOR;
+    default:
+      return 0;
+  }
+};
+
 export const getExportCitationDefaultContext = (props: IUseCitationExporterProps): ICitationExporterState => {
   const {
     records = [],
     format = ExportApiFormatKey.bibtex,
     customFormat = '%1H:%Y:%q',
-    singleMode,
     sort = ['date desc'],
     keyformat = '%R',
     journalformat = ExportApiJournalFormat.AASTeXMacros,
     authorcutoff = APP_DEFAULTS.BIBTEX_DEFAULT_AUTHOR_CUTOFF,
-    maxauthor = format === ExportApiFormatKey.bibtex
-      ? APP_DEFAULTS.BIBTEX_DEFAULT_MAX_AUTHOR
-      : format === ExportApiFormatKey.bibtexabs
-      ? APP_DEFAULTS.BIBTEX_ABS_DEFAULT_MAX_AUTHOR
-      : 0,
+    singleMode = false,
   } = props;
+
+  // maxauthor is different for bibtex and bibtexabs, unless it's set explicitly
+  const maxauthor = props.maxauthor ?? getMaxAuthor(format);
+
   const params: IExportApiParams = {
     format,
     customFormat,

--- a/src/components/CitationExporter/CitationExporter.tsx
+++ b/src/components/CitationExporter/CitationExporter.tsx
@@ -201,7 +201,6 @@ const Exporter = (props: ICitationExporterProps): ReactElement => {
                     </Stack>
                     <Divider display={['block', 'none']} />
                   </Stack>
-                  {/* <ResultArea result={data?.export} format={ctx.params.format} isLoading={isLoading} flex="1" /> */}
                 </Stack>
               </form>
             </TabPanel>
@@ -210,7 +209,6 @@ const Exporter = (props: ICitationExporterProps): ReactElement => {
                 <Stack spacing="4" flexGrow={[3, 2]} maxW="lg">
                   <CustomFormatSelect dispatch={dispatch} />
                 </Stack>
-                {/* <ResultArea result={data?.export} format={ctx.params.format} /> */}
               </Stack>
             </TabPanel>
           </TabPanels>

--- a/src/hocs/withDetailsPage.ts
+++ b/src/hocs/withDetailsPage.ts
@@ -1,42 +1,109 @@
-import api, { fetchSearch, getAbstractParams, searchKeys } from '@api';
-import { AppState } from '@store';
-import { normalizeURLParams } from '@utils';
+import {
+  fetchGraphics,
+  fetchMetrics,
+  fetchSearch,
+  getAbstractParams,
+  getCitationsParams,
+  getCoreadsParams,
+  getMetricsParams,
+  getReferencesParams,
+  getSimilarParams,
+  getTocParams,
+  graphicsKeys,
+  metricsKeys,
+  searchKeys,
+} from '@api';
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { fetchLinks, resolverKeys } from '@api/resolver';
 
 export const withDetailsPage = async (
   ctx: GetServerSidePropsContext,
 ): Promise<GetServerSidePropsResult<Record<string, unknown>>> => {
-  const query = normalizeURLParams<{ id: string }>(ctx.query);
-  api.setUserData(ctx.req.session.token);
+  const { id } = ctx.params as { id: string };
 
-  // primary request for this page is search for the bibcode from url
-  try {
-    // we want to cache this result, for subsequent client-side requests
-    const queryClient = new QueryClient();
-    const params = getAbstractParams(query.id);
-    const primaryResult = await queryClient.fetchQuery({
-      queryKey: searchKeys.abstract(query.id),
+  const pathname = ctx.resolvedUrl.split('?')[0];
+  const queryClient = new QueryClient();
+
+  // Fetch all the data we need for the details page
+  await Promise.allSettled([
+    // primary abstract data
+    queryClient.fetchQuery({
+      queryKey: searchKeys.abstract(id),
       queryFn: fetchSearch,
-      meta: { params },
-    });
+      meta: { params: getAbstractParams(id) },
+    }),
 
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-        dehydratedAppState: {
-          docs: {
-            doc: primaryResult.response.docs[0].bibcode,
-          },
-        } as AppState,
-        id: query.id,
-      },
-    };
-  } catch (e) {
-    return {
-      props: {
-        id: query.id,
-      },
-    };
-  }
+    // graphics
+    queryClient.prefetchQuery({
+      queryKey: graphicsKeys.primary(id),
+      queryFn: fetchGraphics,
+      meta: { params: { bibcode: id } },
+    }),
+
+    // metrics
+    queryClient.prefetchQuery({
+      queryKey: metricsKeys.primary([id]),
+      queryFn: fetchMetrics,
+      meta: { params: getMetricsParams([id]) },
+    }),
+
+    // associated works
+    queryClient.prefetchQuery({
+      queryKey: resolverKeys.links({ bibcode: id, link_type: 'associated' }),
+      queryFn: fetchLinks,
+      meta: { params: { bibcode: id, link_type: 'associated' } },
+    }),
+
+    // references (only if we're on the references page)
+    pathname.endsWith('/references')
+      ? queryClient.prefetchQuery({
+          queryKey: searchKeys.references({ bibcode: id, start: 0 }),
+          queryFn: fetchSearch,
+          meta: { params: getReferencesParams(id, 0) },
+        })
+      : Promise.resolve(),
+
+    // citations (only if we're on the citations page)
+    pathname.endsWith('/citations')
+      ? queryClient.prefetchQuery({
+          queryKey: searchKeys.citations({ bibcode: id, start: 0 }),
+          queryFn: fetchSearch,
+          meta: { params: getCitationsParams(id, 0) },
+        })
+      : Promise.resolve(),
+
+    // coreads (only if we're on the coreads page)
+    pathname.endsWith('/coreads')
+      ? queryClient.prefetchQuery({
+          queryKey: searchKeys.coreads({ bibcode: id, start: 0 }),
+          queryFn: fetchSearch,
+          meta: { params: getCoreadsParams(id, 0) },
+        })
+      : Promise.resolve(),
+
+    // similar (only if we're on the similar page)
+    pathname.endsWith('/similar')
+      ? queryClient.prefetchQuery({
+          queryKey: searchKeys.similar({ bibcode: id, start: 0 }),
+          queryFn: fetchSearch,
+          meta: { params: getSimilarParams(id, 0) },
+        })
+      : Promise.resolve(),
+
+    // toc (only if we're on the toc page)
+    pathname.endsWith('/toc')
+      ? queryClient.prefetchQuery({
+          queryKey: searchKeys.toc({ bibcode: id, start: 0 }),
+          queryFn: fetchSearch,
+          meta: { params: getTocParams(id, 0) },
+        })
+      : Promise.resolve(),
+  ]);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
 };

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -135,7 +135,7 @@ const AbstractPage: NextPage<IAbstractPageProps> = (props: IAbstractPageProps) =
                     <>{author}</>
                   </SearchQueryLink>
                 ))}
-                {doc.author_count > MAX ? <Text>{` and ${doc.author_count - MAX} more`}</Text> : null}
+                {doc?.author_count > MAX ? <Text>{` and ${doc?.author_count - MAX} more`}</Text> : null}
               </Flex>
             )}
 
@@ -152,11 +152,13 @@ const AbstractPage: NextPage<IAbstractPageProps> = (props: IAbstractPageProps) =
                 </Tooltip>
               )}
             </Flex>
-            {isNil(doc.abstract) ? (
-              <Text>No Abstract</Text>
-            ) : (
-              <Text as={MathJax} dangerouslySetInnerHTML={{ __html: doc.abstract }} />
-            )}
+            <Box py="2">
+              {isNil(doc?.abstract) ? (
+                <Text>No Abstract</Text>
+              ) : (
+                <Text as={MathJax} dangerouslySetInnerHTML={{ __html: doc.abstract }} />
+              )}
+            </Box>
             <Details doc={doc} />
             <Flex justifyContent="end">
               <Button variant="link" onClick={handleFeedback}>

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -1,45 +1,35 @@
-import { getCitationsParams, IADSApiSearchResponse, searchKeys, useGetCitations } from '@api';
+import { getCitationsParams, IDocsEntity, useGetAbstract, useGetCitations } from '@api';
 import { Alert, AlertIcon } from '@chakra-ui/react';
 import { AbstractRefList } from '@components/AbstractRefList';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
-import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
 import { useGetAbstractParams } from '@lib/useGetAbstractParams';
-import { unwrapStringValue } from '@utils';
 import { NextPage } from 'next';
 import Head from 'next/head';
-import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
-import { normalizeURLParams } from 'src/utils';
 import { composeNextGSSP } from '@ssr-utils';
+import { useRouter } from 'next/router';
+import { path } from 'ramda';
+import { getDetailsPageTitle } from '@pages/abs/[id]/abstract';
 
-export interface ICitationsPageProps {
-  id: string;
-  error?: {
-    status?: string;
-    message?: string;
-  };
-}
-
-const CitationsPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps) => {
-  const { id, error } = props;
-
-  const doc = useGetAbstractDoc(id);
+const CitationsPage: NextPage = () => {
+  const router = useRouter();
+  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id: router.query.id as string });
+  const doc = path<IDocsEntity>(['docs', 0], abstractDoc);
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
   // get the primary response from server (or cache)
-  const { data, isSuccess } = useGetCitations(getParams(), { keepPreviousData: true });
+  const { data, isSuccess, error: citationsError } = useGetCitations(getParams(), { keepPreviousData: true });
   const citationsParams = getCitationsParams(doc?.bibcode, 0);
-  const title = unwrapStringValue(doc?.title);
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers that cite">
       <Head>
-        <title>NASA Science Explorer - Citations - {title}</title>
+        <title>{getDetailsPageTitle(doc, 'Citations')}</title>
       </Head>
-      {error && (
+      {(abstractError || citationsError) && (
         <Alert status="error">
           <AlertIcon />
-          {error}
+          {abstractError?.message || citationsError?.message}
         </Alert>
       )}
       {isSuccess && (
@@ -57,50 +47,4 @@ const CitationsPage: NextPage<ICitationsPageProps> = (props: ICitationsPageProps
 
 export default CitationsPage;
 
-export const getServerSideProps = composeNextGSSP(withDetailsPage, async (ctx, state) => {
-  const { fetchSearch } = await import('@api');
-  const axios = (await import('axios')).default;
-  const query = normalizeURLParams(ctx.query);
-
-  try {
-    const queryClient = new QueryClient();
-    hydrate(queryClient, state.props?.dehydratedState as DehydratedState);
-    const {
-      response: {
-        docs: [{ bibcode }],
-      },
-    } = queryClient.getQueryData<IADSApiSearchResponse>(searchKeys.abstract(query.id));
-
-    const params = getCitationsParams(bibcode, 0);
-    void (await queryClient.prefetchQuery({
-      queryKey: searchKeys.citations({ bibcode, start: params.start }),
-      queryFn: fetchSearch,
-      meta: { params },
-    }));
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      return {
-        props: {
-          error: {
-            status: e.response.status,
-            message: e.message,
-          },
-        },
-      };
-    }
-    return {
-      props: {
-        error: {
-          status: 500,
-          message: 'Unknown server error',
-        },
-      },
-    };
-  }
-});
+export const getServerSideProps = composeNextGSSP(withDetailsPage);

--- a/src/pages/abs/[id]/exportcitation/[format].tsx
+++ b/src/pages/abs/[id]/exportcitation/[format].tsx
@@ -1,32 +1,23 @@
-import { ExportApiFormatKey, exportCitationKeys, IADSApiSearchResponse, isExportApiFormat, searchKeys } from '@api';
-import { Alert, AlertIcon, Box } from '@chakra-ui/react';
+import { ExportApiFormatKey, IDocsEntity, isExportApiFormat, useGetAbstract } from '@api';
+import { Box } from '@chakra-ui/react';
 import { CitationExporter, JournalFormatMap } from '@components';
-import { getExportCitationDefaultContext } from '@components/CitationExporter/CitationExporter.machine';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { DEFAULT_USER_DATA } from '@components/Settings/model';
 import { withDetailsPage } from '@hocs/withDetailsPage';
-import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
-import { useIsClient } from '@lib/useIsClient';
-import { normalizeURLParams, unwrapStringValue } from '@utils';
 import { useStore } from '@store';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
-import { isEmpty } from 'ramda';
-import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
+import { isEmpty, path } from 'ramda';
 import { composeNextGSSP } from '@ssr-utils';
+import { useRouter } from 'next/router';
+import { getDetailsPageTitle } from '@pages/abs/[id]/abstract';
 
-interface IExportCitationPageProps {
-  id: string;
-  format: ExportApiFormatKey;
-  error?: {
-    status?: string;
-    message?: string;
-  };
-}
-const ExportCitationPage: NextPage<IExportCitationPageProps> = ({ id, format, error }) => {
-  const doc = useGetAbstractDoc(id);
-  const isClient = useIsClient();
-  const title = unwrapStringValue(doc?.title);
+const ExportCitationPage: NextPage = () => {
+  const router = useRouter();
+  const format = isExportApiFormat(router.query.format) ? router.query.format : ExportApiFormatKey.bibtex;
+  const { data } = useGetAbstract({ id: router.query.id as string });
+  const doc = path<IDocsEntity>(['docs', 0], data);
+
   // get export related user settings
   const settings = useStore((state) =>
     state.settings.user && !isEmpty(state.settings.user) ? state.settings.user : DEFAULT_USER_DATA,
@@ -36,101 +27,36 @@ const ExportCitationPage: NextPage<IExportCitationPageProps> = ({ id, format, er
       ? {
           keyformat: settings.bibtexABSKeyFormat,
           journalformat: settings.bibtexJournalFormat,
-          authorcutoff: parseInt(settings.bibtexABSAuthorCutoff),
-          maxauthor: parseInt(settings.bibtexABSMaxAuthors),
+          authorcutoff: parseInt(settings.bibtexABSAuthorCutoff, 10),
+          maxauthor: parseInt(settings.bibtexABSMaxAuthors, 10),
         }
       : {
           keyformat: settings.bibtexKeyFormat,
           journalformat: settings.bibtexJournalFormat,
-          authorcutoff: parseInt(settings.bibtexAuthorCutoff),
-          maxauthor: parseInt(settings.bibtexMaxAuthors),
+          authorcutoff: parseInt(settings.bibtexAuthorCutoff, 10),
+          maxauthor: parseInt(settings.bibtexMaxAuthors, 10),
         };
 
   return (
     <AbsLayout doc={doc} titleDescription="Export citation for">
       <Head>
-        <title>NASA Science Explorer - Export Citation - {title}</title>
+        <title>{getDetailsPageTitle(doc, 'Export')}</title>
       </Head>
       <Box pt="1">
-        {error ? (
-          <Alert status="error">
-            <AlertIcon />
-            {error.message}
-          </Alert>
-        ) : isClient ? (
-          <CitationExporter
-            initialFormat={format}
-            keyformat={keyformat}
-            journalformat={JournalFormatMap[journalformat]}
-            maxauthor={maxauthor}
-            authorcutoff={authorcutoff}
-            records={doc?.bibcode ? [doc.bibcode] : []}
-            singleMode
-          />
-        ) : (
-          <CitationExporter.Static
-            records={doc?.bibcode ? [doc.bibcode] : []}
-            initialFormat={format}
-            totalRecords={1}
-          />
-        )}
+        <CitationExporter
+          initialFormat={format}
+          keyformat={keyformat}
+          journalformat={JournalFormatMap[journalformat]}
+          maxauthor={maxauthor}
+          authorcutoff={authorcutoff}
+          records={doc?.bibcode ? [doc.bibcode] : []}
+          singleMode
+        />
       </Box>
     </AbsLayout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage, async (ctx, state) => {
-  const { fetchExportCitation } = await import('@api');
-  const axios = (await import('axios')).default;
-  const query = normalizeURLParams<{ id: string; format: string }>(ctx.query);
-
-  try {
-    const queryClient = new QueryClient();
-    hydrate(queryClient, state.props?.dehydratedState as DehydratedState);
-    const {
-      response: {
-        docs: [{ bibcode }],
-      },
-    } = queryClient.getQueryData<IADSApiSearchResponse>(searchKeys.abstract(query.id));
-
-    const { params } = getExportCitationDefaultContext({
-      format: isExportApiFormat(query.format) ? query.format : ExportApiFormatKey.bibtex,
-      records: [bibcode],
-      singleMode: true,
-    });
-
-    void (await queryClient.prefetchQuery({
-      queryKey: exportCitationKeys.primary(params),
-      queryFn: fetchExportCitation,
-      meta: { params },
-    }));
-
-    return {
-      props: {
-        format: params.format,
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      return {
-        props: {
-          error: {
-            status: e.response.status,
-            message: e.message,
-          },
-        },
-      };
-    }
-    return {
-      props: {
-        error: {
-          status: 500,
-          message: 'Unknown server error',
-        },
-      },
-    };
-  }
-});
-
 export default ExportCitationPage;
+
+export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage);

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -1,43 +1,34 @@
-import { getReferencesParams, IADSApiSearchResponse, searchKeys, useGetReferences } from '@api';
+import { getReferencesParams, IDocsEntity, useGetAbstract, useGetReferences } from '@api';
 import { Alert, AlertIcon } from '@chakra-ui/react';
 import { AbstractRefList } from '@components/AbstractRefList';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
-import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
 import { useGetAbstractParams } from '@lib/useGetAbstractParams';
-import { unwrapStringValue } from '@utils';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
-import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
-import { normalizeURLParams } from 'src/utils';
 import { composeNextGSSP } from '@ssr-utils';
+import { useRouter } from 'next/router';
+import { path } from 'ramda';
+import { getDetailsPageTitle } from '@pages/abs/[id]/abstract';
 
-export interface IReferencesPageProps {
-  id: string;
-  error?: {
-    status?: string;
-    message?: string;
-  };
-}
-
-const ReferencesPage: NextPage<IReferencesPageProps> = (props: IReferencesPageProps) => {
-  const { id, error } = props;
-  const doc = useGetAbstractDoc(id);
+const ReferencesPage: NextPage = () => {
+  const router = useRouter();
+  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id: router.query.id as string });
+  const doc = path<IDocsEntity>(['docs', 0], abstractDoc);
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
-  const { data, isSuccess } = useGetReferences(getParams(), { keepPreviousData: true });
+  const { data, isSuccess, error: referencesError } = useGetReferences(getParams(), { keepPreviousData: true });
   const referencesParams = getReferencesParams(doc?.bibcode, 0);
-  const title = unwrapStringValue(doc?.title);
 
   return (
     <AbsLayout doc={doc} titleDescription="Paper referenced by">
       <Head>
-        <title>NASA Science Explorer - References - {title}</title>
+        <title>{getDetailsPageTitle(doc, 'References')}</title>
       </Head>
-      {error && (
+      {(abstractError || referencesError) && (
         <Alert status="error">
           <AlertIcon />
-          {error}
+          {abstractError?.message || referencesError?.message}
         </Alert>
       )}
       {isSuccess && (
@@ -55,50 +46,4 @@ const ReferencesPage: NextPage<IReferencesPageProps> = (props: IReferencesPagePr
 
 export default ReferencesPage;
 
-export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage, async (ctx, state) => {
-  const { fetchSearch } = await import('@api');
-  const axios = (await import('axios')).default;
-  const query = normalizeURLParams(ctx.query);
-
-  try {
-    const queryClient = new QueryClient();
-    hydrate(queryClient, state.props?.dehydratedState as DehydratedState);
-    const {
-      response: {
-        docs: [{ bibcode }],
-      },
-    } = queryClient.getQueryData<IADSApiSearchResponse>(searchKeys.abstract(query.id));
-
-    const params = getReferencesParams(bibcode, 0);
-    void (await queryClient.prefetchQuery({
-      queryKey: searchKeys.references({ bibcode, start: params.start }),
-      queryFn: fetchSearch,
-      meta: { params },
-    }));
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      return {
-        props: {
-          error: {
-            status: e.response.status,
-            message: e.message,
-          },
-        },
-      };
-    }
-    return {
-      props: {
-        error: {
-          status: 500,
-          message: 'Unknown server error',
-        },
-      },
-    };
-  }
-});
+export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage);

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -1,46 +1,29 @@
-import { getSimilarParams, IADSApiSearchResponse, searchKeys, useGetSimilar } from '@api';
-import { Alert, AlertIcon } from '@chakra-ui/react';
+import { getSimilarParams, IDocsEntity, useGetAbstract, useGetSimilar } from '@api';
 import { AbstractRefList } from '@components';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
-import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
 import { useGetAbstractParams } from '@lib/useGetAbstractParams';
-import { unwrapStringValue } from '@utils';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
-import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
-import { normalizeURLParams } from 'src/utils';
 import { composeNextGSSP } from '@ssr-utils';
+import { path } from 'ramda';
+import { useRouter } from 'next/router';
+import { getDetailsPageTitle } from '@pages/abs/[id]/abstract';
 
-export interface ISimilarPageProps {
-  id: string;
-  error?: {
-    status?: string;
-    message?: string;
-  };
-}
-
-const SimilarPage: NextPage<ISimilarPageProps> = (props: ISimilarPageProps) => {
-  const { id, error } = props;
-  const doc = useGetAbstractDoc(id);
+const SimilarPage: NextPage = () => {
+  const router = useRouter();
+  const { data: abstractResult } = useGetAbstract({ id: router.query.id as string });
+  const doc = path<IDocsEntity>(['docs', 0], abstractResult);
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
-
   const { data, isSuccess } = useGetSimilar(getParams(), { keepPreviousData: true });
   const similarParams = getSimilarParams(doc?.bibcode, 0);
-  const title = unwrapStringValue(doc?.title);
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers similar to">
       <Head>
-        <title>NASA Science Explorer - Similar - {title}</title>
+        <title>{getDetailsPageTitle(doc, 'Similar')}</title>
       </Head>
-      {error && (
-        <Alert status="error">
-          <AlertIcon />
-          {error}
-        </Alert>
-      )}
       {isSuccess && (
         <AbstractRefList
           doc={doc}
@@ -56,50 +39,4 @@ const SimilarPage: NextPage<ISimilarPageProps> = (props: ISimilarPageProps) => {
 
 export default SimilarPage;
 
-export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage, async (ctx, state) => {
-  const { fetchSearch } = await import('@api');
-  const axios = (await import('axios')).default;
-  const query = normalizeURLParams(ctx.query);
-
-  try {
-    const queryClient = new QueryClient();
-    hydrate(queryClient, state.props?.dehydratedState as DehydratedState);
-    const {
-      response: {
-        docs: [{ bibcode }],
-      },
-    } = queryClient.getQueryData<IADSApiSearchResponse>(searchKeys.abstract(query.id));
-
-    const params = getSimilarParams(bibcode, 0);
-    void (await queryClient.prefetchQuery({
-      queryKey: searchKeys.similar({ bibcode, start: params.start }),
-      queryFn: fetchSearch,
-      meta: { params },
-    }));
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      return {
-        props: {
-          error: {
-            status: e.response.status,
-            message: e.message,
-          },
-        },
-      };
-    }
-    return {
-      props: {
-        error: {
-          status: 500,
-          message: 'Unknown server error',
-        },
-      },
-    };
-  }
-});
+export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage);

--- a/src/pages/abs/[id]/toc.tsx
+++ b/src/pages/abs/[id]/toc.tsx
@@ -1,28 +1,20 @@
-import { getTocParams, IADSApiSearchResponse, searchKeys, useGetToc } from '@api';
-import { Alert, AlertIcon } from '@chakra-ui/react';
+import { getTocParams, IDocsEntity, useGetAbstract, useGetToc } from '@api';
 import { AbstractRefList } from '@components/AbstractRefList';
 import { AbsLayout } from '@components/Layout/AbsLayout';
 import { withDetailsPage } from '@hocs/withDetailsPage';
-import { useGetAbstractDoc } from '@lib/useGetAbstractDoc';
 import { useGetAbstractParams } from '@lib/useGetAbstractParams';
-import { normalizeURLParams, unwrapStringValue } from '@utils';
 import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
-import { dehydrate, DehydratedState, hydrate, QueryClient } from '@tanstack/react-query';
 import { composeNextGSSP } from '@ssr-utils';
 import { useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { path } from 'ramda';
+import { getDetailsPageTitle } from '@pages/abs/[id]/abstract';
 
-interface IVolumePageProps {
-  id: string;
-  error?: {
-    status?: string;
-    message?: string;
-  };
-}
-
-const VolumePage: NextPage<IVolumePageProps> = (props: IVolumePageProps) => {
-  const { id, error } = props;
-  const doc = useGetAbstractDoc(id);
+const VolumePage: NextPage = () => {
+  const router = useRouter();
+  const { data: abstractResult } = useGetAbstract({ id: router.query.id as string });
+  const doc = path<IDocsEntity>(['docs', 0], abstractResult);
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
@@ -37,19 +29,11 @@ const VolumePage: NextPage<IVolumePageProps> = (props: IVolumePageProps) => {
     }
   }, [doc]);
 
-  const title = unwrapStringValue(doc?.title);
-
   return (
     <AbsLayout doc={doc} titleDescription="Papers in the same volume as">
       <Head>
-        <title>NASA Science Explorer - Volume - {title}</title>
+        <title>{getDetailsPageTitle(doc, 'Volume Content')}</title>
       </Head>
-      {error && (
-        <Alert status="error">
-          <AlertIcon />
-          {error}
-        </Alert>
-      )}
       {isSuccess && (
         <AbstractRefList
           doc={doc}
@@ -65,50 +49,4 @@ const VolumePage: NextPage<IVolumePageProps> = (props: IVolumePageProps) => {
 
 export default VolumePage;
 
-export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage, async (ctx, state) => {
-  const { fetchSearch } = await import('@api');
-  const axios = (await import('axios')).default;
-  const query = normalizeURLParams(ctx.query);
-
-  try {
-    const queryClient = new QueryClient();
-    hydrate(queryClient, state.props?.dehydratedState as DehydratedState);
-    const {
-      response: {
-        docs: [{ bibcode }],
-      },
-    } = queryClient.getQueryData<IADSApiSearchResponse>(searchKeys.abstract(query.id));
-
-    const params = getTocParams(bibcode, 0);
-    void (await queryClient.prefetchQuery({
-      queryKey: searchKeys.toc({ bibcode, start: params.start }),
-      queryFn: fetchSearch,
-      meta: { params },
-    }));
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      return {
-        props: {
-          error: {
-            status: e.response.status,
-            message: e.message,
-          },
-        },
-      };
-    }
-    return {
-      props: {
-        error: {
-          status: 500,
-          message: 'Unknown server error',
-        },
-      },
-    };
-  }
-});
+export const getServerSideProps: GetServerSideProps = composeNextGSSP(withDetailsPage);


### PR DESCRIPTION
Noticed that the abstract page, and subpages were not actually being SSR'd.  This was due to an addition to the HOC that caused dehydrated states to get overridden by previous ones (my fault).   This fixes the issue, and refactors all those GSSP calls into the HOC.

- Add some padding around abstract
- Properly merge dehydrated states when composing GSSP's
- Make graphics and metrics errors return instead of throwing
- Make resolver queries not consider 404 status as error
- Small cleanup/refactoring
- Consolidate all server-side calls
