### PR TITLE
Scix 346 and Scix 334 paper network links bug

### DIFF
--- a/src/components/Visualizations/Graphs/PaperNetworkGraph.tsx
+++ b/src/components/Visualizations/Graphs/PaperNetworkGraph.tsx
@@ -114,7 +114,7 @@ export const PaperNetworkGraph = ({
       node_name: 0,
       top_common_references: {},
       total_reads: 0,
-      stable_index: 0,
+      stable_index: 99999,
       id: 99999,
       children: nodesData,
     }),

--- a/src/components/Visualizations/Graphs/usePaperNetworkGraph.tsx
+++ b/src/components/Visualizations/Graphs/usePaperNetworkGraph.tsx
@@ -31,9 +31,6 @@ export const usePaperNetworkGraph = (
     .innerRadius(innerRadius)
     .outerRadius(outerRadius);
 
-  // use the same color scheme (category10) as Nivo graphs so they will match the corresponding line graph
-  const color = d3.scaleOrdinal(d3.schemeCategory10);
-
   const noGroupColor = '#a6a6a6';
 
   const line = d3
@@ -42,8 +39,9 @@ export const usePaperNetworkGraph = (
     .radius(innerRadius + 10)
     .angle((d) => (d.x0 + d.x1) / 2);
 
+  // use the same color scheme (category10) as Nivo graphs so they will match the corresponding line graph
   const nodeFill = (d: HierarchyRectangularNode<IADSApiPaperNetworkSummaryGraphNode>): string =>
-    d.depth === 0 ? 'white' : d.data.node_name > 7 ? noGroupColor : color(d.data.node_name.toString());
+    d.depth === 0 ? 'white' : d.data.node_name > 7 ? noGroupColor : d3.schemeCategory10[d.data.node_name - 1];
 
   const values = useMemo(() => pluck(keyToUseAsValue, nodes_data), [nodes_data, keyToUseAsValue]);
 


### PR DESCRIPTION
A couple of fixes on paper network
* correct the group colors
* Bug caused by the fake node's `stable_id` conflicted with real node's `stable_id`