### PR TITLE
clean user settings query on login and logout

### DIFF
--- a/src/lib/useSettings.ts
+++ b/src/lib/useSettings.ts
@@ -64,7 +64,10 @@ export const useSettings = (options?: UseQueryOptions<IADSApiUserDataResponse>) 
 
   return {
     updateSettings,
-    settings: mergeLeft<IADSApiUserDataResponse, IADSApiUserDataResponse>(settings, DEFAULT_USER_DATA),
+    settings: mergeLeft<IADSApiUserDataResponse, IADSApiUserDataResponse>(
+      settings,
+      DEFAULT_USER_DATA,
+    ) as IADSApiUserDataResponse,
     updateSettingsState,
     getSettingsState,
   };

--- a/src/pages/user/account/login.tsx
+++ b/src/pages/user/account/login.tsx
@@ -1,10 +1,10 @@
-import { IUserCredentials } from '@api';
+import { IUserCredentials, userKeys } from '@api';
 import { Button, Container, FormControl, FormLabel, Heading, Input, InputGroup, Stack } from '@chakra-ui/react';
 import { PasswordTextInput, SimpleLink, StandardAlertMessage } from '@components';
 import { NextPage } from 'next';
 import Head from 'next/head';
 import { FormEventHandler, useCallback, useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios, { AxiosError } from 'axios';
 import { ILoginResponse } from '@pages/api/auth/login';
 import { useReloadWithNotification } from '@components/Notification';
@@ -19,6 +19,7 @@ const Login: NextPage = () => {
   const [mainInputRef, focus] = useFocus<HTMLInputElement>();
   const reload = useReloadWithNotification();
   const { reset: resetUser } = useUser();
+  const client = useQueryClient();
 
   const {
     mutate: submit,
@@ -33,6 +34,8 @@ const Login: NextPage = () => {
       if (data?.error) {
         throw new Error(data.error);
       }
+      client.removeQueries(userKeys.getUserSettings());
+
       return data;
     },
     {


### PR DESCRIPTION
I would like to clear cache on user settings query because after I login or logout, the previous settings are still present. Not sure where and what is the right way to do it. 