### PR TITLE
Fix "Query Canceled" Error

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+**/.git
+**/.svn
+**/.hg
+**/node_modules
+
+# This file gives issues with complex types, for now ignore
+**/src/test-utils.tsx

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "semi": true,
   "useTabs": false,
   "trailingComma": "all",
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "parser": "typescript"
 }

--- a/src/api/author-affiliation/author-affiliation.ts
+++ b/src/api/author-affiliation/author-affiliation.ts
@@ -32,17 +32,13 @@ export const useAuthorAffiliationExport: ExportQuery = (params, options) => {
   });
 };
 
-export const fetchAuthorAffiliationSearch: QueryFunction<IAuthorAffiliationResponse['data']> = async ({
-  meta,
-  signal,
-}) => {
+export const fetchAuthorAffiliationSearch: QueryFunction<IAuthorAffiliationResponse['data']> = async ({ meta }) => {
   const { params } = meta as { params: IAuthorAffiliationPayload };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.AUTHOR_AFFILIATION_SEARCH,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<IAuthorAffiliationResponse>(config);
@@ -50,14 +46,13 @@ export const fetchAuthorAffiliationSearch: QueryFunction<IAuthorAffiliationRespo
   return data.data;
 };
 
-export const fetchAuthorAffiliationExport: QueryFunction<string> = async ({ meta, signal }) => {
+export const fetchAuthorAffiliationExport: QueryFunction<string> = async ({ meta }) => {
   const { params } = meta as { params: IAuthorAffiliationExportPayload };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.AUTHOR_AFFILIATION_EXPORT,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<string>(config);

--- a/src/api/biblib/libraries.ts
+++ b/src/api/biblib/libraries.ts
@@ -88,13 +88,12 @@ export const useGetLibraries: ADSQuery<IADSApiLibraryParams, IADSApiLibraryRespo
   });
 };
 
-export const fetchLibraries: QueryFunction<IADSApiLibraryResponse> = async ({ meta, signal }) => {
+export const fetchLibraries: QueryFunction<IADSApiLibraryResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiLibraryParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.LIBRARIES,
     params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiLibraryResponse>(config);
@@ -135,13 +134,12 @@ export const useGetLibraryEntity: ADSQuery<IADSApiLibraryEntityParams, IADSApiLi
   });
 };
 
-export const fetchLibraryEntity: QueryFunction<IADSApiLibraryEntityResponse> = async ({ meta, signal }) => {
+export const fetchLibraryEntity: QueryFunction<IADSApiLibraryEntityResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiLibraryEntityParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.LIBRARIES}/${params.id}`,
     params: omit(['id'], params),
-    signal,
   };
 
   const { data } = await api.request<IADSApiLibraryEntityResponse>(config);
@@ -312,12 +310,11 @@ export const useGetPermission: ADSQuery<IADSApiLibraryPermissionParams, IADSApiL
   });
 };
 
-export const getPermission: QueryFunction<IADSApiLibraryPermissionResponse> = async ({ meta, signal }) => {
+export const getPermission: QueryFunction<IADSApiLibraryPermissionResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiLibraryPermissionParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.PERMISSIONS}/${params.id}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiLibraryPermissionResponse>(config);
@@ -393,12 +390,11 @@ export const useGetAnnotation: ADSQuery<IADSApiLibraryGetAnnotationParams, IADSA
   });
 };
 
-export const fetchAnnotation: QueryFunction<IADSApiLibraryGetAnnotationResponse> = async ({ meta, signal }) => {
+export const fetchAnnotation: QueryFunction<IADSApiLibraryGetAnnotationResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiLibraryGetAnnotationParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.LIBRARY_NOTES}/${params.library}/${params.bibcode}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiLibraryGetAnnotationResponse>(config);

--- a/src/api/export/export.ts
+++ b/src/api/export/export.ts
@@ -22,7 +22,7 @@ export const useGetExportCitation: ADSQuery<IExportApiParams, IExportApiResponse
   });
 };
 
-export const fetchExportCitation: QueryFunction<IExportApiResponse> = async ({ meta, signal }) => {
+export const fetchExportCitation: QueryFunction<IExportApiResponse> = async ({ meta }) => {
   const {
     params: { customFormat, format, ...params },
   } = meta as { params: IExportApiParams };
@@ -33,7 +33,6 @@ export const fetchExportCitation: QueryFunction<IExportApiResponse> = async ({ m
   const config: ApiRequestConfig = {
     method: 'POST',
     url: `${ApiTargets.EXPORT}/${format}`,
-    signal,
     data: {
       ...params,
       ...(format === ExportApiFormatKey.custom ? { format: customFormat } : {}),

--- a/src/api/graphics/graphics.ts
+++ b/src/api/graphics/graphics.ts
@@ -58,13 +58,12 @@ export const useGetGraphics: ADSQuery<IDocsEntity['bibcode'], IADSApiGraphicsRes
   });
 };
 
-export const fetchGraphics: QueryFunction<IADSApiGraphicsResponse> = async ({ meta, signal }) => {
+export const fetchGraphics: QueryFunction<IADSApiGraphicsResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiGraphicsParams };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.GRAPHICS}/${params.bibcode}`,
-    signal,
   };
 
   const { data: graphics } = await api.request<IADSApiGraphicsResponse>(config);

