### PR TITLE
Scix 467

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,7 +5,7 @@ export const logger: Logger = pino({
   browser: {
     asObject: true,
   },
-  level: process.env.LOG_LEVEL || 'info',
+  level: process.env.NEXT_PUBLIC_LOG_LEVEL || 'info',
   base: {
     env: process.env.NODE_ENV || 'development',
   },
@@ -29,7 +29,7 @@ export const edgeLogger: Logger = pino({
       }
     },
   },
-  level: process.env.LOG_LEVEL || 'info',
+  level: process.env.NEXT_PUBLIC_LOG_LEVEL || 'info',
   base: {
     env: process.env.NODE_ENV || 'development',
   },


### PR DESCRIPTION
Add analytics emitter in the middleware that, for now, just emits to link_gateway when a route starting with `/abs` is seen