### PR TITLE
Move color mode icon to nav menu

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Container, Flex, IconButton, Tooltip, useColorMode, useMediaQuery } from '@chakra-ui/react';
+import { Container, Flex, useMediaQuery } from '@chakra-ui/react';
 import { SkipNavLink } from '@chakra-ui/skip-nav';
 import { useRouter } from 'next/router';
 import { FC, useMemo } from 'react';
@@ -8,7 +8,6 @@ import dynamic from 'next/dynamic';
 import { LandingTabsStatic } from '@components';
 import { Notification } from '@components/Notification';
 import Head from 'next/head';
-import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 
 const LandingTabs = dynamic(() => import('@components/LandingTabs/LandingTabs').then((mod) => mod.LandingTabs), {
   ssr: false,
@@ -32,8 +31,6 @@ export const Layout: FC = ({ children }) => {
 
   const favicon = useMemo(() => (isDarkMode ? darkModeFavicon : lightModeFavicon), [isDarkMode]);
 
-  const { colorMode, toggleColorMode } = useColorMode();
-
   return (
     <Flex direction="column">
       <Head>
@@ -44,22 +41,6 @@ export const Layout: FC = ({ children }) => {
       {isPrint ? null : <NavBar />}
       {isPrint ? null : <Notification />}
       <main>
-        <Tooltip label={`Switch to ${colorMode === 'light' ? 'dark' : 'light'} mode`}>
-          <IconButton
-            size="lg"
-            position="fixed"
-            bottom={10}
-            right={10}
-            onClick={toggleColorMode}
-            color={colorMode === 'light' ? 'gray.50' : 'gray.800'}
-            backgroundColor={colorMode === 'light' ? 'gray.800' : 'gray.50'}
-            border="1px solid"
-            aria-label="toggle dark mode"
-            icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
-            zIndex="sticky"
-            isRound
-          />
-        </Tooltip>
         {isLandingPage && <LandingTabs />}
         <Container maxW={isLandingPage ? 'container.md' : 'container.xl'} id="main-content">
           {children}

--- a/src/components/NavBar/ColorModeMenu.tsx
+++ b/src/components/NavBar/ColorModeMenu.tsx
@@ -1,0 +1,28 @@
+import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import { Flex, IconButton, Switch, Tooltip, useColorMode } from '@chakra-ui/react';
+
+export const ColorModeMenu = ({ type }: { type: 'icon' | 'switch' }) => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  return (
+    <>
+      {type === 'icon' ? (
+        <Tooltip label={`Switch to ${colorMode === 'light' ? 'dark' : 'light'} mode`}>
+          <IconButton
+            size="xs"
+            onClick={toggleColorMode}
+            color={colorMode === 'light' ? 'gray.50' : 'gray.800'}
+            backgroundColor={colorMode === 'light' ? 'gray.800' : 'gray.50'}
+            border="1px solid"
+            aria-label="toggle dark mode"
+            icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
+          />
+        </Tooltip>
+      ) : (
+        <Flex m={4} justifyContent="space-between">
+          Dark Mode <Switch isChecked={colorMode === 'dark'} onChange={toggleColorMode} aria-label="dark mode switch" />
+        </Flex>
+      )}
+    </>
+  );
+};

--- a/src/components/NavBar/NavMenus.tsx
+++ b/src/components/NavBar/NavMenus.tsx
@@ -26,6 +26,7 @@ import { FeedbackDropdown } from './FeedbackDropdown';
 import { OrcidDropdown } from './OrcidDropdown';
 import { ListType } from './types';
 import { isBrowser } from '@utils';
+import { ColorModeMenu } from './ColorModeMenu';
 
 export const NavMenus = (): ReactElement => {
   const toggleMenu = () => {
@@ -117,11 +118,12 @@ export const NavMenus = (): ReactElement => {
                   </AccordionPanel>
                 </AccordionItem>
               </Accordion>
+              <ColorModeMenu type="switch" />
             </DrawerBody>
           </DrawerContent>
         </Drawer>
       </Box>
-      <Box display={{ base: 'none', lg: 'flex' }} flexDirection="row" mx={3}>
+      <Box display={{ base: 'none', lg: 'flex' }} flexDirection="row" mx={3} alignItems="center">
         {/* Cannot use stack here, will produce warning with popper in menu */}
         <FeedbackDropdown type={ListType.DROPDOWN} />
         <OrcidDropdown type={ListType.DROPDOWN} />
@@ -130,6 +132,7 @@ export const NavMenus = (): ReactElement => {
           <MenuButton onClick={handleHelp}>Help</MenuButton>
         </Menu>
         <AccountDropdown type={ListType.DROPDOWN} />
+        <ColorModeMenu type="icon" />
       </Box>
     </Flex>
   );


### PR DESCRIPTION
Move the dark mode switch to nav menu, based on the discussion with @kelockhart 
<img width="1046" alt="Screen Shot 2024-01-17 at 3 33 36 PM" src="https://github.com/adsabs/nectar/assets/636361/538bcc8a-f9f5-4013-91ed-fdfff3cc552e">
<img width="483" alt="Screen Shot 2024-01-17 at 3 33 58 PM" src="https://github.com/adsabs/nectar/assets/636361/fb19c0bb-3b73-4085-b5d6-892f588c5866">
