### PR TITLE
Update UAT facet to flat list, Change modal icon

### DIFF
--- a/src/components/SearchFacet/config.ts
+++ b/src/components/SearchFacet/config.ts
@@ -110,10 +110,9 @@ export const facetConfig: Record<SearchFacetID, Omit<ISearchFacetProps, 'onQuery
   uat: {
     label: 'UAT',
     field: 'uat_facet_hier' as FacetField,
-    hasChildren: true,
+    hasChildren: false,
     logic: defaultLogic,
     storeId: 'uat',
-    maxDepth: 2,
     noLoadMore: true,
   },
 };


### PR DESCRIPTION
* Updates UAT facet to be a flat list to match incoming data
* Updates Facet icon to better reflect action, now shows on all facets regardless of remaining records to fetch
* Adds a tooltip to the button
* Move facet filters to be run as a post-transform during the request step rather than during the render step so that the `totalRecords` show up properly (only use-case is the `refereed/property` facet for now)

![image](https://github.com/user-attachments/assets/f39f56d7-7241-44af-8a72-345fb850e7ce)
