### PR TITLE
add share public library links

### DIFF
--- a/src/components/Libraries/LibraryEntityPane.tsx
+++ b/src/components/Libraries/LibraryEntityPane.tsx
@@ -18,11 +18,12 @@ import {
   Tooltip,
   Tr,
   useBreakpoint,
+  useClipboard,
   useToast,
 } from '@chakra-ui/react';
 
 import { biblibSortOptions } from '@/components/Sort/model';
-import { BuildingLibraryIcon } from '@heroicons/react/24/solid';
+import { BuildingLibraryIcon, ShareIcon } from '@heroicons/react/24/solid';
 
 import { AppState, useStore } from '@/store';
 import { NumPerPageType } from '@/types';
@@ -221,6 +222,26 @@ export const LibraryEntityPane = ({ id, publicView }: ILibraryEntityPaneProps) =
     );
   };
 
+  const { hasCopied, onCopy, setValue, value } = useClipboard('');
+
+  useEffect(() => {
+    if (library?.metadata?.id) {
+      setValue(`${process.env.NEXT_PUBLIC_BASE_CANONICAL_URL}/public-libraries/${library.metadata.id}`);
+    }
+  }, [library, setValue]);
+
+  const handleCopyPublicURL = () => {
+    if (value !== '') {
+      onCopy();
+    }
+  };
+
+  useEffect(() => {
+    if (hasCopied) {
+      toast({ status: 'info', title: 'Copied to Clipboard' });
+    }
+  }, [hasCopied, toast]);
+
   return (
     <>
       {isLoadingLibs && (
@@ -251,41 +272,67 @@ export const LibraryEntityPane = ({ id, publicView }: ILibraryEntityPaneProps) =
                   Back to libraries
                 </Button>
               </SimpleLink>
-              <SimpleLink href={`/user/libraries/${id}/settings`}>
-                <IconButton
-                  aria-label="settings"
-                  icon={<SettingsIcon />}
-                  variant="outline"
-                  data-testid="settings-btn"
-                />
-              </SimpleLink>
+              <HStack>
+                {isPublic && (
+                  <Tooltip label="View as public library">
+                    <SimpleLink href={`/public-libraries/${library.metadata.id}`}>
+                      <IconButton
+                        aria-label="view as public library"
+                        icon={<BuildingLibraryIcon width="20px" height="20px" />}
+                        variant="outline"
+                      />
+                    </SimpleLink>
+                  </Tooltip>
+                )}
+                <SimpleLink href={`/user/libraries/${id}/settings`}>
+                  <IconButton
+                    aria-label="settings"
+                    icon={<SettingsIcon />}
+                    variant="outline"
+                    data-testid="settings-btn"
+                  />
+                </SimpleLink>
+              </HStack>
             </Flex>
           )}
 
-          <Flex alignItems="center" gap={2}>
-            {publicView ? (
-              <Icon
-                as={BuildingLibraryIcon}
-                aria-label="SciX Public Library"
-                borderRadius={25}
-                w={10}
-                h={10}
-                backgroundColor="gray.700"
-                color="white"
-                p={2}
-              />
-            ) : isPublic ? (
-              <Tooltip label="This library is public">
-                <UnlockIcon color="green.500" aria-label="public" />
-              </Tooltip>
-            ) : (
-              <Tooltip label="This library is private">
-                <LockIcon aria-label="private" />
+          <Flex justifyContent="space-between">
+            <Flex alignItems="center" gap={2}>
+              {publicView ? (
+                <Icon
+                  as={BuildingLibraryIcon}
+                  aria-label="SciX Public Library"
+                  borderRadius={25}
+                  w={10}
+                  h={10}
+                  backgroundColor="gray.700"
+                  color="white"
+                  p={2}
+                />
+              ) : isPublic ? (
+                <Tooltip label="This library is public">
+                  <UnlockIcon color="green.500" aria-label="public" />
+                </Tooltip>
+              ) : (
+                <Tooltip label="This library is private">
+                  <LockIcon aria-label="private" />
+                </Tooltip>
+              )}
+              <Heading variant="pageTitle" as="h1" data-testid="lib-title">
+                {name}
+              </Heading>
+            </Flex>
+            {publicView && isPublic && (
+              <Tooltip label="Copy public library link">
+                <IconButton
+                  aria-label="copy public library link"
+                  icon={<ShareIcon width="18px" height="18px" />}
+                  variant="outline"
+                  cursor="pointer"
+                  onClick={handleCopyPublicURL}
+                />
               </Tooltip>
             )}
-            <Heading variant="pageTitle" as="h1" data-testid="lib-title">
-              {name}
-            </Heading>
           </Flex>
           <Text my={2} data-testid="lib-desc">
             {description}


### PR DESCRIPTION
* User library page: add 'open as public library' for library that is public
* Public library page: add 'share' button to copy library link

<img width="1168" alt="Screenshot 2025-02-06 at 2 40 51 PM" src="https://github.com/user-attachments/assets/60b4bbd2-1d50-42a8-b193-51b764bc20a1" />
<img width="1187" alt="Screenshot 2025-02-06 at 2 41 06 PM" src="https://github.com/user-attachments/assets/406c2166-5688-4970-b320-95180d605788" />
