### PR TITLE
Small fixes

### DIFF
--- a/src/lib/useBackToSearchResults.ts
+++ b/src/lib/useBackToSearchResults.ts
@@ -10,7 +10,7 @@ const selector = {
 
 export const useBackToSearchResults = () => {
   const latestQuery = useStore(selector.latestQuery);
-  const show = latestQuery.q !== '';
+  const show = latestQuery.q !== '' && latestQuery.q !== '*:*';
 
   const getSearchHref = useCallback<() => ISimpleLinkProps['href']>(() => {
     const search = makeSearchParams({ ...latestQuery, p: calculatePage(latestQuery.start, latestQuery.rows) });

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -3,6 +3,7 @@ import {
   AlertDescription,
   AlertIcon,
   AlertTitle,
+  Badge,
   Box,
   Button,
   Center,
@@ -41,7 +42,7 @@ import { MathJax } from 'better-react-mathjax';
 import { GetServerSideProps, NextPage } from 'next';
 import dynamic from 'next/dynamic';
 import { equals, isNil, path, values } from 'ramda';
-import { memo, ReactElement, useState } from 'react';
+import { memo, ReactElement, ReactNode, useState } from 'react';
 import { useRouter } from 'next/router';
 import { FolderPlusIcon } from '@heroicons/react/24/solid';
 import { useSession } from '@/lib/useSession';
@@ -368,9 +369,17 @@ const Keywords = memo(({ keywords }: { keywords: Array<string> }) => {
 Keywords.displayName = 'Keywords';
 
 const UATKeywords = memo(({ keywords, ids }: { keywords: Array<string>; ids: Array<string> }) => {
-  const label = `Search for papers that mention this keyword`;
+  const desc = `Search for papers that mention this keyword`;
+  const label = (
+    <>
+      {`UAT ${pluralize('Keyword', keywords?.length ?? 0)} (generated)`}
+      <Badge colorScheme="blue" mx={1}>
+        BETA
+      </Badge>
+    </>
+  );
   return (
-    <Detail label={`UAT ${pluralize('Keyword', keywords?.length ?? 0)} (generated)`} value={keywords}>
+    <Detail label={label} value={keywords}>
       {(keywords) => (
         <Flex flexWrap={'wrap'}>
           {keywords.map((keyword, index) => (
@@ -391,10 +400,10 @@ const UATKeywords = memo(({ keywords, ids }: { keywords: Array<string>; ids: Arr
                   _hover={{
                     color: 'gray.900',
                   }}
-                  aria-label={label}
+                  aria-label={desc}
                   fontSize="md"
                 >
-                  <Tooltip label={label}>
+                  <Tooltip label={desc}>
                     <Center>
                       <Icon as={MagnifyingGlassIcon} transform="rotate(90deg)" />
                     </Center>
@@ -460,7 +469,7 @@ const PlanetaryFeatures = memo(({ features, ids }: { features: Array<string>; id
 PlanetaryFeatures.displayName = 'PlanetaryFeatures';
 
 interface IDetailProps<T = string | Array<string>> {
-  label: string;
+  label: string | ReactNode;
   href?: string;
   newTab?: boolean;
   value: T;

--- a/src/pages/search/exportcitation/[format].tsx
+++ b/src/pages/search/exportcitation/[format].tsx
@@ -27,7 +27,7 @@ import { exportCitationKeys, fetchExportCitation } from '@/api/export/export';
 interface IExportCitationPageProps {
   format: ExportApiFormatKey;
   query: IADSApiSearchParams;
-  referrer?: string;
+  referrer?: string; // this is currently used by the library
   error?: {
     status?: string;
     message?: string;
@@ -59,7 +59,7 @@ const ExportCitationPage: NextPage<IExportCitationPageProps> = (props) => {
         };
 
   const { data, fetchNextPage, hasNextPage, error } = useSearchInfinite(query);
-  const { getSearchHref } = useBackToSearchResults();
+  const { getSearchHref, show: showSearchHref } = useBackToSearchResults();
 
   // TODO: add more error handling here
   if (!data) {
@@ -81,9 +81,12 @@ const ExportCitationPage: NextPage<IExportCitationPageProps> = (props) => {
       </Head>
       <Flex direction="column">
         <HStack my={10}>
-          <SimpleLink href={referrer ?? getSearchHref()}>
-            <ChevronLeftIcon w={8} h={8} />
-          </SimpleLink>
+          {(referrer || showSearchHref) && (
+            <SimpleLink href={referrer ?? getSearchHref()}>
+              <ChevronLeftIcon w={8} h={8} />
+            </SimpleLink>
+          )}
+
           <Heading as="h2" fontSize="2xl">
             Export Citations
           </Heading>


### PR DESCRIPTION
### 1. Add beta label to UAT keywords in abstract

<img width="651" alt="Screenshot 2025-03-24 at 10 17 33 AM" src="https://github.com/user-attachments/assets/19a37331-8367-4f47-917f-22383aebb223" />

### 2. Hide back link in export citation page if query is not available.