### PR TITLE
Remove `suspense: true` from settings fetch options

### DIFF
--- a/src/lib/useSettings.ts
+++ b/src/lib/useSettings.ts
@@ -20,7 +20,6 @@ export const useSettings = (options?: UseQueryOptions<IADSApiUserDataResponse>, 
   });
   const queryClient = useQueryClient();
   const { data: settingsdata, ...getSettingsState } = useGetUserSettings({
-    suspense: true,
     retry: false,
     enabled: isAuthenticated,
     placeholderData: DEFAULT_USER_DATA,


### PR DESCRIPTION
In the case this fails we fallback to initialData anyway so the usage of an error boundary is probably not necessary.