### PR TITLE
Remove the integration tests action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Pull Request
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
 
@@ -89,53 +89,3 @@ jobs:
           flags: unittests
           name: codecov-nectar
           verbose: true
-
-  e2e-tests:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    env:
-      CI: true
-      BASE_CANONICAL_URL: ${{ vars.BASE_CANONICAL_URL }}
-      API_HOST_CLIENT: ${{ vars.API_HOST_CLIENT }}
-      API_HOST_SERVER: ${{ vars.API_HOST_SERVER }}
-      COOKIE_SECRET: ${{ vars.COOKIE_SECRET }}
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      SENTRYCLI_SKIP_DOWNLOAD: 1
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Install Deps
-        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 SENTRYCLI_SKIP_DOWNLOAD=1 pnpm install
-
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
-
-      - name: setup environment variables
-        run: |
-          touch .env.local
-          echo "CI=${{ env.CI }}" >> .env.local
-          echo "BASE_CANONICAL_URL=${{ env.BASE_CANONICAL_URL }}" >> .env.local
-          echo "API_HOST_CLIENT=${{ env.API_HOST_CLIENT }}" >> .env.local
-          echo "API_HOST_SERVER=${{ env.API_HOST_SERVER }}" >> .env.local
-          echo "COOKIE_SECRET=${{ env.COOKIE_SECRET }}" >> .env.local
-
-      - name: Run integration tests
-        run: pnpm integration
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30


### PR DESCRIPTION
Instead of running these using the latest code, the integration tests will run against hosted dev environment as part of a deployment step