### PR TITLE
feat(search): Add warning on partial results

### DIFF
--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -39,6 +39,8 @@ export interface INormalizedADSApiSearchParams {
 interface IADSApiSearchResponseHeader {
   status: number;
   params: IADSApiSearchParams;
+  QTime: number;
+  partialResults?: boolean;
 }
 
 interface IADSApiSearchResponseError {


### PR DESCRIPTION
<img width="1572" height="479" alt="image" src="https://github.com/user-attachments/assets/1c699f81-78fb-4a5c-b920-d7d9cf1a9dce" />


Updates the primary search hook to support customizing the `select` option
