### PR TITLE
Fix settings error on abstract page

### DIFF
--- a/src/components/AbstractSideNav/AbstractSideNav.tsx
+++ b/src/components/AbstractSideNav/AbstractSideNav.tsx
@@ -1,4 +1,4 @@
-import { IDocsEntity, useGetUserSettings, useHasGraphics, useHasMetrics } from '@api';
+import { IDocsEntity, useHasGraphics, useHasMetrics } from '@api';
 import { Badge } from '@chakra-ui/react';
 import { exportFormats, IMenuItem, SideNavigationMenu, TopNavigationMenu } from '@components';
 import {
@@ -16,7 +16,7 @@ import { useRouter } from 'next/router';
 import { HTMLAttributes, ReactElement } from 'react';
 import { Routes } from './types';
 import { values } from 'ramda';
-import { useSession } from '@lib/useSession';
+import { useSettings } from '@lib/useSettings';
 
 const abstractPath = '/abs';
 
@@ -32,11 +32,7 @@ const useGetItems = ({
   const router = useRouter();
   const docId = router.query.id as string;
 
-  const { isAuthenticated } = useSession();
-
-  const { data: settings } = useGetUserSettings({
-    enabled: isAuthenticated,
-  });
+  const { settings } = useSettings();
 
   // for export citation menu link, it needs to go to user's default setting if logged in
   // otherwise go to bibtex

--- a/src/components/AbstractSources/AbstractSources.tsx
+++ b/src/components/AbstractSources/AbstractSources.tsx
@@ -1,4 +1,4 @@
-import { Esources, IDocsEntity, useGetUserSettings } from '@api';
+import { Esources, IDocsEntity } from '@api';
 import {
   Button,
   HStack,
@@ -21,6 +21,7 @@ import { useResolverQuery } from '@api/resolver';
 import { AcademicCapIcon } from '@heroicons/react/24/solid';
 import { processLinkData } from '@components/AbstractSources/linkGenerator';
 import { IDataProductSource, IFullTextSource, IRelatedWorks } from '@components/AbstractSources/types';
+import { useSettings } from '@lib/useSettings';
 
 export interface IAbstractSourcesProps extends HTMLAttributes<HTMLDivElement> {
   doc?: IDocsEntity;
@@ -28,7 +29,7 @@ export interface IAbstractSourcesProps extends HTMLAttributes<HTMLDivElement> {
 
 export const AbstractSources = ({ doc }: IAbstractSourcesProps): ReactElement => {
   const isClient = useIsClient();
-  const { data: settings } = useGetUserSettings();
+  const { settings } = useSettings();
 
   const sources = processLinkData(doc, settings.link_server);
 

--- a/src/components/__tests__/AbstractSources.test.tsx
+++ b/src/components/__tests__/AbstractSources.test.tsx
@@ -1,9 +1,16 @@
 import { render } from '@test-utils';
 import Meta, { Default } from '../__stories__/AbstractSources.stories';
 import { composeStory } from '@storybook/react';
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 
 const AbstractSources = composeStory(Default, Meta);
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: vi.fn(),
+  }),
+}));
+
 test('renders without crashing', () => {
   render(<AbstractSources />);
 });


### PR DESCRIPTION
When navigating to abstract page, if the user is not logged in, the 'useGetUserSettings' call will return an undefined value.

I missed this was the hook used here in an earlier commit.  I should have switched this to use `useSettings` since this hook guarantees the `settings` will return an object.
