### PR TITLE
custom export pagination

### DIFF
--- a/src/components/CitationExporter/CitationExporter.tsx
+++ b/src/components/CitationExporter/CitationExporter.tsx
@@ -148,11 +148,23 @@ const Exporter = (props: ICitationExporterProps): ReactElement => {
   return (
     <ExportContainer
       header={
-        <>
-          Exporting record{ctx.range[1] - ctx.range[0] > 1 ? 's' : ''}{' '}
-          {ctx.range[0] + 1 + page * APP_DEFAULTS.EXPORT_PAGE_SIZE} to{' '}
-          {ctx.range[1] + page * APP_DEFAULTS.EXPORT_PAGE_SIZE} (total: {totalRecords.toLocaleString()})
-        </>
+        <Stack direction="row" alignItems="center" gap={4}>
+          <>
+            Exporting record{ctx.range[1] - ctx.range[0] > 1 ? 's' : ''}{' '}
+            {ctx.range[0] + 1 + page * APP_DEFAULTS.EXPORT_PAGE_SIZE} to{' '}
+            {ctx.range[1] + page * APP_DEFAULTS.EXPORT_PAGE_SIZE} (total: {totalRecords.toLocaleString()})
+          </>
+          {!singleMode && hasNextPage && (
+            <Button
+              variant="outline"
+              rightIcon={<ChevronRightIcon fontSize="2xl" />}
+              onClick={nextPage}
+              isLoading={isLoading}
+            >
+              Next {APP_DEFAULTS.EXPORT_PAGE_SIZE}
+            </Button>
+          )}
+        </Stack>
       }
       isLoading={isLoading}
       {...divProps}
@@ -182,17 +194,6 @@ const Exporter = (props: ICitationExporterProps): ReactElement => {
                               ctx.params.format === ExportApiFormatKey.bibtexabs))) && (
                           <Button type="submit" data-testid="export-submit" isLoading={isLoading} width="full">
                             Submit
-                          </Button>
-                        )}
-                        {!singleMode && hasNextPage && (
-                          <Button
-                            variant="outline"
-                            rightIcon={<ChevronRightIcon fontSize="2xl" />}
-                            onClick={nextPage}
-                            isLoading={isLoading}
-                            width="full"
-                          >
-                            Next {APP_DEFAULTS.EXPORT_PAGE_SIZE}
                           </Button>
                         )}
                       </Stack>


### PR DESCRIPTION
Moved the pagination control to the top, for two reasons:
1. Custom format gets pagination control
2. It makes more sense next to the page information

<img width="1169" alt="Screenshot 2024-08-05 at 11 13 27 AM" src="https://github.com/user-attachments/assets/e799cb86-19c5-4a6b-818e-f61e205a9560">

