### PR TITLE
Remove e-tag config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,7 +25,7 @@ const CSP = `
 const nextConfig = {
   distDir: process.env.DIST_DIR || 'dist',
   generateBuildId: async () => nextBuildId({ dir: process.env.__dirname, describe: true }),
-  generateEtags: true,
+  generateEtags: false,
   poweredByHeader: false,
   reactStrictMode: true,
   experimental: {


### PR DESCRIPTION
Removing E-tags since some of the response bodies are not predictable and will cause the cache to bust because of minor changes in the response.

i.e. dates and other things causing the hashes to be different