--- a/src/api/metrics/metrics.ts
+++ b/src/api/metrics/metrics.ts
@@ -86,14 +86,13 @@ export const useGetMetricsTimeSeries: ADSQuery<Bibcode[], IADSApiMetricsResponse
   });
 };
 
-export const fetchMetrics: QueryFunction<IADSApiMetricsResponse> = async ({ meta, signal }) => {
+export const fetchMetrics: QueryFunction<IADSApiMetricsResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiMetricsParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_METRICS,
     data: params,
-    signal,
   };
 
   const { data: metrics } = await api.request<IADSApiMetricsResponse>(config);

--- a/src/api/orcid/orcid.ts
+++ b/src/api/orcid/orcid.ts
@@ -137,21 +137,20 @@ export const useOrcidPreferences: OrcidQuery<'getPreferences'> = (params, option
   });
 };
 
-const fetchExchangeToken: QueryFunction<IOrcidUser> = async ({ meta, signal }) => {
+const fetchExchangeToken: QueryFunction<IOrcidUser> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['exchangeToken'] };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.ORCID_EXCHANGE_TOKEN,
     params,
-    signal,
   };
 
   const { data } = await api.request<IOrcidUser>(config);
   return data;
 };
 
-const getPreferences: QueryFunction<IOrcidResponse['getPreferences']> = async ({ meta, signal }) => {
+const getPreferences: QueryFunction<IOrcidResponse['getPreferences']> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['getPreferences'] };
 
   if (!isValidIOrcidUser(params.user)) {
@@ -164,14 +163,13 @@ const getPreferences: QueryFunction<IOrcidResponse['getPreferences']> = async ({
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
-    signal,
   };
 
   const { data } = await api.request<IOrcidResponse['getPreferences']>(config);
   return data;
 };
 
-export const fetchProfile: QueryFunction<IOrcidResponse['profile']> = async ({ meta, signal }) => {
+export const fetchProfile: QueryFunction<IOrcidResponse['profile']> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['profile'] };
 
   if (!isValidIOrcidUser(params.user)) {
@@ -186,7 +184,6 @@ export const fetchProfile: QueryFunction<IOrcidResponse['profile']> = async ({ m
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
-    signal,
   };
 
   const { data } = await api.request<IOrcidResponse['profile']>(config);
@@ -300,7 +297,7 @@ const updateWork: MutationFunction<IOrcidResponse['updateWork'], IOrcidMutationP
 
   return data;
 };
-const getName: QueryFunction<IOrcidResponse['name']> = async ({ meta, signal }) => {
+const getName: QueryFunction<IOrcidResponse['name']> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['name'] };
 
   if (!isValidIOrcidUser(params.user)) {
@@ -313,14 +310,13 @@ const getName: QueryFunction<IOrcidResponse['name']> = async ({ meta, signal }) 
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
-    signal,
   };
 
   const { data } = await api.request<null>(config);
   return data;
 };
 
-const getWork: QueryFunction<IOrcidResponse['getWork']> = async ({ meta, signal }) => {
+const getWork: QueryFunction<IOrcidResponse['getWork']> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['getWork'] };
 
   if (!isValidIOrcidUser(params.user)) {
@@ -333,7 +329,6 @@ const getWork: QueryFunction<IOrcidResponse['getWork']> = async ({ meta, signal 
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
-    signal,
   };
 
   const { data } = await api.request<null>(config);

--- a/src/api/reference/reference.ts
+++ b/src/api/reference/reference.ts
@@ -26,13 +26,12 @@ export const useReferenceSearch: ReferenceQuery = (text, options) => {
   });
 };
 
-export const fetchReferenceText: QueryFunction<IADSApiReferenceResponse> = async ({ meta, signal }) => {
+export const fetchReferenceText: QueryFunction<IADSApiReferenceResponse> = async ({ meta }) => {
   const { params } = meta as { params: { text: string } };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.REFERENCE}/${params.text}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiReferenceResponse>(config);

--- a/src/api/resolver/resolver.ts
+++ b/src/api/resolver/resolver.ts
@@ -21,14 +21,13 @@ export const useResolverQuery: ADSQuery<IADSApiResolverParams, IADSApiResolverRe
   });
 };
 
