### PR TITLE
Scix 580/fix metatags on abstract pages

### DIFF
--- a/src/api/search/search.ts
+++ b/src/api/search/search.ts
@@ -398,19 +398,21 @@ export const useBigQuerySearch: ADSMutation<
   });
 };
 
-export const fetchBigQuerySearch: MutationFunction<IADSApiSearchResponse['response'], IBigQueryMutationParams> =
-  async ({ params, variables }: IBigQueryMutationParams) => {
-    const config: ApiRequestConfig = {
-      method: 'POST',
-      url: `${ApiTargets.BIGQUERY}`,
-      params: { ...params, rows: variables.rows, sort: variables.sort },
-      data: `bibcode\n${variables.bibcodes.join('\n')}`,
-      headers: { 'Content-Type': 'bigquery/csv' },
-    };
-
-    const { data } = await api.request<IADSApiSearchResponse>(config);
-    return data.response;
+export const fetchBigQuerySearch: MutationFunction<
+  IADSApiSearchResponse['response'],
+  IBigQueryMutationParams
+> = async ({ params, variables }: IBigQueryMutationParams) => {
+  const config: ApiRequestConfig = {
+    method: 'POST',
+    url: `${ApiTargets.BIGQUERY}`,
+    params: { ...params, rows: variables.rows, sort: variables.sort },
+    data: `bibcode\n${variables.bibcodes.join('\n')}`,
+    headers: { 'Content-Type': 'bigquery/csv' },
   };
+
+  const { data } = await api.request<IADSApiSearchResponse>(config);
+  return data.response;
+};
 
 /**
  * Fetches search results from the API based on provided search parameters.
@@ -466,7 +468,7 @@ export const fetchSearchSSR = async (
   params: IADSApiSearchParams,
   ctx: GetServerSidePropsContext,
   {}: QueryFunctionContext,
-) => {
+): Promise<IADSApiSearchResponse> => {
   const finalParams = { ...params };
 
   const token = ctx.req.session?.token?.access_token;

--- a/src/components/AbstractSources/AbstractSourceItems.tsx
+++ b/src/components/AbstractSources/AbstractSourceItems.tsx
@@ -94,7 +94,7 @@ export const FullTextSourceItems = ({ resources, type, ...boxProps }: IFullTextS
                   {group.links.map((link) => (
                     <MenuItem key={link.rawType} as={SimpleLink} href={link.path} newTab>
                       {link.rawType === Esources.INSTITUTION ? (
-                        <Icon as={AcademicCapIcon} mr={1} />
+                        <Icon as={AcademicCapIcon} mr={1} fontSize="2em" />
                       ) : link.open ? (
                         <UnlockIcon color="green.600" mr={1} />
                       ) : (
@@ -121,7 +121,7 @@ export const FullTextSourceItems = ({ resources, type, ...boxProps }: IFullTextS
                       key={link.rawType}
                       icon={
                         link.rawType === Esources.INSTITUTION ? (
-                          <AcademicCapIcon />
+                          <Icon as={AcademicCapIcon} fontSize="2em" />
                         ) : link.type === 'pdf' ? (
                           <PdfFileIcon fill={link.open ? 'green' : 'gray'} />
                         ) : link.type === 'html' ? (

--- a/src/components/AbstractSources/AbstractSourceItems.tsx
+++ b/src/components/AbstractSources/AbstractSourceItems.tsx
@@ -94,7 +94,7 @@ export const FullTextSourceItems = ({ resources, type, ...boxProps }: IFullTextS
                   {group.links.map((link) => (
                     <MenuItem key={link.rawType} as={SimpleLink} href={link.path} newTab>
                       {link.rawType === Esources.INSTITUTION ? (
-                        <Icon as={AcademicCapIcon} mr={1} fontSize="2em" />
+                        <Icon as={AcademicCapIcon} mr={1} fontSize="2xl" />
                       ) : link.open ? (
                         <UnlockIcon color="green.600" mr={1} />
                       ) : (
@@ -121,7 +121,7 @@ export const FullTextSourceItems = ({ resources, type, ...boxProps }: IFullTextS
                       key={link.rawType}
                       icon={
                         link.rawType === Esources.INSTITUTION ? (
-                          <Icon as={AcademicCapIcon} fontSize="2em" />
+                          <Icon as={AcademicCapIcon} fontSize="2xl" />
                         ) : link.type === 'pdf' ? (
                           <PdfFileIcon fill={link.open ? 'green' : 'gray'} />
                         ) : link.type === 'html' ? (

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -115,7 +115,7 @@ export const Item = (props: IItemProps): ReactElement => {
         {hideCheckbox ? null : <ItemCheckbox index={index} bibcode={bibcode} label={title} isChecked={isChecked} />}
       </Flex>
       <Stack direction="column" width="full" spacing={0} mx={3} mt={2}>
-        <Flex justifyContent="space-between">
+        <Flex justifyContent="space-between" minH="40px">
           <SimpleLink href={`/abs/${bibcode}/abstract`} fontWeight="semibold" className="article-title">
             <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
           </SimpleLink>

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -32,7 +32,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>((props, re
   return (
     <VStack as="section" direction="column" spacing={2} align="stretch">
       <QuickFields isLoading={isLoading} dispatch={dispatch} />
-      <SearchInput ref={refs} dispatch={dispatch} state={state} {...rest} />
+      <SearchInput ref={refs} dispatch={dispatch} state={state} isLoading={isLoading} {...rest} />
     </VStack>
   );
 });

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -239,11 +239,7 @@ const Handle = ({ handle, getHandleProps, align, mt, showLabel, onEnter }: IHand
         tabIndex={0}
         {...getHandleProps(handle.id)}
       />
-      {showLabel && (
-        <Box mt={5} fontSize="md">
-          {handle.value}
-        </Box>
-      )}
+      {showLabel && <Box fontSize="md">{handle.value}</Box>}
     </Stack>
   );
 };

--- a/src/lib/serverside/bootstrap.ts
+++ b/src/lib/serverside/bootstrap.ts
@@ -1,0 +1,40 @@
+import { getIronSession } from 'iron-session/edge';
+import { sessionConfig } from '@/config';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { isTokenExpired, pickUserData } from '@/auth-utils';
+import { ApiTargets } from '@/api/models';
+import { logger } from '@/logger';
+import { IUserData } from '@/api/user/types';
+
+const log = logger.child({ module: 'bootstrap' }, { msgPrefix: '[bootstrap] ' });
+
+export const bootstrap = async (req: IncomingMessage, res: ServerResponse) => {
+  const session = await getIronSession(req, res, sessionConfig);
+
+  if (session.token && !isTokenExpired(session.token.expires_at)) {
+    return { token: session.token };
+  }
+
+  try {
+    const bsRes = await fetch(`${process.env.API_HOST_SERVER}${ApiTargets.BOOTSTRAP}`, {
+      headers: new Headers({ Cookie: req.headers.cookie }),
+    });
+
+    if (!bsRes.ok) {
+      log.error({ status: bsRes.status, statusText: bsRes.statusText }, 'Failed to fetch bootstrap data');
+      return { error: 'Something went wrong retrieving bootstrap data' };
+    }
+
+    session.token = pickUserData((await bsRes.json()) as IUserData);
+    await session.save();
+
+    if (bsRes.headers.has('set-cookie')) {
+      res.setHeader('Set-Cookie', bsRes.headers.get('set-cookie'));
+    }
+
+    return { token: session.token };
+  } catch (error) {
+    log.error({ error }, 'Error fetching bootstrap data');
+    return { error: 'Issue fetching bootstrap data' };
+  }
+};

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -169,17 +169,27 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   const url = new URL(`${process.env.API_HOST_SERVER}${ApiTargets.SEARCH}`);
   url.search = stringifySearchParams(params);
-  const result = await fetch(url, {
-    headers: new Headers({ Authorization: `Bearer ${bsRes.token.access_token}` }),
-  });
-  const data = (await result.json()) as IADSApiSearchResponse;
-  queryClient.setQueryData(searchKeys.abstract(ctx.params.id as string), data);
-  queryClient.setQueryData(['user'], bsRes.token);
-  ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
 
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-    },
-  };
+  try {
+    const result = await fetch(url, {
+      headers: new Headers({ Authorization: `Bearer ${bsRes.token.access_token}` }),
+    });
+    const data = (await result.json()) as IADSApiSearchResponse;
+    queryClient.setQueryData(searchKeys.abstract(ctx.params.id as string), data);
+    queryClient.setQueryData(['user'], bsRes.token);
+    ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+
+    return {
+      props: {
+        dehydratedState: dehydrate(queryClient),
+      },
+    };
+  } catch (error) {
+    logger.error({ error, url: url.toString() }, 'Error fetching abstract data');
+    return {
+      props: {
+        pageError: 'Failed to load abstract data',
+      },
+    };
+  }
 };

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -7,7 +7,6 @@ import { OrcidActiveIcon } from '@/components/icons/Orcid';
 import { AbsLayout } from '@/components/Layout/AbsLayout';
 import { APP_DEFAULTS } from '@/config';
 import { useIsClient } from '@/lib/useIsClient';
-import { composeNextGSSP } from '@/ssr-utils';
 import { MathJax } from 'better-react-mathjax';
 import { GetServerSideProps, NextPage } from 'next';
 import dynamic from 'next/dynamic';
@@ -21,12 +20,14 @@ import { feedbackItems } from '@/components/NavBar';
 import { SearchQueryLink } from '@/components/SearchQueryLink';
 import { AbstractSources } from '@/components/AbstractSources';
 import { AddToLibraryModal } from '@/components/Libraries';
-import { parseAPIError } from '@/utils/common/parseAPIError';
-import { fetchSearchSSR, searchKeys, useGetAbstract } from '@/api/search/search';
-import { IADSApiSearchParams, IDocsEntity } from '@/api/search/types';
+import { searchKeys, useGetAbstract } from '@/api/search/search';
+import { IADSApiSearchParams, IADSApiSearchResponse, IDocsEntity } from '@/api/search/types';
 import { getAbstractParams } from '@/api/search/models';
 import { useTrackAbstractView } from '@/lib/useTrackAbstractView';
 import { AbstractDetails } from '@/components/AbstractDetails';
+import { bootstrap } from '@/lib/serverside/bootstrap';
+import { ApiTargets } from '@/api/models';
+import { stringifySearchParams } from '@/utils/common/search';
 
 const AllAuthorsModal = dynamic<IAllAuthorsModalProps>(
   () =>
@@ -156,26 +157,29 @@ const AbstractPage: NextPage = () => {
 
 export default AbstractPage;
 
-export const getServerSideProps: GetServerSideProps = composeNextGSSP(async (ctx) => {
-  try {
-    const { id } = ctx.params as { id: string };
-    const params = getAbstractParams(id);
-    const queryClient = new QueryClient();
-    await queryClient.fetchQuery({
-      queryKey: searchKeys.abstract(id),
-      queryFn: (qfCtx) => fetchSearchSSR(params, ctx, qfCtx),
-    });
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-    };
-  } catch (err) {
-    logger.error({ err, url: ctx.resolvedUrl }, 'Error fetching details');
-    return {
-      props: {
-        pageError: parseAPIError(err),
-      },
-    };
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const bsRes = await bootstrap(ctx.req, ctx.res);
+  if (bsRes.error) {
+    logger.error({ error: bsRes.error, url: ctx.resolvedUrl }, 'Error during bootstrap');
+    return { props: { pageError: bsRes.error } };
   }
-});
+
+  const params = getAbstractParams(ctx.params.id as string);
+  const queryClient = new QueryClient();
+
+  const url = new URL(`${process.env.API_HOST_SERVER}${ApiTargets.SEARCH}`);
+  url.search = stringifySearchParams(params);
+  const result = await fetch(url, {
+    headers: new Headers({ Authorization: `Bearer ${bsRes.token.access_token}` }),
+  });
+  const data = (await result.json()) as IADSApiSearchResponse;
+  queryClient.setQueryData(searchKeys.abstract(ctx.params.id as string), data);
+  queryClient.setQueryData(['user'], bsRes.token);
+  ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+};


### PR DESCRIPTION
Removes GSSP export on search page -- First step in a larger refactor, we need to figure out where the main overhead is on the search page.

Fix 'my institution' icon size

Isolates the bootstrapping and fetching to the GSSP on the abstract page, in lieu of using the *SSR methods for fetching.  This results in a cleaner SSR approach for this page, and I think we should move towards doing everywhere. 