### PR TITLE
fix pagination error

### DIFF
--- a/src/components/AbstractRefList/AbstractRefList.tsx
+++ b/src/components/AbstractRefList/AbstractRefList.tsx
@@ -24,7 +24,7 @@ export const AbstractRefList = (props: IAbstractRefListProps): ReactElement => {
   const params = { ...searchLinkParams, start: calculateStartIndex(page, APP_DEFAULTS.RESULT_PER_PAGE) };
 
   const handlePageChange = (page: number) => {
-    onPageChange(page);
+    onPageChange(page - 1);
     void router.push({ pathname: router.pathname, search: stringifySearchParams({ ...router.query, p: page }) });
   };
 

--- a/src/components/ResultList/Pagination/Pagination.tsx
+++ b/src/components/ResultList/Pagination/Pagination.tsx
@@ -267,7 +267,7 @@ const PaginationButton: FC<{ page: number; noLinks: boolean; onlyUpdatePageParam
 };
 
 const cleanPage = (page: number) => (Number.isNaN(page) ? 1 : page);
-const clampPage = (page: number, totalPages: number) => clamp(1, totalPages - 1, page);
+const clampPage = (page: number, totalPages: number) => clamp(1, totalPages, page);
 /**
  * Popover for manually selecting a page
  */

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -8,15 +8,21 @@ import { NextPage } from 'next';
 import { composeNextGSSP } from '@/ssr-utils';
 import { useRouter } from 'next/router';
 import { path } from 'ramda';
+import { APP_DEFAULTS } from '@/config';
 
 const CitationsPage: NextPage = () => {
   const router = useRouter();
   const { data: abstractDoc, error: abstractError } = useGetAbstract({ id: router.query.id as string });
   const doc = path<IDocsEntity>(['docs', 0], abstractDoc);
+  const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
   // get the primary response from server (or cache)
-  const { data, isSuccess, error: citationsError } = useGetCitations(getParams(), { keepPreviousData: true });
+  const {
+    data,
+    isSuccess,
+    error: citationsError,
+  } = useGetCitations({ ...getParams(), start: pageIndex * APP_DEFAULTS.RESULT_PER_PAGE }, { keepPreviousData: true });
   const citationsParams = getCitationsParams(doc?.bibcode, 0);
 
   return (

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -6,15 +6,20 @@ import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { composeNextGSSP } from '@/ssr-utils';
 import { withDetailsPage } from '@/hocs/withDetailsPage';
+import { APP_DEFAULTS } from '@/config';
 
 const CoreadsPage: NextPage = () => {
   const router = useRouter();
   const { data: abstractDoc } = useGetAbstract({ id: router.query.id as string });
   const doc = abstractDoc?.docs?.[0];
+  const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
 
-  const { data, isSuccess } = useGetCoreads(getParams(), { keepPreviousData: true });
+  const { data, isSuccess } = useGetCoreads(
+    { ...getParams(), start: pageIndex * APP_DEFAULTS.RESULT_PER_PAGE },
+    { keepPreviousData: true },
+  );
   const coreadsParams = getCoreadsParams(doc?.bibcode, 0);
 
   return (

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -8,14 +8,20 @@ import { GetServerSideProps, NextPage } from 'next';
 import { composeNextGSSP } from '@/ssr-utils';
 import { useRouter } from 'next/router';
 import { path } from 'ramda';
+import { APP_DEFAULTS } from '@/config';
 
 const ReferencesPage: NextPage = () => {
   const router = useRouter();
   const { data: abstractDoc, error: abstractError } = useGetAbstract({ id: router.query.id as string });
   const doc = path<IDocsEntity>(['docs', 0], abstractDoc);
+  const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
-  const { data, isSuccess, error: referencesError } = useGetReferences(getParams(), { keepPreviousData: true });
+  const {
+    data,
+    isSuccess,
+    error: referencesError,
+  } = useGetReferences({ ...getParams(), start: pageIndex * APP_DEFAULTS.RESULT_PER_PAGE }, { keepPreviousData: true });
   const referencesParams = getReferencesParams(doc?.bibcode, 0);
 
   return (

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -7,14 +7,19 @@ import { GetServerSideProps, NextPage } from 'next';
 import { composeNextGSSP } from '@/ssr-utils';
 import { path } from 'ramda';
 import { useRouter } from 'next/router';
+import { APP_DEFAULTS } from '@/config';
 
 const SimilarPage: NextPage = () => {
   const router = useRouter();
   const { data: abstractResult } = useGetAbstract({ id: router.query.id as string });
   const doc = path<IDocsEntity>(['docs', 0], abstractResult);
+  const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
   const { getParams, onPageChange } = useGetAbstractParams(doc?.bibcode);
-  const { data, isSuccess } = useGetSimilar(getParams(), { keepPreviousData: true });
+  const { data, isSuccess } = useGetSimilar(
+    { ...getParams(), start: pageIndex * APP_DEFAULTS.RESULT_PER_PAGE },
+    { keepPreviousData: true },
+  );
   const similarParams = getSimilarParams(doc?.bibcode, 0);
 
   return (


### PR DESCRIPTION
Fix a few pagination related errors in abstract reference lists:
* `onPageChange` is 0-based, but its usage was 1-based, and fetching the wrong page
* Abstract pages with result list was always fetching starting index 0 instead of using the `p` param
* The popover page selector did not include the last page to be selectable. 