-export const fetchLinks: QueryFunction<IADSApiResolverResponse> = async ({ meta, signal }) => {
+export const fetchLinks: QueryFunction<IADSApiResolverResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiResolverParams };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.RESOLVER}/${params.bibcode}/${params.link_type}`,
     validateStatus: (status) => status === 200 || status === 404,
-    signal,
   };
 
   const { data } = await api.request<IADSApiResolverResponse>(config);

--- a/src/api/search/search.ts
+++ b/src/api/search/search.ts
@@ -393,7 +393,7 @@ export const fetchBigQuerySearch: MutationFunction<IADSApiSearchResponse['respon
  *
  * @returns {Promise<IADSApiSearchResponse>} - A promise that resolves to the search response data.
  */
-export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta, signal }) => {
+export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiSearchParams };
 
   const finalParams = { ...params };
@@ -406,7 +406,6 @@ export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta, 
     method: 'GET',
     url: ApiTargets.SEARCH,
     params: finalParams,
-    signal,
   };
   const { data } = await api.request<IADSApiSearchResponse>(config);
   return data;
@@ -428,7 +427,7 @@ export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta, 
 export const fetchSearchSSR = async (
   params: IADSApiSearchParams,
   ctx: GetServerSidePropsContext,
-  { signal }: QueryFunctionContext,
+  {}: QueryFunctionContext,
 ) => {
   const finalParams = { ...params };
 
@@ -447,7 +446,6 @@ export const fetchSearchSSR = async (
     method: 'GET',
     url: ApiTargets.SEARCH,
     params: finalParams,
-    signal,
     headers: {
       ...defaultRequestConfig.headers,
       Authorization: `Bearer ${token}`,
@@ -462,7 +460,6 @@ export const fetchSearchSSR = async (
 export const fetchSearchInfinite: QueryFunction<IADSApiSearchResponse & { pageParam: string }> = async ({
   meta,
   pageParam = '*',
-  signal,
 }: QueryFunctionContext<QueryKey, string>) => {
   const { params } = meta as { params: IADSApiSearchParams };
 
@@ -479,7 +476,6 @@ export const fetchSearchInfinite: QueryFunction<IADSApiSearchResponse & { pagePa
       ...finalParams,
       cursorMark: pageParam,
     } as IADSApiSearchParams,
-    signal,
   };
   const { data } = await api.request<IADSApiSearchResponse>(config);
 

--- a/src/api/user/user.ts
+++ b/src/api/user/user.ts
@@ -142,12 +142,11 @@ const changeUserEmail = async (credentials: IUserChangeEmailCredentials) => {
   throw new Error('change-email-failed');
 };
 
-export const fetchUserSettings: QueryFunction<IADSApiUserDataResponse> = async ({ signal }) => {
+export const fetchUserSettings: QueryFunction<IADSApiUserDataResponse> = async ({}) => {
   const config = {
     ...defaultRequestConfig,
     method: 'GET',
     url: ApiTargets.USER_DATA,
-    signal,
   };
 
   const { data } = await api.request<IADSApiUserDataResponse>(config);

--- a/src/api/vault/vault.ts
+++ b/src/api/vault/vault.ts
@@ -87,38 +87,35 @@ export const useVaultBigQuerySearch: ADSQuery<IDocsEntity['bibcode'][], IADSApiV
   });
 };
 
-export const fetchVaultSearch: QueryFunction<IADSApiVaultResponse> = async ({ meta, signal }) => {
+export const fetchVaultSearch: QueryFunction<IADSApiVaultResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiSearchParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.MYADS_STORAGE_QUERY,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiVaultResponse>(config);
   return data;
 };
 
-export const fetchVaultExecuteQuery: QueryFunction<IADSApiSearchResponse['response']> = async ({ meta, signal }) => {
+export const fetchVaultExecuteQuery: QueryFunction<IADSApiSearchResponse['response']> = async ({ meta }) => {
   const { params } = meta as { params: IADSVaultExecuteQueryParams };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_STORAGE}/execute_query/${params.qid}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiSearchResponse['response']>(config);
   return data;
 };
 
-export const fetchLibraryLinkServers: QueryFunction<IADSApiLibraryLinkServersResponse> = async ({ signal }) => {
+export const fetchLibraryLinkServers: QueryFunction<IADSApiLibraryLinkServersResponse> = async ({}) => {
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.LINK_SERVERS,
-    signal,
   };
 
   const { data } = await api.request<IADSApiLibraryLinkServersResponse>(config);
@@ -145,11 +142,10 @@ export const useGetNotifications = (options?: UseQueryOptions<IADSApiNotificatio
   });
 };
 
-export const fetchNotifications: QueryFunction<IADSApiNotificationsReponse> = async ({ signal }) => {
+export const fetchNotifications: QueryFunction<IADSApiNotificationsReponse> = async ({}) => {
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.MYADS_NOTIFICATIONS,
-    signal,
   };
 
   const { data } = await api.request<IADSApiNotificationsReponse>(config);
@@ -170,12 +166,11 @@ export const useGetNotification: ADSQuery<IADSApiNotificationParams, IADSApiNoti
   });
 };
 
-export const fetchNotification: QueryFunction<IADSApiNotificationReponse> = async ({ meta, signal }) => {
+export const fetchNotification: QueryFunction<IADSApiNotificationReponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiNotificationParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_NOTIFICATIONS}/${params.id.toString()}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiNotificationReponse>(config);
@@ -269,12 +264,11 @@ export const useGetNotificationQuery: ADSQuery<IADSApiNotificationQueryParams, I
   });
 };
 
-export const fetchNotificationQuery: QueryFunction<IADSApiNotificationQueryResponse> = async ({ meta, signal }) => {
+export const fetchNotificationQuery: QueryFunction<IADSApiNotificationQueryResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiNotificationParams };
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_NOTIFICATIONS_QUERY}/${params.id.toString()}`,
-    signal,
   };
 
   const { data } = await api.request<IADSApiNotificationQueryResponse>(config);

