### PR TITLE
fix popover shifting on arrow key

### DIFF
--- a/src/components/SearchBar/SearchInput.tsx
+++ b/src/components/SearchBar/SearchInput.tsx
@@ -143,7 +143,7 @@ export const SearchInput = forwardRef<ISearchInputProps, 'input'>((props, ref) =
   }, [focus]);
 
   return (
-    <Popover isOpen={state.isOpen} placement="bottom" gutter={0} matchWidth autoFocus={false}>
+    <Popover isOpen={state.isOpen} placement="bottom" gutter={0} matchWidth autoFocus={false} strategy="fixed">
       <PopoverAnchor>
         <InputGroup
           display="flex"


### PR DESCRIPTION
Fix a bug where the popover for the search bar shifts when using arrow keys.