### PR TITLE
Fix facet bug when an operator word is in the filter string

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -40,7 +40,7 @@ const stringify = (ast: lucene.AST) => lucene.toString(ast);
 const isNonEmptyString = (v: unknown) => typeof v === 'string' && v.length > 0;
 const isUndefinedOrEmpty = (v: unknown) => typeof v === 'undefined' || (typeof v === 'string' && v.length === 0);
 const stripFieldFromClause = (clause: string) => replace(FIELD_REGEX, '', clause);
-const capitalizeOperators = (query: string) => query.replace(/\b(and|or|not)\b/gi, toUpper);
+const capitalizeOperators = (query: string) => query.replace(/\b(and|or|not)\b(?=(?:[^"]*"[^"]*")*[^"]*$)/gi, toUpper);
 const appendIfString = (list: string[], result: string) => (is(String, result) ? [...list, result] : list);
 export const getOperator = pipe<[string], lucene.AST, string, string>(
   parse,


### PR DESCRIPTION
Found this bug when applying UAT keyword filter 'galactic and extragalactic astronomy. The `and` was converted to capitalized and that seemed to turn into the 'and' operator and messed up the results. 

The fix: apply operator capitalization outside of quotes.

https://github.com/user-attachments/assets/fbe031e2-6ac4-4928-9ab8-becd0b8eaafb

