### PR TITLE
Add boostType param to search based on the App Mode

### DIFF
--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -25,6 +25,7 @@ export interface IADSApiSearchParams {
   start?: number;
   'stats.field'?: string;
   stats?: boolean;
+  boostType?: string;
 
   [key: string]: string | number | (string | number)[] | boolean;
 }

--- a/src/lib/__tests__/useApplyBoostTypeToParams.test.ts
+++ b/src/lib/__tests__/useApplyBoostTypeToParams.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import { AppMode } from '@/types';
+import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
+import { renderHook } from '@/test-utils';
+import { IADSApiSearchParams } from '@/api/search/types';
+import { APP_DEFAULTS } from '@/config';
+
+describe('useApplyBoostTypeToParams', () => {
+  const cases: Array<
+    [string, AppMode, Parameters<typeof useApplyBoostTypeToParams>, ReturnType<typeof useApplyBoostTypeToParams>]
+  > = [
+    ['GENERAL mode', AppMode.GENERAL, [{ params: { q: 'star' } }], { params: { q: 'star', boostType: 'general' } }],
+    [
+      'ASTROPHYSICS mode',
+      AppMode.ASTROPHYSICS,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'astrophysics' } },
+    ],
+    [
+      'HELIOPHYSICS mode',
+      AppMode.HELIOPHYSICS,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'heliophysics' } },
+    ],
+    [
+      'PLANET_SCIENCE mode',
+      AppMode.PLANET_SCIENCE,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'planetary' } },
+    ],
+    [
+      'EARTH_SCIENCE mode',
+      AppMode.EARTH_SCIENCE,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'earthscience' } },
+    ],
+    [
+      'BIO_PHYSICAL mode',
+      AppMode.BIO_PHYSICAL,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'general' } },
+    ],
+    [
+      'Unknown mode',
+      'UNKNOWN' as AppMode,
+      [{ params: { q: 'star' } }],
+      { params: { q: 'star', boostType: 'general' } },
+    ],
+    [
+      'Empty params',
+      AppMode.GENERAL,
+      [{ params: {} as IADSApiSearchParams }],
+      { params: { q: APP_DEFAULTS.EMPTY_QUERY, boostType: 'general' } },
+    ],
+  ];
+
+  test.concurrent.each(cases)('%s', (_, mode, args, expected) => {
+    const { result } = renderHook(() => useApplyBoostTypeToParams(...args), { initialStore: { mode } });
+    expect(result.current).toEqual(expected);
+  });
+});

--- a/src/lib/useApplyBoostTypeToParams.ts
+++ b/src/lib/useApplyBoostTypeToParams.ts
@@ -1,0 +1,27 @@
+import { AppState, useStore } from '@/store';
+import { AppMode } from '@/types';
+import { IADSApiSearchParams } from '@/api/search/types';
+import { APP_DEFAULTS } from '@/config';
+import { isIADSSearchParams } from '@/utils/common/guards';
+
+const appModeSelector = (state: AppState) => state.mode;
+
+const mapBoostTypeToAppMode: Record<AppMode, string> = {
+  [AppMode.GENERAL]: 'general',
+  [AppMode.ASTROPHYSICS]: 'astrophysics',
+  [AppMode.HELIOPHYSICS]: 'heliophysics',
+  [AppMode.PLANET_SCIENCE]: 'planetary',
+  [AppMode.EARTH_SCIENCE]: 'earthscience',
+  [AppMode.BIO_PHYSICAL]: 'general',
+};
+
+export const useApplyBoostTypeToParams = (options: {
+  params: IADSApiSearchParams;
+}): { params: IADSApiSearchParams } => {
+  const appMode = useStore(appModeSelector);
+  const boostType = mapBoostTypeToAppMode[appMode] || 'general';
+
+  return isIADSSearchParams(options.params)
+    ? { params: { ...options.params, boostType } }
+    : { params: { q: APP_DEFAULTS.EMPTY_QUERY, boostType } };
+};

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -56,6 +56,7 @@ import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
 import { defaultParams } from '@/api/search/models';
 import { solrDefaultSortDirection, SolrSort, SolrSortField } from '@/api/models';
+import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
 
 const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
   () =>
@@ -109,12 +110,14 @@ const SearchPage: NextPage = () => {
 
   // parse the query params from the URL, this should match what the server parsed
   const parsedParams = parseQueryFromUrl(router.asPath);
-  const params = {
-    ...defaultParams,
-    ...parsedParams,
-    rows: storeNumPerPage,
-    start: calculateStartIndex(parsedParams.p, storeNumPerPage, numFound),
-  };
+  const { params } = useApplyBoostTypeToParams({
+    params: {
+      ...defaultParams,
+      ...parsedParams,
+      rows: storeNumPerPage,
+      start: calculateStartIndex(parsedParams.p, storeNumPerPage, numFound),
+    },
+  });
 
   const { data, isSuccess, isLoading, isFetching, error, isError } = useSearch(omitP(params));
   const histogramContainerRef = useRef<HTMLDivElement>(null);
@@ -247,7 +250,7 @@ const SearchPage: NextPage = () => {
                 {!isPrint && (
                   <Pagination
                     numPerPage={storeNumPerPage}
-                    page={params.p}
+                    page={params.p as number}
                     totalResults={data.numFound}
                     onPerPageSelect={handlePerPageChange}
                   />

--- a/src/utils/common/search.ts
+++ b/src/utils/common/search.ts
@@ -9,6 +9,8 @@ import { SolrSort } from '@/api/models';
 import { IADSApiSearchParams } from '@/api/search/types';
 import { logger } from '@/logger';
 
+const IGNORED_URL_KEYS = ['fl', 'start', 'rows', 'id', 'boostType'];
+
 /**
  * Type representing the parsed query parameters.
  *
@@ -193,8 +195,6 @@ export const safeSplitString = (value: string | string[], delimiter: string | Re
   }
 };
 
-// omit params that should not be included in any urls
-// `id` is typically slug used in abstract pages
 /**
  * A variable that holds a function which omits specified search parameters
  * from an object. The specified search parameters are 'fl', 'start', 'rows',
@@ -202,7 +202,7 @@ export const safeSplitString = (value: string | string[], delimiter: string | Re
  *
  * @type {function(Object): Object}
  */
-const omitSearchParams: (arg0: object) => object = omit(['fl', 'start', 'rows', 'id']);
+const omitSearchParams: (arg0: object) => object = omit(IGNORED_URL_KEYS);
 
 /**
  * Generates search parameters for constructing a URL.


### PR DESCRIPTION
This param is based on the current app mode and will subscribes the component to changes to the mode -- so this should update the search on change.

I also added `boostType` to the ignored URL params -- since this param will get overridden by the app mode on the incoming search regardless.

