### PR TITLE
use default sort order

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -150,6 +150,20 @@ export const solrSorts = [
   'score desc',
 ] as const;
 
+export const solrDefaultSortDirection: Record<SolrSortField, SortDirection> = {
+  author_count: 'asc',
+  bibcode: 'desc',
+  citation_count: 'desc',
+  citation_count_norm: 'desc',
+  classic_factor: 'desc',
+  first_author: 'asc',
+  date: 'desc',
+  entry_date: 'desc',
+  read_count: 'desc',
+  score: 'desc',
+  id: 'desc',
+};
+
 export type BiblibSortField =
   | 'author_count'
   | 'bibcode'

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -52,7 +52,7 @@ import { makeSearchParams, parseQueryFromUrl } from '@/utils/common/search';
 import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
 import { defaultParams } from '@/api/search/models';
-import { SolrSort } from '@/api/models';
+import { solrDefaultSortDirection, SolrSort, SolrSortField } from '@/api/models';
 
 const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
   () =>
@@ -150,8 +150,15 @@ const SearchPage: NextPage = () => {
       return;
     }
 
+    // if sort field has changed, use its default sort order
+    const currentSortField = query.sort[0].split(' ')[0];
+    const newSortField = sort.split(' ')[0] as SolrSortField;
+
+    const newSort =
+      currentSortField === newSortField ? sort : `${newSortField} ${solrDefaultSortDirection[newSortField]}`;
+
     // generate search string and trigger page transition, also update store
-    const search = makeSearchParams({ ...params, ...query, sort, p: 1 });
+    const search = makeSearchParams({ ...params, ...query, sort: newSort, p: 1 });
     void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
   };
 


### PR DESCRIPTION
When user changes sort order, the default direction is used.
* Author count and first author, use asc
* Everything else, use desc

https://github.com/user-attachments/assets/155e33e5-4570-414f-9e09-8d13067b80e5