--- a/src/api/vis/vis.ts
+++ b/src/api/vis/vis.ts
@@ -41,14 +41,13 @@ export const useGetAuthorNetwork: ADSQuery<IADSApiSearchParams, IADSApiAuthorNet
   });
 };
 
-export const fetchAuthorNetwork: QueryFunction<IADSApiAuthorNetworkResponse> = async ({ meta, signal }) => {
+export const fetchAuthorNetwork: QueryFunction<IADSApiAuthorNetworkResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiVisParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_AUTHOR_NETWORK,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiAuthorNetworkResponse>(config);
@@ -67,14 +66,13 @@ export const useGetPaperNetwork: ADSQuery<IADSApiSearchParams, IADSApiPaperNetwo
   });
 };
 
-export const fetchPaperNetwork: QueryFunction<IADSApiPaperNetworkResponse> = async ({ meta, signal }) => {
+export const fetchPaperNetwork: QueryFunction<IADSApiPaperNetworkResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiVisParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_PAPER_NETWORK,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiPaperNetworkResponse>(config);
@@ -93,14 +91,13 @@ export const useGetWordCloud: ADSQuery<IADSApiSearchParams, IADSApiWordCloudResp
   });
 };
 
-export const fetchWordCloud: QueryFunction<IADSApiWordCloudResponse> = async ({ meta, signal }) => {
+export const fetchWordCloud: QueryFunction<IADSApiWordCloudResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiWordCloudParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_WORDCLOUD,
     data: params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiWordCloudResponse>(config);
@@ -119,14 +116,13 @@ export const useGetResultsGraph: ADSQuery<IADSApiSearchParams, IADSApiSearchResp
   });
 };
 
