### PR TITLE
Update help page urls

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -64,17 +64,14 @@ export const Footer: FC = () => {
         <Text fontWeight="bold" pb={1}>
           RESOURCES
         </Text>
-        <SimpleLink href="/about" variant="footer">
+        <SimpleLink href="/scixabout" variant="footer">
           About SciX
         </SimpleLink>
         <SimpleLink href="/feedback/general" variant="footer">
           Give Feedback
         </SimpleLink>
-        <SimpleLink href="/help" variant="footer">
+        <SimpleLink href="/scixhelp" variant="footer">
           SciX Help
-        </SimpleLink>
-        <SimpleLink href="/help/whats_new" variant="footer">
-          What's New
         </SimpleLink>
         <SimpleLink href="/about/careers" variant="footer">
           Careers@ADS
@@ -93,7 +90,7 @@ export const Footer: FC = () => {
         <SimpleLink href={EXTERNAL_URLS.TWITTER_SCIX} variant="footer">
           @scixcommunity
         </SimpleLink>
-        <SimpleLink href="/blog" variant="footer">
+        <SimpleLink href="/scixblog" variant="footer">
           SciX Blog
         </SimpleLink>
       </Flex>

--- a/src/components/NavBar/AboutDropdown.tsx
+++ b/src/components/NavBar/AboutDropdown.tsx
@@ -6,17 +6,12 @@ import { MenuDropdown } from './MenuDropdown';
 const items = [
   {
     id: 'about',
-    path: '/about',
+    path: '/scixabout',
     label: 'About SciX',
   },
   {
-    id: 'new',
-    path: '/help/whats_new',
-    label: "What's New",
-  },
-  {
     id: 'blog',
-    path: '/blog',
+    path: '/scixblog',
     label: 'SciX Blog',
   },
 ];

--- a/src/components/NavBar/NavMenus.tsx
+++ b/src/components/NavBar/NavMenus.tsx
@@ -39,7 +39,7 @@ export const NavMenus = (): ReactElement => {
 
   const handleHelp = () => {
     if (isBrowser()) {
-      window.open('/help/', '_blank', 'noopener,noreferrer');
+      window.open('/scixhelp', '_blank', 'noopener,noreferrer');
       onClose();
     }
   };

--- a/src/components/__stories__/Pager.stories.tsx
+++ b/src/components/__stories__/Pager.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<IPagerProps> = {
 type Story = StoryObj<IPagerProps>;
 export default meta;
 
-const template: Story = {
+export const Default: Story = {
   render: () => (
     <Pager
       pages={[
@@ -22,10 +22,6 @@ const template: Story = {
       ]}
     />
   ),
-};
-
-export const Default: Story = {
-  ...template,
 };
 
 export const WithDynamicContent: Story = {

--- a/src/components/__tests__/Pager.test.tsx
+++ b/src/components/__tests__/Pager.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@test-utils';
 import { test } from 'vitest';
-import { composeStories } from '@storybook/testing-react';
+import { composeStories } from '@storybook/react';
 import * as stories from '../__stories__/Pager.stories';
 
 const { Default: Pager } = composeStories(stories);

--- a/src/pages/user/settings/librarylink.tsx
+++ b/src/pages/user/settings/librarylink.tsx
@@ -64,7 +64,7 @@ const LibraryLinkServerPage = () => {
           </Text>
           <Text>
             For more information, please visit our{' '}
-            <SimpleLink href="/help" display="inline">
+            <SimpleLink href="/scixhelp" display="inline">
               help docs
             </SimpleLink>
             .


### PR DESCRIPTION
Changes:
* /help -> /scixhelp
* /about -> /scixabout
* /blog -> /scixblog

Removes "What's new" link