### PR TITLE
deduplicate incoming esource URLs

### DIFF
--- a/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
@@ -192,7 +192,7 @@ export const RecordPanel = ({
     if (isFocused) {
       setFocus('name');
     }
-  }, [isFocused]);
+  }, [isFocused, setFocus]);
 
   useEffect(() => {
     if (state === 'idle') {

--- a/src/lib/__tests__/useGetResourceLinks.test.ts
+++ b/src/lib/__tests__/useGetResourceLinks.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { fetchUrl, transformUrl } from '../useGetResourceLinks';
+
+const htmlWithLinks = `
+  <script src="my-script.js" defer=""></script>
+  <script src="my-styles.css" defer=""></script>
+  <a href="https://arxiv.org/pdf/1234.5678.pdf">arXiv</a>
+  <a href="https://doi.org/10.1234/abcd">DOI</a>
+  <a href="https://example.com/page.html">HTML</a>
+  <a href="https://example.com/style.css">CSS</a>
+  <a href="http://www.nasa.gov">NASA</a>
+  <a href="https://example.com/document.pdf">PDF</a>
+  <a href="https://example.com/page.html">HTML Duplicate</a>
+`;
+
+const SKIP_URLS = [
+  'http://www.cfa.harvard.edu/sao',
+  'https://www.cfa.harvard.edu/',
+  'http://www.si.edu',
+  'http://www.nasa.gov',
+];
+
+const expectedUrls = [
+  { type: 'arXiv', url: 'https://arxiv.org/pdf/1234.5678.pdf' },
+  { type: 'DOI', url: 'https://doi.org/10.1234/abcd' },
+  { type: 'HTML', url: 'https://example.com/page.html' },
+  { type: 'PDF', url: 'https://example.com/document.pdf' },
+];
+
+describe('resourceLinks', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  test('transformUrl filters known static/resource files', () => {
+    expect(transformUrl('https://example.com/image.jpg')).toBeNull();
+    expect(transformUrl('https://example.com/script.js')).toBeNull();
+  });
+
+  test('transformUrl filters known skipped domains', () => {
+    for (const url of SKIP_URLS) {
+      expect(transformUrl(url)).toBeNull();
+    }
+  });
+
+  test('transformUrl assigns correct type', () => {
+    expect(transformUrl('https://arxiv.org/pdf/foo.pdf')).toEqual({
+      type: 'arXiv',
+      url: 'https://arxiv.org/pdf/foo.pdf',
+    });
+
+    expect(transformUrl('https://doi.org/10.1234')).toEqual({
+      type: 'DOI',
+      url: 'https://doi.org/10.1234',
+    });
+
+    expect(transformUrl('https://example.com/anything')).toEqual({
+      type: 'HTML',
+      url: 'https://example.com/anything',
+    });
+  });
+
+  test('transformUrl returns null for empty or invalid URLs', () => {
+    expect(transformUrl('')).toBeNull();
+    expect(transformUrl('invalid-url')).toBeNull();
+    expect(transformUrl('https://example.com/image.png')).toBeNull();
+  });
+
+  test('transformUrl normalizes URLs', () => {
+    expect(transformUrl('https://example.com/')).toEqual({
+      type: 'HTML',
+      url: 'https://example.com',
+    });
+    expect(transformUrl('https://example.com/page.HTML')).toEqual({
+      type: 'HTML',
+      url: 'https://example.com/page.html',
+    });
+  });
+
+  test('fetchUrl returns deduplicated transformed links', async () => {
+    const mockFetch = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValueOnce({
+      text: () => Promise.resolve(htmlWithLinks),
+    });
+
+    const result = await fetchUrl('fake-id');
+    expect(result).toEqual(expectedUrls);
+  });
+
+  test('fetchUrl returns empty list if input has no valid links', async () => {
+    const mockFetch = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValueOnce({
+      text: () => Promise.resolve('<p>No links here</p>'),
+    });
+
+    const result = await fetchUrl('fake-id');
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/useGetResourceLinks.ts
+++ b/src/lib/useGetResourceLinks.ts
@@ -1,17 +1,21 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { isValidURL } from '@/utils/common/isValidURL';
 
 export const resourceUrlTypes = ['arXiv', 'PDF', 'DOI', 'HTML', 'Other'] as const;
 
 export type ResourceUrlType = typeof resourceUrlTypes[number];
+
 export interface IResourceUrl {
   type: ResourceUrlType;
   url: string;
 }
+
 interface IUseResourceLinksProps {
   identifier: string;
   options?: UseQueryOptions<IResourceUrl[]>;
 }
 
+// TODO: slightly brittle, since these links could change over time
 const SKIP_URLS = [
   'http://www.cfa.harvard.edu/sao',
   'https://www.cfa.harvard.edu/',
@@ -19,42 +23,58 @@ const SKIP_URLS = [
   'http://www.nasa.gov',
 ];
 
-export const useGetResourceLinks = ({ identifier, options }: IUseResourceLinksProps) => {
+const URL_TYPE_MAP: Record<string, ResourceUrlType> = {
+  arxiv: 'arXiv',
+  pdf: 'PDF',
+  doi: 'DOI',
+  html: 'HTML',
+};
+
+const RESOURCE_EXT_REGEX = /\.(jpg|jpeg|png|gif|webp|svg|css|js|ico|woff2?|ttf|otf|eot|map|mp4|webm)(\?|$)/i;
+const URL_REGX = /href="(https?:\/\/[^"]*)"/gi;
+
+/**
+ * Transforms a URL into a structured resource link object.
+ * @param url
+ */
+export const transformUrl = (url: string) => {
+  if (!url || typeof url !== 'string' || !isValidURL(url) || RESOURCE_EXT_REGEX.test(url) || SKIP_URLS.includes(url)) {
+    return null;
+  }
+
+  const normalizedUrl = url.toLowerCase().replace(/\/$/, '');
+  const urlType = Object.keys(URL_TYPE_MAP).find((key) => normalizedUrl.includes(key));
+  const type = urlType ? URL_TYPE_MAP[urlType] : 'HTML';
+  return { type, url: normalizedUrl } as IResourceUrl;
+};
+
+/**
+ * Fetches resource links for a given identifier.
+ * @param identifier
+ */
+export const fetchUrl = async (identifier: string): Promise<IResourceUrl[]> => {
   const url = `/link_gateway/${encodeURIComponent(identifier)}/ESOURCE`;
+  const res = await fetch(url);
+  const raw = await res.text();
 
-  // url regex, skip internal links
-  const reg = /href="(https?:\/\/[^"]*)"/gi;
+  if (!raw) {
+    return [];
+  }
 
-  const data = useQuery<IResourceUrl[]>(
-    ['resourceLink', identifier],
-    async () => {
-      const res = await fetch(url);
-      const raw = await res.text();
-      if (!!raw) {
-        return (
-          Array.from(
-            new Set(raw.matchAll(reg)),
-            (e) =>
-              ({
-                type: e[1].includes('arxiv')
-                  ? ('arXiv' as IResourceUrl['type'])
-                  : e[1].includes('pdf')
-                  ? ('PDF' as IResourceUrl['type'])
-                  : e[1].includes('doi')
-                  ? ('DOI' as IResourceUrl['type'])
-                  : ('HTML' as IResourceUrl['type']),
-                url: e[1],
-              } as IResourceUrl),
-          )
-            .slice(1)
+  const seen = new Set<string>();
+  const result = Array.from(raw.matchAll(URL_REGX), ([, href]) => transformUrl(href));
 
-            // filter out urls based on a skip list
-            .filter((u) => !SKIP_URLS.includes(u.url))
-        );
-      }
-      return [] as IResourceUrl[];
-    },
-    options,
-  );
-  return data;
+  const output: IResourceUrl[] = [];
+  for (const res of result) {
+    if (res && !seen.has(res.url)) {
+      seen.add(res.url);
+      output.push(res);
+    }
+  }
+
+  return output;
+};
+
+export const useGetResourceLinks = ({ identifier, options }: IUseResourceLinksProps) => {
+  return useQuery<IResourceUrl[]>(['resourceLink', identifier], () => fetchUrl(identifier), options);
 };

--- a/src/lib/useGetResourceLinks.ts
+++ b/src/lib/useGetResourceLinks.ts
@@ -55,8 +55,18 @@ export const transformUrl = (url: string) => {
 export const fetchUrl = async (identifier: string): Promise<IResourceUrl[]> => {
   const url = `/link_gateway/${encodeURIComponent(identifier)}/ESOURCE`;
   const res = await fetch(url);
-  const raw = await res.text();
 
+  // check for 302 redirects
+  if (res.status === 302 || res.status === 301) {
+    const redirectUrl = res.headers.get('Location');
+    if (redirectUrl) {
+      const transformedUrl = transformUrl(redirectUrl);
+      return transformedUrl ? [transformedUrl] : [];
+    }
+    return [];
+  }
+
+  const raw = await res.text();
   if (!raw) {
     return [];
   }

--- a/src/utils/common/isValidURL.ts
+++ b/src/utils/common/isValidURL.ts
@@ -1,0 +1,9 @@
+/**
+ * @see https://uibakery.io/regex-library/url
+ */
+const URL_REGEX =
+  /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
+
+export const isValidURL = (url: string): boolean => {
+  return URL_REGEX.test(url);
+};


### PR DESCRIPTION
Extract the fetcher and the transformer parts so we can test.
Adds tests
More robust handling of non-resource URLs
Handles filtering directly in the initial map, for slightly more efficiency over the original filter.

Also fixes SCIX-470