-export const fetchResultsGraph: QueryFunction<IADSApiSearchResponse> = async ({ meta, signal }) => {
+export const fetchResultsGraph: QueryFunction<IADSApiSearchResponse> = async ({ meta }) => {
   const { params } = meta as { params: IADSApiSearchParams };
 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.SEARCH,
     params,
-    signal,
   };
 
   const { data } = await api.request<IADSApiSearchResponse>(config);

--- a/src/components/BibstemPicker/BibstemPicker.tsx
+++ b/src/components/BibstemPicker/BibstemPicker.tsx
@@ -280,7 +280,6 @@ const BibstemPickerImpl = (props: IBibstemPickerProps, ref: ForwardedRef<never>)
       <AsyncCreatableSelect<IBibstemOption, typeof isMultiple>
         instanceId="bibstem-picker"
         aria-label="bibstem picker"
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         loadOptions={fetchOptions}
         // only look at the incoming meta value to decide what to update
         onChange={(payload, meta) => dispatch({ type: 'update_selected', payload, meta })}

--- a/src/components/FeedbackForms/AssociatedArticles/AssociatedArticlesForm.tsx
+++ b/src/components/FeedbackForms/AssociatedArticles/AssociatedArticlesForm.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
-
 import { CheckIcon, DeleteIcon } from '@chakra-ui/icons';
 import {
   AlertStatus,

--- a/src/components/Libraries/AddLibraryModal.tsx
+++ b/src/components/Libraries/AddLibraryModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
 import {
   Modal,
   ModalOverlay,

--- a/src/components/Libraries/OperationModal.tsx
+++ b/src/components/Libraries/OperationModal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
-
 import {
   Button,
   Checkbox,

--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -29,7 +29,7 @@ const Component = ({ onQueryUpdate, width, height, onExpand, expanded }: IYearHi
   // query without the year range filter, to show all years on the histogram
   const cleanedQuery = useMemo(() => {
     const q = JSON.parse(JSON.stringify(query)) as IADSApiSearchParams;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
     return q.fq ? (removeFQ(fqNameYearRange, q) as IADSApiSearchParams) : q;
   }, [query]);
 

--- a/src/components/Visualizations/Graphs/BubblePlot.tsx
+++ b/src/components/Visualizations/Graphs/BubblePlot.tsx
@@ -184,7 +184,6 @@ export const BubblePlot = ({
         [width, height],
       ])
       .on('end', (event) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const e = event as D3BrushEvent<IBubbleNode>;
         const extent = e.selection;
 

--- a/src/components/__tests__/usePagination.test.tsx
+++ b/src/components/__tests__/usePagination.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/require-await */
 import {
   calculatePagination,
   cleanClamp,

--- a/src/lib/__tests__/useDownloadFile.test.tsx
+++ b/src/lib/__tests__/useDownloadFile.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { useDownloadFile } from '@/lib/useDownloadFile';
 import { act, renderHook } from '@testing-library/react';
 import { saveAs } from 'file-saver';

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { orcidHandlers } from '@/mocks/handlers/orcid';
 import { userHandlers } from '@/mocks/responses/user/user';
 import { objectsHandlers } from '@/mocks/handlers/objects';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 const bypassStrings = ['sentry.io', '_next', '__next', 'site.webmanifest', 'favicon'];
 
 const startMsw = async () => {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { ColorModeScript } from '@chakra-ui/react';
 import { theme } from '@/theme';
 import Document, { Head, Html, Main, NextScript } from 'next/document';

--- a/src/pages/search/authoraffiliations.tsx
+++ b/src/pages/search/authoraffiliations.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps = composeNextGSSP(async (ctx) => {
 
     // react-query infinite queries cannot be serialized by next, currently.
     // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
     const dehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
 
     return {

--- a/src/pages/search/exportcitation/[format].tsx
+++ b/src/pages/search/exportcitation/[format].tsx
@@ -174,7 +174,7 @@ export const getServerSideProps: GetServerSideProps = composeNextGSSP(async (ctx
 
     // react-query infinite queries cannot be serialized by next, currently.
     // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
     const dehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
 
     return {

--- a/src/pages/search/metrics.tsx
+++ b/src/pages/search/metrics.tsx
@@ -58,7 +58,7 @@ export const getServerSideProps: GetServerSideProps = composeNextGSSP(async (ctx
 
     // react-query infinite queries cannot be serialized by next, currently.
     // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
     // const dehydratedState: DehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
 
     return Promise.resolve({

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -19,9 +19,16 @@ import { theme } from '@/theme';
  */
 export const createServerListenerMocks = (server: SetupServerApi) => {
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+// Extract the `on` method type
+  type ServerEventOnMethod = typeof server.events.on;
+
+// Extract listener type for a specific event
+  type EventListener<T extends keyof ServerLifecycleEventsMap> =
+    ServerEventOnMethod extends (event: T, listener: infer U) => void ? U : never;
+
+// Extract the parameters of the listener
   type EventMockParams<T extends keyof ServerLifecycleEventsMap> =
-    Parameters<Parameters<typeof server.events.on<T>>[1]>;
+    Parameters<EventListener<T>>;
 
   const onRequest = vi.fn<EventMockParams<'request:start'>, void>();
   const onMatch = vi.fn<EventMockParams<'request:match'>, void>();


### PR DESCRIPTION
This is happening because we pass the abortcontroller signal from react-query to axios allow it to cancel queries when components unmount or requests become stale.

I think in general it's okay to have this happen, but for some reason some of our components must unmount prematurely causing this unexpected behavior.  This change makes sure react-query doesn't pass it's controller through.