### PR TITLE
Get first-author working on classic form

### DIFF
--- a/src/components/ClassicForm/__tests__/helpers.test.ts
+++ b/src/components/ClassicForm/__tests__/helpers.test.ts
@@ -34,9 +34,18 @@ describe('Classic Form Query Handling', () => {
     ['foo\n=bar\n-baz', 'and', 'author:(foo =bar -baz)'],
     ['foo$', 'and', 'author:(foo) author_count:1'],
     ['foo$', 'or', 'author:(foo) author_count:1'],
-    ['foo$\nbar\n-baz', 'boolean', 'author:(foo OR bar OR -baz) author_count:1'],
+    ['foo$\nbar\n-baz', 'boolean', 'author:(foo bar -baz) author_count:1'],
     ['=foo$', 'and', 'author:(=foo) author_count:1'],
-    ['foo\nbar$\nbaz', 'and', 'author:(foo OR bar OR baz) author_count:1'],
+    ['foo\nbar$\nbaz', 'and', 'author:(foo bar baz) author_count:1'],
+    ['^foo\n^bar\nbaz', 'and', 'author:(baz) first_author:(foo bar)'],
+    ['^foo, a\n^foo, b\nbaz', 'and', 'author:(baz) first_author:("foo, a" "foo, b")'],
+    ['^foo, a\n^foo, b$\nbaz', 'and', 'author:(baz) first_author:("foo, a" "foo, b") author_count:1'],
+    ['    foo     \n   baz   \n  ^baz  ', 'and', 'author:(foo baz) first_author:(baz)'],
+    ['-foo', 'and', 'author:(-foo)'],
+    ['foo\n-bar\n=baz', 'and', 'author:(foo -bar =baz)'],
+    ['foo@bar.com', 'and', 'author:("foo@bar.com")'],
+    ['foo bar', 'and', 'author:("foo bar")'],
+    ['foo-bar', 'and', 'author:("foo-bar")'],
   ])('getAuthor(%s, %s) -> %s', (author, logic, expected) => expect(getAuthor(author, logic)).toBe(expected));
 
   // object


### PR DESCRIPTION
Makes sure that the classic form handles `^Smith,A` type first-author searches properly.

`^Smith, A  -->  first_author:("Smith, A")`