### PR TITLE
improve page loading indicator

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,7 @@ import { isNilOrEmpty, notEqual } from 'ramda-adjunct';
 import { useUser } from '@/lib/useUser';
 import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
 import '../styles/styles.css';
+import '../styles/page-loader.css';
 import { logger } from '@/logger';
 import { GoogleTagManager, sendGTMEvent } from '@next/third-parties/google';
 import Head from 'next/head';

--- a/src/styles/page-loader.css
+++ b/src/styles/page-loader.css
@@ -1,0 +1,9 @@
+/* overwrite nprogress.css */
+
+#nprogress .spinner {
+  display: none;
+}
+
+#nprogress .bar {
+  height: 5px;
+}


### PR DESCRIPTION
Instead of moving the spinner as suggested, I removed the spinner but made the progress bar thicker. I hope this is more clear that the page is loading, but without the indicator in the way.


https://github.com/user-attachments/assets/6e1787a5-e455-4a5f-8553-ee050c395d36

