### PR TITLE
Show affiliation in author list as html

### DIFF
--- a/src/components/AllAuthorsModal/AllAuthorsModal.tsx
+++ b/src/components/AllAuthorsModal/AllAuthorsModal.tsx
@@ -242,7 +242,7 @@ const AuthorsTable = forwardRef<HTMLInputElement, { doc: IDocsEntity; onSearchCl
                   )}
                 </Td>
                 <Td>
-                  <Text>{aff}</Text>
+                  <Text dangerouslySetInnerHTML={{ __html: aff }} />
                 </Td>
               </Tr>
             );


### PR DESCRIPTION
It seems like aff may have html entities and needs to be rendered as HTML.

Before
![image (2)](https://github.com/user-attachments/assets/78b03e6a-ade8-4f87-9e3d-5c7518cb2cd7)

After
<img width="834" alt="Screenshot 2025-02-14 at 11 57 40 AM" src="https://github.com/user-attachments/assets/47908576-5b8a-42fe-b148-10ce92a70e04" />
