### PR TITLE
Fix feedback form diff bug

### DIFF
--- a/src/components/FeedbackForms/MissingRecord/DiffUtil.ts
+++ b/src/components/FeedbackForms/MissingRecord/DiffUtil.ts
@@ -49,10 +49,6 @@ export const getDiffSections = (leftValues: FormValues, rightValues: FormValues)
   const sectionsChanges: DiffSection[] = Object.entries(left).map(([key, value]) => {
     const isArray = Array.isArray(value);
 
-    if (isArray && value.length === 0) {
-      return null;
-    }
-
     let changes: (ArrayChange<string> | Change)[] = [];
 
     try {


### PR DESCRIPTION
Sometimes the preview for the feedback form doesn't show changes. This happened when the original array field was empty, and the diff would return null. However, the diff should continue to check even if original array was empty.