### PR TITLE
Scix 473 html in abstract metadata

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -425,7 +425,9 @@ const Detail = <T,>(props: IDetailProps<T>): ReactElement => {
             {normalizedValue}
           </SimpleLink>
         )}
-        {typeof children === 'function' ? children(value) : !href && normalizedValue}
+        {typeof children === 'function'
+          ? children(value)
+          : !href && <span dangerouslySetInnerHTML={{ __html: normalizedValue }} />}
         {copiable && <SimpleCopyButton text={normalizedValue as string} size="xs" variant="outline" mx={2} />}
       </Td>
     </Tr>


### PR DESCRIPTION
Render abstract metadata as html

Before:
<img width="561" alt="Screenshot 2025-01-15 at 11 07 47 AM" src="https://github.com/user-attachments/assets/3c978418-ebeb-468e-8862-038f655bce7d" />

After:
<img width="485" alt="Screenshot 2025-01-15 at 11 07 37 AM" src="https://github.com/user-attachments/assets/4870bc6a-1b2f-41b6-a27d-f73b4fcec254" />

