### PR TITLE
Scix 567/author affiliation form doesn't load with some queries

### DIFF
--- a/src/api/author-affiliation/model.ts
+++ b/src/api/author-affiliation/model.ts
@@ -7,7 +7,7 @@ const defaultParams: IAuthorAffiliationPayload = {
 };
 
 export const getAuthorAffiliationSearchParams = (
-  params: Partial<IAuthorAffiliationPayload>,
+  params: Partial<IAuthorAffiliationPayload> = {},
 ): IAuthorAffiliationPayload => {
   return {
     ...defaultParams,

--- a/src/components/AuthorAffiliations/AffiliationControls.tsx
+++ b/src/components/AuthorAffiliations/AffiliationControls.tsx
@@ -1,0 +1,84 @@
+/** ---------- Controls (left: actions, right: selects) ---------- */
+import { ChangeEventHandler, Dispatch } from 'react';
+import { useAuthorAffStore } from '@/components/AuthorAffiliations/store';
+import { Button, Flex, FormControl, FormLabel, Select, Stack, VisuallyHidden, Wrap, WrapItem } from '@chakra-ui/react';
+import { ExportModal } from '@/components/AuthorAffiliations/ExportModal';
+import { countOptions } from '@/components/AuthorAffiliations/models';
+import { AffTableAction, AffTableState } from '@/components/AuthorAffiliations/AuthorAffiliations';
+
+export const AffiliationControls = ({
+  formState,
+  dispatch,
+}: {
+  formState: AffTableState;
+  dispatch: Dispatch<AffTableAction>;
+}) => {
+  const isDisabled = useAuthorAffStore((s) => s.isLoading || s.items.length === 0);
+  const reset = useAuthorAffStore((s) => s.reset);
+  const toggleAll = useAuthorAffStore((s) => s.toggleAll);
+
+  const handleYearChange: ChangeEventHandler<HTMLSelectElement> = (e) =>
+    dispatch({ type: 'setNumYears', payload: Number(e.currentTarget.value) });
+
+  const handleAuthorChange: ChangeEventHandler<HTMLSelectElement> = (e) =>
+    dispatch({ type: 'setMaxAuthors', payload: Number(e.currentTarget.value) });
+
+  return (
+    <section aria-labelledby="modify-form-area" id="author-affiliation-content">
+      <VisuallyHidden as="h3" id="modify-form-area">
+        Modify Form Parameters
+      </VisuallyHidden>
+
+      {/* Mobile: column; md+: row spaced */}
+      <Flex
+        mt="2"
+        mb="4"
+        direction={{ base: 'column', md: 'row' }}
+        align={{ base: 'stretch', md: 'center' }}
+        justify="space-between"
+        gap={3}
+      >
+        {/* Left: action buttons */}
+        <Stack direction="row" align="center">
+          <Button size="xs" variant="ghost" onClick={toggleAll} isDisabled={isDisabled}>
+            Toggle All
+          </Button>
+          <Button size="xs" variant="ghost" onClick={reset} isDisabled={isDisabled}>
+            Reset
+          </Button>
+          <ExportModal isDisabled={isDisabled} />
+        </Stack>
+
+        {/* Right: selects; Wrap keeps them tidy at small widths */}
+        <Wrap spacing="12px" justify={{ base: 'flex-start', md: 'flex-end' }}>
+          <WrapItem>
+            <FormControl minW="180px">
+              <FormLabel>Max Authors</FormLabel>
+              <Select onChange={handleAuthorChange} value={String(formState.maxAuthors)}>
+                {countOptions.map((count) => (
+                  <option value={count} key={count}>
+                    {count}
+                  </option>
+                ))}
+                <option value="0">All Authors</option>
+              </Select>
+            </FormControl>
+          </WrapItem>
+          <WrapItem>
+            <FormControl minW="160px">
+              <FormLabel>Years</FormLabel>
+              <Select onChange={handleYearChange} value={String(formState.numYears)}>
+                {countOptions.map((count) => (
+                  <option value={count} key={count}>
+                    {count}
+                  </option>
+                ))}
+                <option value="0">All Years</option>
+              </Select>
+            </FormControl>
+          </WrapItem>
+        </Wrap>
+      </Flex>
+    </section>
+  );
+};

--- a/src/components/AuthorAffiliations/AuthorAffiliations.tsx
+++ b/src/components/AuthorAffiliations/AuthorAffiliations.tsx
@@ -1,6 +1,5 @@
-import { useAuthorAffiliationSearch } from '@/api/author-affiliation/author-affiliation';
 import { getAuthorAffiliationSearchParams } from '@/api/author-affiliation/model';
-import { IAuthorAffiliationItem, IAuthorAffiliationPayload } from '@/api/author-affiliation/types';
+import { IAuthorAffiliationPayload } from '@/api/author-affiliation/types';
 import {
   Alert,
   AlertTitle,
@@ -8,11 +7,12 @@ import {
   BoxProps,
   Button,
   Checkbox,
+  Flex,
   FormControl,
   FormLabel,
   Heading,
   Select,
-  SkeletonText,
+  Skeleton,
   Stack,
   Table,
   TableContainer,
@@ -25,242 +25,328 @@ import {
   Tr,
   useBoolean,
   VisuallyHidden,
+  Wrap,
+  WrapItem,
 } from '@chakra-ui/react';
-import { assoc, isNil, pathOr } from 'ramda';
-import { isNilOrEmpty, isNotNilOrEmpty } from 'ramda-adjunct';
-import { ChangeEventHandler, Dispatch, ReactElement, SetStateAction, useCallback, useEffect, useState } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
-import { AuthorAffiliationsErrorMessage } from './ErrorMessage';
+import { isNil, pathOr, pluck } from 'ramda';
+import { isNotNilOrEmpty } from 'ramda-adjunct';
+import {
+  ChangeEventHandler,
+  Dispatch,
+  ReactElement,
+  Reducer,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+} from 'react';
 import { ExportModal } from './ExportModal';
 import { countOptions, NONESYMBOL } from './models';
 import { AuthorAffStoreProvider, useAuthorAffStore } from './store';
-import { IGroupedAuthorAffilationData } from './types';
 import { isIADSSearchParams } from '@/utils/common/guards';
 import { IADSApiSearchParams, IDocsEntity } from '@/api/search/types';
-import { useSearchInfinite } from '@/api/search/search';
+import { useSearch } from '@/api/search/search';
+import { useAuthorAffiliationSearch } from '@/api/author-affiliation/author-affiliation';
+import { IGroupedAuthorAffilationData } from './types';
+import { AuthorAffiliationsErrorMessage, errorMessages } from '@/components/AuthorAffiliations/ErrorMessage';
+import { parseAPIError } from '@/utils/common/parseAPIError';
+
+/** ---------- Types & constants ---------- */
+
+type AffTableState = {
+  maxAuthors: number;
+  numYears: number;
+};
+
+type AffTableAction = { type: 'setMaxAuthors'; payload: number } | { type: 'setNumYears'; payload: number };
 
 export type AuthorAffiliationsProps =
-  | (BoxProps & { params: IAuthorAffiliationPayload; query?: IADSApiSearchParams })
+  | (BoxProps & { params: IAuthorAffiliationPayload; query?: IADSApiSearchParams; ssrError?: string })
   | { params?: IAuthorAffiliationPayload; query: IADSApiSearchParams };
 
-export const AuthorAffiliations = (props: AuthorAffiliationsProps): ReactElement => {
-  const { params: initialParams, query, ...boxProps } = props;
-  const [params, setParams] = useState<IAuthorAffiliationPayload>(() =>
-    getAuthorAffiliationSearchParams(initialParams),
-  );
+const DEFAULT_PARAMS = getAuthorAffiliationSearchParams();
 
-  // get affiliations data, this depends on params.bibcode having items
-  const {
-    data: affData,
-    isLoading,
-    isError,
-    error,
-  } = useAuthorAffiliationSearch(params, {
-    enabled: !isNilOrEmpty(params.bibcode),
+/** ---------- Hooks ---------- */
+
+const useBibcodesFromQuery = (query: IADSApiSearchParams) => {
+  return useSearch(query, {
+    enabled: isIADSSearchParams(query),
     useErrorBoundary: true,
-    keepPreviousData: true,
+    select: (data) => {
+      if (isNil(data)) {
+        return [];
+      }
+      const docs = pathOr<IDocsEntity[]>([], ['response', 'docs'], data);
+      return isNotNilOrEmpty(docs) ? pluck('bibcode', docs) : [];
+    },
   });
+};
 
-  // query for bibcodes, this will only run if we weren't passed params (and we have a query)
-  const { data: queryData } = useSearchInfinite(query, {
-    enabled: isIADSSearchParams(query) && isNilOrEmpty(params.bibcode),
-    useErrorBoundary: true,
-  });
-
-  // extract the bibcodes from the search response
-  useEffect(() => {
-    if (queryData && isNilOrEmpty(params.bibcode)) {
-      setParams(
-        assoc(
-          'bibcode',
-          pathOr<IDocsEntity[]>([], ['pages', '0', 'response', 'docs'], queryData).map((d) => d.bibcode),
-        ),
-      );
+const useSubCaption = (state: AffTableState) => {
+  return useMemo(() => {
+    if (!state) {
+      return null;
     }
-  }, [queryData, params.bibcode]);
+    const { maxAuthors, numYears } = state;
+    const currentYear = new Date().getFullYear();
+    const parts: string[] = [];
+
+    if (isNotNilOrEmpty(numYears)) {
+      parts.push(numYears === 0 ? 'All years' : `From ${currentYear - numYears} to ${currentYear}`);
+    }
+    if (isNotNilOrEmpty(maxAuthors)) {
+      parts.push(`${maxAuthors === 0 ? 'All' : maxAuthors} author${maxAuthors !== 1 ? 's' : ''} from each work`);
+    }
+    return parts.join(' | ');
+  }, [state]);
+};
+
+/** ---------- Reducer ---------- */
+
+const reducer: Reducer<AffTableState, AffTableAction> = (state, action) => {
+  switch (action.type) {
+    case 'setMaxAuthors':
+      return { ...state, maxAuthors: action.payload };
+    case 'setNumYears':
+      return { ...state, numYears: action.payload };
+    default:
+      return state;
+  }
+};
+
+/** ---------- Header ---------- */
+
+const AffiliationHeader = ({ formState }: { formState: AffTableState }) => {
+  const items = useAuthorAffStore((s) => s.items);
+  const caption =
+    !items || items.length === 0
+      ? 'Author affiliations form'
+      : `Showing affiliation data for ${items.length.toLocaleString()} authors`;
+  const sub = useSubCaption(formState);
 
   return (
-    <Box {...boxProps}>
-      <ErrorBoundary FallbackComponent={AuthorAffiliationsErrorMessage}>
-        <AuthorAffStoreProvider items={affData}>
-          <AffForm
-            params={params}
-            setParams={setParams}
-            items={affData}
-            isLoading={isLoading}
-            isError={isError}
-            error={error}
-            records={pathOr<number>(0, ['pages', '0', 'response', 'docs', 'length'], queryData)}
-          />
-        </AuthorAffStoreProvider>
-      </ErrorBoundary>
-    </Box>
+    <>
+      <Heading as="h2" size="md" mt="2" id="author-affiliation-title">
+        {caption}
+      </Heading>
+      <Text color="gray.500">{sub}</Text>
+    </>
   );
 };
 
-interface IAffFormProps {
-  params: IAuthorAffiliationPayload;
-  setParams: Dispatch<SetStateAction<IAuthorAffiliationPayload>>;
-  items: IAuthorAffiliationItem[];
-  isLoading: boolean;
-  isError: boolean;
-  error: unknown;
-  records: number;
-}
-const AffForm = (props: IAffFormProps) => {
-  const setItems = useAuthorAffStore((state) => state.setItems);
-  const reset = useAuthorAffStore((state) => state.reset);
-  const toggleAll = useAuthorAffStore((state) => state.toggleAll);
-  const { params, records, setParams, isLoading } = props;
+/** ---------- Controls (left: actions, right: selects) ---------- */
 
-  // push any new items into store to reset state,
-  // this is necessary to sync incoming items with store
-  useEffect(() => setItems(props.items), [props.items]);
-  const items = useAuthorAffStore((state) => state.items);
+const AffiliationControls = ({
+  formState,
+  dispatch,
+}: {
+  formState: AffTableState;
+  dispatch: Dispatch<AffTableAction>;
+}) => {
+  const isDisabled = useAuthorAffStore((s) => s.isLoading || s.items.length === 0);
+  const reset = useAuthorAffStore((s) => s.reset);
+  const toggleAll = useAuthorAffStore((s) => s.toggleAll);
 
   const handleYearChange: ChangeEventHandler<HTMLSelectElement> = (e) =>
-    setParams(assoc('numyears', [parseInt(e.currentTarget.value, 10)]));
-  const handleAuthorChange: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    setParams(assoc('maxauthor', [parseInt(e.currentTarget.value, 10)]));
-  };
+    dispatch({ type: 'setNumYears', payload: Number(e.currentTarget.value) });
 
-  // should disable controls if loading or no items
-  const isDisabled = isLoading || items.length === 0;
+  const handleAuthorChange: ChangeEventHandler<HTMLSelectElement> = (e) =>
+    dispatch({ type: 'setMaxAuthors', payload: Number(e.currentTarget.value) });
 
   return (
-    <Box>
-      <Heading as="h2" size="md" mt="2" id="author-affiliation-title">
-        {getCaption(items?.length ?? 0, records)}
-      </Heading>
-      <Text colorScheme="grey">{getSubCaption(params)}</Text>
+    <section aria-labelledby="modify-form-area" id="author-affiliation-content">
+      <VisuallyHidden as="h3" id="modify-form-area">
+        Modify Form Parameters
+      </VisuallyHidden>
 
-      <Stack
-        spacing="2"
-        mb="4"
+      {/* Mobile: column; md+: row spaced */}
+      <Flex
         mt="2"
-        alignItems={['center', 'flex-end']}
-        flexDirection={['column-reverse', 'row']}
-        id="author-affiliation-content"
+        mb="4"
+        direction={{ base: 'column', md: 'row' }}
+        align={{ base: 'stretch', md: 'center' }}
+        justify="space-between"
+        gap={3}
       >
-        <Stack flex="1" spacing="4" direction="row" alignItems="center" mt={['2', 'auto']}>
-          {/* Form toggle buttons  */}
+        {/* Left: action buttons */}
+        <Stack direction="row" align="center">
           <Button size="xs" variant="ghost" onClick={toggleAll} isDisabled={isDisabled}>
             Toggle All
           </Button>
           <Button size="xs" variant="ghost" onClick={reset} isDisabled={isDisabled}>
             Reset
           </Button>
-
           <ExportModal isDisabled={isDisabled} />
         </Stack>
 
-        {/* main form area */}
-        <VisuallyHidden as="h3" id="modify-form-area">
-          Modify Form Parameters
-        </VisuallyHidden>
-        <Stack
-          aria-labelledby="modify-form-area"
-          display="flex"
-          flexBasis={['auto', '30%']}
-          flexDirection={['column', 'row']}
-          width={['full', 'auto']}
-          alignItems="flex-end"
-          gap="2"
-        >
-          <FormControl>
-            <FormLabel>Max Authors</FormLabel>
-            <Select onChange={handleAuthorChange} isDisabled={isDisabled} value={params.maxauthor[0]}>
-              {countOptions.map((count) => (
-                <option value={count} key={count}>
-                  {count}
-                </option>
-              ))}
-              <option value="0">all</option>
-            </Select>
-          </FormControl>
-          <FormControl>
-            <FormLabel>Years</FormLabel>
-            <Select onChange={handleYearChange} isDisabled={isDisabled} value={params.numyears[0]}>
-              {countOptions.map((count) => (
-                <option value={count} key={count}>
-                  {count}
-                </option>
-              ))}
-              <option value="0">all</option>
-            </Select>
-          </FormControl>
-        </Stack>
-      </Stack>
-      <TableContainer>
-        <Table>
-          <Thead>
+        {/* Right: selects; Wrap keeps them tidy at small widths */}
+        <Wrap spacing="12px" justify={{ base: 'flex-start', md: 'flex-end' }}>
+          <WrapItem>
+            <FormControl minW="180px">
+              <FormLabel>Max Authors</FormLabel>
+              <Select onChange={handleAuthorChange} value={String(formState.maxAuthors)}>
+                {countOptions.map((count) => (
+                  <option value={count} key={count}>
+                    {count}
+                  </option>
+                ))}
+                <option value="0">All Authors</option>
+              </Select>
+            </FormControl>
+          </WrapItem>
+          <WrapItem>
+            <FormControl minW="160px">
+              <FormLabel>Years</FormLabel>
+              <Select onChange={handleYearChange} value={String(formState.numYears)}>
+                {countOptions.map((count) => (
+                  <option value={count} key={count}>
+                    {count}
+                  </option>
+                ))}
+                <option value="0">All Years</option>
+              </Select>
+            </FormControl>
+          </WrapItem>
+        </Wrap>
+      </Flex>
+    </section>
+  );
+};
+
+const useFetchAffData = (query: IADSApiSearchParams, formState: AffTableState) => {
+  const setItems = useAuthorAffStore((s) => s.setItems);
+  const setIsLoading = useAuthorAffStore((s) => s.setIsLoading);
+
+  const { data: bibcode } = useBibcodesFromQuery(query);
+
+  const {
+    data: items,
+    isLoading,
+    error,
+    isError,
+  } = useAuthorAffiliationSearch(
+    getAuthorAffiliationSearchParams({ maxauthor: [formState.maxAuthors], numyears: [formState.numYears], bibcode }),
+    { enabled: isNotNilOrEmpty(bibcode) },
+  );
+
+  useEffect(() => {
+    setIsLoading(isLoading);
+  }, [isLoading, setIsLoading]);
+  useEffect(() => {
+    if (isNotNilOrEmpty(items)) {
+      setItems(items);
+    }
+  }, [items, setItems]);
+
+  return { isLoading, error, isError };
+};
+
+/** ---------- Table ---------- */
+
+const AffiliationTable = (props: { query: IADSApiSearchParams; formState: AffTableState }) => {
+  const { query, formState } = props;
+  const { isLoading, error, isError } = useFetchAffData(query, formState);
+  const items = useAuthorAffStore((s) => s.items);
+
+  if (isError && parseAPIError(error) !== errorMessages.noResults) {
+    return <AuthorAffiliationsErrorMessage error={error} />;
+  }
+
+  return (
+    <TableContainer>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th>#</Th>
+            <Th>Author</Th>
+            <Th>Affiliation(s)</Th>
+            <Th>Year(s)</Th>
+            <Th>Last Active Date(s)</Th>
+          </Tr>
+        </Thead>
+        <Tbody data-testid="author-aff-table-body">
+          {isLoading ? (
+            <SkeletonTableRows />
+          ) : items.length === 0 ? (
             <Tr>
-              <Th>#</Th>
-              <Th>Author</Th>
-              <Th>Affiliation(s)</Th>
-              <Th>Year(s)</Th>
-              <Th>Last Active Date(s)</Th>
+              <Td colSpan={5}>
+                <Alert status="warning" justifyContent="center">
+                  <AlertTitle>No affiliation data to display, please refine your search</AlertTitle>
+                </Alert>
+              </Td>
             </Tr>
-          </Thead>
-          <Tbody data-testid="author-aff-table-body">
-            {isLoading ? (
-              <SkeletonTableRows />
-            ) : items.length === 0 ? (
-              <Tr>
-                <Td colSpan={5}>
-                  <Alert status="warning" justifyContent="center">
-                    <AlertTitle>No affiliation data to display</AlertTitle>
-                  </Alert>
-                </Td>
-              </Tr>
-            ) : (
-              items.map((ctx, idx) => <Row context={ctx} key={`${ctx.authorName}_${idx}`} idx={idx + 1} />)
-            )}
-          </Tbody>
-        </Table>
-      </TableContainer>
+          ) : (
+            items.map((ctx, idx) => <Row context={ctx} key={`${ctx.authorName}_${idx}`} idx={idx + 1} />)
+          )}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+/** ---------- Root ---------- */
+
+export const AuthorAffiliations = (props: AuthorAffiliationsProps): ReactElement => {
+  const { query, ...boxProps } = props as { query: IADSApiSearchParams } & BoxProps;
+
+  const [formState, dispatch] = useReducer(reducer, {
+    maxAuthors: DEFAULT_PARAMS.maxauthor[0],
+    numYears: DEFAULT_PARAMS.numyears[0],
+  });
+
+  return (
+    <Box {...boxProps}>
+      <AuthorAffStoreProvider items={[]} isLoading={true}>
+        <AffiliationHeader formState={formState} />
+        <AffiliationControls formState={formState} dispatch={dispatch} />
+        <AffiliationTable formState={formState} query={query} />
+      </AuthorAffStoreProvider>
     </Box>
   );
 };
 
+/** ---------- Skeleton Rows ---------- */
+
 const SkeletonTableRows = () => {
   return (
     <>
-      <Tr my="2">
-        <Td colSpan={5}>
-          <SkeletonText h="8" />
-        </Td>
-      </Tr>
-      <Tr my="2">
-        <Td colSpan={5}>
-          <SkeletonText h="8" />
-        </Td>
-      </Tr>
-      <Tr my="2">
-        <Td colSpan={5}>
-          <SkeletonText h="8" />
-        </Td>
-      </Tr>
-      <Tr my="2">
-        <Td colSpan={5}>
-          <SkeletonText h="8" />
-        </Td>
-      </Tr>
+      {[0, 1, 2, 3].map((i) => (
+        <Tr key={i}>
+          <Td>{i + 1}</Td>
+          <Td>
+            <Skeleton h="3" w="20" />
+          </Td>
+          <Td>
+            <Skeleton h="3" w="20" />
+          </Td>
+          <Td>
+            <Skeleton h="3" w="40" />
+          </Td>
+          <Td>
+            <Skeleton h="3" w="20" />
+          </Td>
+        </Tr>
+      ))}
     </>
   );
 };
 
+/** ---------- Data Row ---------- */
+
 const Row = (props: { context: IGroupedAuthorAffilationData; idx: number }) => {
   const { context: ctx, idx } = props;
 
-  // focused state to style the whole row
   const [isFocused, setIsFocused] = useBoolean(false);
 
-  const state = useAuthorAffStore(useCallback((state) => state.getSelectionState(ctx.authorName), [ctx.authorName]));
-  const selectDate = useAuthorAffStore((state) => state.selectDate);
-  const toggle = useAuthorAffStore((state) => state.toggle);
-  const toggleAff = useAuthorAffStore((state) => state.toggleAff);
-  const getHandler = useCallback((idx: number) => () => toggleAff(ctx.authorName, idx), [ctx.authorName]);
+  const state = useAuthorAffStore(useCallback((s) => s.getSelectionState(ctx.authorName), [ctx.authorName]));
+  const selectDate = useAuthorAffStore((s) => s.selectDate);
+  const toggle = useAuthorAffStore((s) => s.toggle);
+  const toggleAff = useAuthorAffStore((s) => s.toggleAff);
+
+  const getHandler = useCallback(
+    (affIdx: number) => () => toggleAff(ctx.authorName, affIdx),
+    [ctx.authorName, toggleAff],
+  );
 
   return (
     <Tr onFocus={setIsFocused.on} onBlur={setIsFocused.off} border={isFocused ? `2px solid blue` : `none`}>
@@ -281,12 +367,12 @@ const Row = (props: { context: IGroupedAuthorAffilationData; idx: number }) => {
         </Checkbox>
       </Td>
       <Td>
-        <Stack dir="column">
-          {ctx.affiliations.map((aff, idx) => (
+        <Stack direction="column">
+          {ctx.affiliations.map((aff, i) => (
             <Checkbox
-              key={`aff_${aff}_${idx}`}
-              isChecked={state.affSelected.includes(idx)}
-              onChange={getHandler(idx)}
+              key={`aff_${aff}_${i}`}
+              isChecked={state.affSelected.includes(i)}
+              onChange={getHandler(i)}
               isDisabled={!state.selected}
               onFocus={setIsFocused.on}
               onBlur={setIsFocused.off}
@@ -301,11 +387,11 @@ const Row = (props: { context: IGroupedAuthorAffilationData; idx: number }) => {
         </Stack>
       </Td>
       <Td>
-        <Stack as="ul" dir="column" spacing="2">
-          {ctx.years.map((years, idx) => (
-            <li key={`years_${years.join(',')}_${idx}`}>
+        <Stack as="ul" direction="column" spacing="2">
+          {ctx.years.map((years, i) => (
+            <li key={`years_${years.join(',')}_${i}`}>
               <Tooltip label={years.join(', ')} aria-label={years.join(', ')}>
-                <Text isTruncated width="24">
+                <Text isTruncated w="24">
                   {years.join(', ')}
                 </Text>
               </Tooltip>
@@ -314,61 +400,29 @@ const Row = (props: { context: IGroupedAuthorAffilationData; idx: number }) => {
         </Stack>
       </Td>
       <Td>
-        <>
-          <VisuallyHidden as="label" htmlFor={`${ctx.authorName}-last_active_date_select`}>
-            Select last active date
-          </VisuallyHidden>
-          {ctx.lastActiveDate.length === 1 ? (
-            <Text>{ctx.lastActiveDate}</Text>
-          ) : (
-            <Select
-              value={state.dateSelected}
-              onChange={(e) => selectDate(ctx.authorName, e.currentTarget.value)}
-              id={`${ctx.authorName}-last_active_date_select`}
-              isDisabled={!state.selected}
-              size="xs"
-              onFocus={setIsFocused.on}
-              onBlur={setIsFocused.off}
-            >
-              {ctx.lastActiveDate.map((date, idx) => (
-                <option key={`lastactivedate_${date}_${idx}`} value={date}>
-                  {date}
-                </option>
-              ))}
-            </Select>
-          )}
-        </>
+        <VisuallyHidden as="label" htmlFor={`${ctx.authorName}-last_active_date_select`}>
+          Select last active date
+        </VisuallyHidden>
+        {ctx.lastActiveDate.length === 1 ? (
+          <Text>{ctx.lastActiveDate[0]}</Text>
+        ) : (
+          <Select
+            value={state.dateSelected}
+            onChange={(e) => selectDate(ctx.authorName, e.currentTarget.value)}
+            id={`${ctx.authorName}-last_active_date_select`}
+            isDisabled={!state.selected}
+            size="xs"
+            onFocus={setIsFocused.on}
+            onBlur={setIsFocused.off}
+          >
+            {ctx.lastActiveDate.map((date, i) => (
+              <option key={`lastactivedate_${date}_${i}`} value={date}>
+                {date}
+              </option>
+            ))}
+          </Select>
+        )}
       </Td>
     </Tr>
   );
-};
-
-const getSubCaption = (params: IAuthorAffiliationPayload) => {
-  const currentYear = new Date().getFullYear();
-  const out = [];
-
-  if (isNil(params)) {
-    return null;
-  }
-
-  if (isNotNilOrEmpty(params.numyears)) {
-    out.push(params.numyears[0] === 0 ? `All years` : `From ${currentYear - params.numyears[0]} to ${currentYear}`);
-  }
-
-  if (isNotNilOrEmpty(params.maxauthor)) {
-    out.push(
-      `${params.maxauthor[0] === 0 ? 'All' : params.maxauthor[0]} author${
-        params.maxauthor[0] !== 1 ? 's' : ''
-      } from each work`,
-    );
-  }
-
-  return out.join(' | ');
-};
-
-const getCaption = (numAuthors: number, numRecords = 0) => {
-  if (isNil(numAuthors) || numAuthors <= 0) {
-    return 'Author affiliations form';
-  }
-  return `Showing affiliation data for ${numAuthors.toLocaleString()} authors (${numRecords} works)`;
 };

--- a/src/components/AuthorAffiliations/ErrorMessage.tsx
+++ b/src/components/AuthorAffiliations/ErrorMessage.tsx
@@ -19,9 +19,9 @@ const defaultTitle = 'Sorry, we were unable to generate the affiliations form';
 const getMessage = (error: string) => {
   switch (error) {
     case errorMessages.noBibcodeSubmitted:
-      return "No records we're sent, try going back to the search results and re-generating this form.";
+      return "No records were sent, try going back to the search results and re-generating this form.";
     case errorMessages.noResults:
-      return 'No results were found for this query, Try expanding the year range or the number of authors.';
+      return 'No results were found for this query, try expanding the year range or the number of authors.';
     default:
       return 'Please try reloading the page to see if the error persists.';
   }

--- a/src/components/AuthorAffiliations/ErrorMessage.tsx
+++ b/src/components/AuthorAffiliations/ErrorMessage.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertDescription, AlertIcon, AlertTitle, Button } from '@chakra-ui/react';
+import { Alert, AlertDescription, AlertIcon, AlertTitle, Box, Button, Center } from '@chakra-ui/react';
 import { FallbackProps } from 'react-error-boundary';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 
@@ -19,11 +19,11 @@ const defaultTitle = 'Sorry, we were unable to generate the affiliations form';
 const getMessage = (error: string) => {
   switch (error) {
     case errorMessages.noBibcodeSubmitted:
-      return "No records we're sent, try going back to the search results and re-generating this form";
+      return "No records we're sent, try going back to the search results and re-generating this form.";
     case errorMessages.noResults:
-      return "No results we're found for this query, try going back to the search results and re-generating this form";
+      return 'No results were found for this query, Try expanding the year range or the number of authors.';
     default:
-      return 'Please try reloading the page to see if the error persists';
+      return 'Please try reloading the page to see if the error persists.';
   }
 };
 
@@ -38,17 +38,19 @@ export const AuthorAffiliationsErrorMessage = (
   const error = typeof props.error === 'string' ? props.error : parseAPIError(props.error);
 
   return (
-    <Alert status="error" maxW="container.sm" flexWrap="wrap" justifyContent="center">
-      <AlertIcon />
-      <AlertTitle>{title}</AlertTitle>
-      <AlertDescription>
-        {getMessage(error)}.
-        {resetErrorBoundary ? (
-          <Button variant="link" onClick={resetErrorBoundary}>
-            Or try again
-          </Button>
-        ) : null}
-      </AlertDescription>
-    </Alert>
+    <Center m="6">
+      <Alert status="error" maxW="container.sm" flexWrap="wrap" justifyContent="center" borderRadius="md">
+        <AlertIcon />
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>
+          <Box my="2">{getMessage(error)}</Box>
+          {resetErrorBoundary ? (
+            <Button variant="link" onClick={resetErrorBoundary}>
+              Or try again
+            </Button>
+          ) : null}
+        </AlertDescription>
+      </Alert>
+    </Center>
   );
 };

--- a/src/components/AuthorAffiliations/ExportModal.tsx
+++ b/src/components/AuthorAffiliations/ExportModal.tsx
@@ -19,7 +19,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { exportTypes } from './models';
-import { useExportModal } from './useExportModal';
+import { useExportModal } from './hooks/useExportModal';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { SimpleLink } from '@/components/SimpleLink';
 
@@ -52,7 +52,7 @@ export const ExportModal = (props: ButtonProps) => {
         <ModalContent>
           <ModalCloseButton />
           <ModalHeader>
-            Exporting {numSelected} entrie{numSelected > 1 ? 's' : ''}
+            Exporting {numSelected.toLocaleString()} entr{numSelected > 1 ? 'ies' : 'y'}
           </ModalHeader>
           <ModalBody>
             <FormLabel htmlFor="export-selection">Select export format</FormLabel>
@@ -66,7 +66,7 @@ export const ExportModal = (props: ButtonProps) => {
               </Stack>
             </RadioGroup>
             <Button onClick={onFetch} mt="2" width="full" isLoading={isLoading} isDisabled={isError || noData}>
-              Export to file
+              Export
             </Button>
             {noData ? (
               <Alert status="warning" mt="2">

--- a/src/components/AuthorAffiliations/ExportModal.tsx
+++ b/src/components/AuthorAffiliations/ExportModal.tsx
@@ -18,7 +18,6 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react';
-import { useEffect } from 'react';
 import { exportTypes } from './models';
 import { useExportModal } from './useExportModal';
 import { parseAPIError } from '@/utils/common/parseAPIError';
@@ -31,7 +30,6 @@ export const ExportModal = (props: ButtonProps) => {
   const {
     isLoading,
     format,
-    onDone,
     onFetch,
     onFormatChange,
     numSelected,
@@ -43,13 +41,6 @@ export const ExportModal = (props: ButtonProps) => {
   } = useExportModal({
     enabled: isOpen,
   });
-
-  useEffect(() => {
-    if (!isOpen) {
-      // if modal closes unexpectedly, this will make sure the state gets reset
-      onDone();
-    }
-  }, [isOpen, onDone]);
 
   return (
     <>

--- a/src/components/AuthorAffiliations/__tests__/AuthorAffiliationsErrorMessage.test.tsx
+++ b/src/components/AuthorAffiliations/__tests__/AuthorAffiliationsErrorMessage.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@/test-utils';
+import { expect, test, vi } from 'vitest';
+
+// SUT
+import { AuthorAffiliationsErrorMessage, errorMessages } from '../ErrorMessage';
+
+// Mock parseAPIError so we control message mapping
+vi.mock('@/utils/common/parseAPIError', () => ({
+  parseAPIError: (e: unknown) => (typeof e === 'string' ? e : 'Unknown Server Error'),
+}));
+
+test('renders default title and generic message', () => {
+  const { getByText } = render(<AuthorAffiliationsErrorMessage error={'something unknown'} />);
+  expect(getByText('Sorry, we were unable to generate the affiliations form')).toBeTruthy();
+  expect(getByText('Please try reloading the page to see if the error persists.')).toBeTruthy();
+});
+
+test('shows custom title when provided', () => {
+  const { getByText } = render(<AuthorAffiliationsErrorMessage title="Custom Title" error={'something unknown'} />);
+  expect(getByText('Custom Title')).toBeTruthy();
+});
+
+test('maps specific messages: noResults', () => {
+  const { getByText } = render(<AuthorAffiliationsErrorMessage error={errorMessages.noResults} />);
+  expect(getByText(/No results were found for this query/i)).toBeTruthy();
+});
+
+test('shows retry button when resetErrorBoundary is provided', async () => {
+  const reset = vi.fn();
+  const { user, getByRole } = render(<AuthorAffiliationsErrorMessage error={'x'} resetErrorBoundary={reset} />);
+  await user.click(getByRole('button', { name: /try again/i }));
+  expect(reset).toHaveBeenCalled();
+});

--- a/src/components/AuthorAffiliations/helpers.ts
+++ b/src/components/AuthorAffiliations/helpers.ts
@@ -12,7 +12,7 @@ import {
   mapObjIndexed,
   not,
   over,
-  path,
+  pathOr,
   prop,
   propEq,
   set,
@@ -26,9 +26,9 @@ import { AuthorAffSelectionState, IGroupedAuthorAffilationData } from './types';
 
 // accessors
 const authorName = prop('authorName');
-const name = path<string>(['affiliations', 'name']);
-const years = path<string[]>(['affiliations', 'years']);
-const lastActiveDate = path<string>(['affiliations', 'lastActiveDate']);
+const name = pathOr<string>(NONESYMBOL, ['affiliations', 'name']);
+const years = pathOr<string[]>([], ['affiliations', 'years']);
+const lastActiveDate = pathOr<string>(NONESYMBOL, ['affiliations', 'lastActiveDate']);
 
 /**
  * @note

--- a/src/components/AuthorAffiliations/hooks/UseBibcodesFromQuery.tsx
+++ b/src/components/AuthorAffiliations/hooks/UseBibcodesFromQuery.tsx
@@ -1,0 +1,20 @@
+/** ---------- Hooks ---------- */
+import { IADSApiSearchParams, IDocsEntity } from '@/api/search/types';
+import { useSearch } from '@/api/search/search';
+import { isIADSSearchParams } from '@/utils/common/guards';
+import { isNil, pathOr, pluck } from 'ramda';
+import { isNotNilOrEmpty } from 'ramda-adjunct';
+
+export const useBibcodesFromQuery = (query: IADSApiSearchParams) => {
+  return useSearch(query, {
+    enabled: isIADSSearchParams(query),
+    useErrorBoundary: true,
+    select: (data) => {
+      if (isNil(data)) {
+        return [];
+      }
+      const docs = pathOr<IDocsEntity[]>([], ['response', 'docs'], data);
+      return isNotNilOrEmpty(docs) ? pluck('bibcode', docs) : [];
+    },
+  });
+};

--- a/src/components/AuthorAffiliations/hooks/UseFetchAffData.tsx
+++ b/src/components/AuthorAffiliations/hooks/UseFetchAffData.tsx
@@ -1,0 +1,44 @@
+import { IADSApiSearchParams } from '@/api/search/types';
+import { useAuthorAffStore } from '@/components/AuthorAffiliations/store';
+import { useAuthorAffiliationSearch } from '@/api/author-affiliation/author-affiliation';
+import { getAuthorAffiliationSearchParams } from '@/api/author-affiliation/model';
+import { isNotNilOrEmpty } from 'ramda-adjunct';
+import { useEffect } from 'react';
+import { parseAPIError } from '@/utils/common/parseAPIError';
+import { errorMessages } from '@/components/AuthorAffiliations/ErrorMessage';
+import { useBibcodesFromQuery } from '@/components/AuthorAffiliations/hooks/UseBibcodesFromQuery';
+import { AffTableState } from '@/components/AuthorAffiliations';
+
+export const useFetchAffData = (query: IADSApiSearchParams, formState: AffTableState) => {
+  const setItems = useAuthorAffStore((s) => s.setItems);
+  const setIsLoading = useAuthorAffStore((s) => s.setIsLoading);
+
+  const { data: bibcode } = useBibcodesFromQuery(query);
+
+  const {
+    data: items,
+    isLoading,
+    error,
+    isError,
+  } = useAuthorAffiliationSearch(
+    getAuthorAffiliationSearchParams({ maxauthor: [formState.maxAuthors], numyears: [formState.numYears], bibcode }),
+    { enabled: isNotNilOrEmpty(bibcode) },
+  );
+
+  // sync store with query result
+  useEffect(() => {
+    setIsLoading(isLoading);
+  }, [isLoading, setIsLoading]);
+
+  useEffect(() => {
+    if (isNotNilOrEmpty(items)) {
+      setItems(items);
+
+      // TODO: (refactor) this will be unnecessary when the service returns empty array instead of error
+    } else if (isError && parseAPIError(error) === errorMessages.noResults) {
+      setItems([]);
+    }
+  }, [error, isError, items, setItems]);
+
+  return { isLoading, error, isError };
+};

--- a/src/components/AuthorAffiliations/hooks/UseSubCaption.tsx
+++ b/src/components/AuthorAffiliations/hooks/UseSubCaption.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { isNotNilOrEmpty } from 'ramda-adjunct';
+import { AffTableState } from '@/components/AuthorAffiliations/AuthorAffiliations';
+
+export const useSubCaption = (state: AffTableState) => {
+  return useMemo(() => {
+    if (!state) {
+      return null;
+    }
+    const { maxAuthors, numYears } = state;
+    const currentYear = new Date().getFullYear();
+    const parts: string[] = [];
+
+    if (numYears !== null && numYears !== undefined) {
+      parts.push(numYears === 0 ? 'All years' : `From ${currentYear - numYears} to ${currentYear}`);
+    }
+    if (maxAuthors !== null && maxAuthors !== undefined) {
+      parts.push(`${maxAuthors === 0 ? 'All' : maxAuthors} author${maxAuthors !== 1 ? 's' : ''} from each work`);
+    }
+    return parts.join(' | ');
+  }, [state]);
+};

--- a/src/components/AuthorAffiliations/hooks/useExportModal.ts
+++ b/src/components/AuthorAffiliations/hooks/useExportModal.ts
@@ -2,14 +2,14 @@ import { authorAffiliationsKeys, useAuthorAffiliationExport } from '@/api/author
 import { mergeLeft } from 'ramda';
 import { Reducer, useEffect, useReducer } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { exportTypeFileMappings, exportTypes } from './models';
-import { IAuthorAffState, useAuthorAffStore } from './store';
+import { exportTypeFileMappings, exportTypes } from '../models';
+import { IAuthorAffState, useAuthorAffStore } from '../store';
 import { FileType, useDownloadFile } from '@/lib/useDownloadFile';
 
 interface IExportModalState {
   mode: 'SELECTING' | 'EXPORTING' | 'DOWNLOADING';
   type: FileType;
-  format: typeof exportTypes[number];
+  format: (typeof exportTypes)[number];
   selected: string[];
 }
 
@@ -21,7 +21,7 @@ const initialState: IExportModalState = {
 };
 
 type Action =
-  | { type: 'SET_FORMAT'; format: typeof exportTypes[number] }
+  | { type: 'SET_FORMAT'; format: (typeof exportTypes)[number] }
   | { type: 'SET_SELECTED'; selected: string[] }
   | { type: 'EXPORT' }
   | { type: 'DATA' }
@@ -70,13 +70,10 @@ export const useExportModal = (props: { enabled: boolean }) => {
   // update state when the hook gets enabled (i.e. modal opened up)
   useEffect(() => {
     dispatch({ type: 'SET_SELECTED', selected: getFormattedSelection() });
-  }, [enabled]);
+  }, [enabled, getFormattedSelection]);
 
   const { data, error, isError } = useAuthorAffiliationExport(
-    {
-      selected: state.selected,
-      format: state.format,
-    },
+    { selected: state.selected, format: state.format },
     { enabled: state.mode === 'EXPORTING' && state.selected.length > 0 },
   );
 
@@ -95,7 +92,7 @@ export const useExportModal = (props: { enabled: boolean }) => {
         dispatch({ type: 'DATA' });
       }
     }
-  }, [data, state.selected, state.format, state.mode]);
+  }, [data, state.selected, state.format, state.mode, qc]);
 
   // update state if we receive data, or error
   useEffect(() => {
@@ -118,14 +115,14 @@ export const useExportModal = (props: { enabled: boolean }) => {
     if (state.mode === 'DOWNLOADING') {
       onDownload();
     }
-  }, [state.mode]);
+  }, [onDownload, state.mode]);
 
   return {
     isLoading: state.mode === 'EXPORTING' || state.mode === 'DOWNLOADING',
     onDone: () => dispatch({ type: 'DONE' }),
     format: state.format,
     onFetch: () => dispatch({ type: 'EXPORT' }),
-    onFormatChange: (format: typeof exportTypes[number]) => dispatch({ type: 'SET_FORMAT', format }),
+    onFormatChange: (format: (typeof exportTypes)[number]) => dispatch({ type: 'SET_FORMAT', format }),
     downloadLink: linkHref,
     downloadFilename: filename,
     isError,

--- a/src/components/AuthorAffiliations/index.ts
+++ b/src/components/AuthorAffiliations/index.ts
@@ -1,2 +1,4 @@
 export * from './AuthorAffiliations';
 export * from './ErrorMessage';
+export { AffiliationControls } from '@/components/AuthorAffiliations/AffiliationControls';
+export { useSubCaption } from '@/components/AuthorAffiliations/hooks/UseSubCaption';

--- a/src/components/AuthorAffiliations/types.ts
+++ b/src/components/AuthorAffiliations/types.ts
@@ -8,9 +8,9 @@ export interface IGroupedAuthorAffilationData {
 }
 
 export interface IFormState {
-  exportType: typeof exportTypes[number];
-  authorCount: typeof countOptions[number];
-  yearCount: typeof countOptions[number];
+  exportType: (typeof exportTypes)[number];
+  authorCount: (typeof countOptions)[number];
+  yearCount: (typeof countOptions)[number];
 }
 
 export type AuthorAffSelectionState = Record<

--- a/src/pages/search/authoraffiliations.tsx
+++ b/src/pages/search/authoraffiliations.tsx
@@ -2,11 +2,9 @@ import { ChevronLeftIcon } from '@chakra-ui/icons';
 import { Button, Container as Box } from '@chakra-ui/react';
 import { useBackToSearchResults } from '@/lib/useBackToSearchResults';
 import { NextPage } from 'next';
-import { logger } from '@/logger';
 import { AuthorAffiliations, AuthorAffiliationsErrorMessage } from '@/components/AuthorAffiliations';
 import { SimpleLink } from '@/components/SimpleLink';
 import { parseQueryFromUrl } from '@/utils/common/search';
-import { parseAPIError } from '@/utils/common/parseAPIError';
 import { useRouter } from 'next/router';
 import { IADSApiSearchParams } from '@/api/search/types';
 import { APP_DEFAULTS } from '@/config';
@@ -43,79 +41,3 @@ const AuthorAffiliationsPage: NextPage = () => {
 };
 
 export default AuthorAffiliationsPage;
-
-// export const getServerSideProps = composeNextGSSP(async (ctx) => {
-//   const {
-//     qid = null,
-//     p,
-//     format,
-//     ...query
-//   } = parseQueryFromUrl<{ qid: string; format: string }>(ctx.req.url, { sortPostfix: 'id asc' });
-//
-//   if (!query && !qid) {
-//     return {
-//       props: {
-//         error: 'No Records',
-//       },
-//     };
-//   }
-//
-//   const queryClient = new QueryClient();
-//   const params: IADSApiSearchParams = {
-//     rows: APP_DEFAULTS.AUTHOR_AFF_SEARCH_SIZE,
-//     fl: ['bibcode'],
-//     sort: APP_DEFAULTS.SORT,
-//     ...(qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query),
-//   };
-//
-//   try {
-//     // primary search, this is based on query params
-//     const data = await queryClient.fetchInfiniteQuery({
-//       queryKey: searchKeys.infinite(params),
-//       queryFn: fetchSearchInfinite,
-//       meta: { params },
-//     });
-//
-//     const authorAffiliationParams = getAuthorAffiliationSearchParams({
-//       bibcode: data.pages[0].response.docs.map((d) => d.bibcode),
-//     });
-//
-//     try {
-//       void (await queryClient.fetchQuery({
-//         queryKey: authorAffiliationsKeys.search(authorAffiliationParams),
-//         queryFn: fetchAuthorAffiliationSearch,
-//         meta: { params: authorAffiliationParams },
-//       }));
-//
-//       // react-query infinite queries cannot be serialized by next, currently.
-//       // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
-//
-//       const dehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
-//
-//       return {
-//         props: {
-//           params: authorAffiliationParams,
-//           query: params,
-//           dehydratedState,
-//         },
-//       };
-//     } catch (error) {
-//       logger.error({ msg: 'GSSP error on author affiliations form', error });
-//       return {
-//         props: {
-//           params: authorAffiliationParams,
-//           query: params,
-//           error: parseAPIError(error),
-//         },
-//       };
-//     }
-//   } catch (e) {
-//     logger.error({ msg: 'GSSP error on search for author affiliations form', error: e });
-//     return {
-//       props: {
-//         query: params,
-//         error: parseAPIError(e),
-//       },
-//     };
-//   }
-// });

--- a/src/pages/search/authoraffiliations.tsx
+++ b/src/pages/search/authoraffiliations.tsx
@@ -1,35 +1,29 @@
-import { authorAffiliationsKeys, fetchAuthorAffiliationSearch } from '@/api/author-affiliation/author-affiliation';
-import { getAuthorAffiliationSearchParams } from '@/api/author-affiliation/model';
-import { IAuthorAffiliationPayload } from '@/api/author-affiliation/types';
 import { ChevronLeftIcon } from '@chakra-ui/icons';
 import { Button, Container as Box } from '@chakra-ui/react';
-
-import { APP_DEFAULTS } from '@/config';
 import { useBackToSearchResults } from '@/lib/useBackToSearchResults';
-import { composeNextGSSP } from '@/ssr-utils';
 import { NextPage } from 'next';
-import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { logger } from '@/logger';
 import { AuthorAffiliations, AuthorAffiliationsErrorMessage } from '@/components/AuthorAffiliations';
 import { SimpleLink } from '@/components/SimpleLink';
 import { parseQueryFromUrl } from '@/utils/common/search';
 import { parseAPIError } from '@/utils/common/parseAPIError';
+import { useRouter } from 'next/router';
 import { IADSApiSearchParams } from '@/api/search/types';
-import { fetchSearchInfinite, searchKeys } from '@/api/search/search';
+import { APP_DEFAULTS } from '@/config';
+import { ErrorBoundary } from 'react-error-boundary';
 
-interface IAuthorAffilationsPageProps {
-  error?: string;
-  query?: IADSApiSearchParams;
-  params?: IAuthorAffiliationPayload;
-}
-
-const AuthorAffiliationsPage: NextPage<IAuthorAffilationsPageProps> = (props) => {
-  const { error, query, params } = props;
+const AuthorAffiliationsPage: NextPage = () => {
   const { getSearchHref, show: showBackLink } = useBackToSearchResults();
-
-  if (error) {
-    return <AuthorAffiliationsErrorMessage error={new Error(error)} />;
-  }
+  const router = useRouter();
+  const { qid, ...query } = parseQueryFromUrl<{ qid: string; format: string }>(router.asPath, {
+    sortPostfix: 'id asc',
+  });
+  const searchParams: IADSApiSearchParams = {
+    rows: APP_DEFAULTS.AUTHOR_AFF_SEARCH_SIZE,
+    fl: ['bibcode'],
+    sort: APP_DEFAULTS.SORT,
+    ...(qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query),
+  };
 
   return (
     <>
@@ -39,8 +33,10 @@ const AuthorAffiliationsPage: NextPage<IAuthorAffilationsPageProps> = (props) =>
         </Button>
       )}
 
-      <Box as="section" maxW="container.xl" mt={showBackLink ? 0 : 4} mb="4" centerContent>
-        <AuthorAffiliations params={params} query={query} w="full" maxW="container.lg" />
+      <Box as="section" maxW="container.xl" mt={showBackLink ? 0 : 4} mb="8" centerContent>
+        <ErrorBoundary FallbackComponent={AuthorAffiliationsErrorMessage}>
+          <AuthorAffiliations query={searchParams} w="full" maxW="container.lg" />
+        </ErrorBoundary>
       </Box>
     </>
   );
@@ -48,66 +44,78 @@ const AuthorAffiliationsPage: NextPage<IAuthorAffilationsPageProps> = (props) =>
 
 export default AuthorAffiliationsPage;
 
-export const getServerSideProps = composeNextGSSP(async (ctx) => {
-  const {
-    qid = null,
-    p,
-    format,
-    ...query
-  } = parseQueryFromUrl<{ qid: string; format: string }>(ctx.req.url, { sortPostfix: 'id asc' });
-
-  if (!query && !qid) {
-    return {
-      props: {
-        error: 'No Records',
-      },
-    };
-  }
-
-  const queryClient = new QueryClient();
-  const params: IADSApiSearchParams = {
-    rows: APP_DEFAULTS.AUTHOR_AFF_SEARCH_SIZE,
-    fl: ['bibcode'],
-    sort: APP_DEFAULTS.SORT,
-    ...(qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query),
-  };
-
-  try {
-    // primary search, this is based on query params
-    const data = await queryClient.fetchInfiniteQuery({
-      queryKey: searchKeys.infinite(params),
-      queryFn: fetchSearchInfinite,
-      meta: { params },
-    });
-
-    const authorAffiliationParams = getAuthorAffiliationSearchParams({
-      bibcode: data.pages[0].response.docs.map((d) => d.bibcode),
-    });
-    void (await queryClient.fetchQuery({
-      queryKey: authorAffiliationsKeys.search(authorAffiliationParams),
-      queryFn: fetchAuthorAffiliationSearch,
-      meta: { params: authorAffiliationParams },
-    }));
-
-    // react-query infinite queries cannot be serialized by next, currently.
-    // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
-
-    const dehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
-
-    return {
-      props: {
-        params: authorAffiliationParams,
-        query: params,
-        dehydratedState,
-      },
-    };
-  } catch (error) {
-    logger.error({ msg: 'GSSP error on author affiliations form', error });
-    return {
-      props: {
-        query: params,
-        error: parseAPIError(error),
-      },
-    };
-  }
-});
+// export const getServerSideProps = composeNextGSSP(async (ctx) => {
+//   const {
+//     qid = null,
+//     p,
+//     format,
+//     ...query
+//   } = parseQueryFromUrl<{ qid: string; format: string }>(ctx.req.url, { sortPostfix: 'id asc' });
+//
+//   if (!query && !qid) {
+//     return {
+//       props: {
+//         error: 'No Records',
+//       },
+//     };
+//   }
+//
+//   const queryClient = new QueryClient();
+//   const params: IADSApiSearchParams = {
+//     rows: APP_DEFAULTS.AUTHOR_AFF_SEARCH_SIZE,
+//     fl: ['bibcode'],
+//     sort: APP_DEFAULTS.SORT,
+//     ...(qid ? { q: `docs(${qid})`, sort: ['id asc'] } : query),
+//   };
+//
+//   try {
+//     // primary search, this is based on query params
+//     const data = await queryClient.fetchInfiniteQuery({
+//       queryKey: searchKeys.infinite(params),
+//       queryFn: fetchSearchInfinite,
+//       meta: { params },
+//     });
+//
+//     const authorAffiliationParams = getAuthorAffiliationSearchParams({
+//       bibcode: data.pages[0].response.docs.map((d) => d.bibcode),
+//     });
+//
+//     try {
+//       void (await queryClient.fetchQuery({
+//         queryKey: authorAffiliationsKeys.search(authorAffiliationParams),
+//         queryFn: fetchAuthorAffiliationSearch,
+//         meta: { params: authorAffiliationParams },
+//       }));
+//
+//       // react-query infinite queries cannot be serialized by next, currently.
+//       // see https://github.com/tannerlinsley/react-query/issues/3301#issuecomment-1041374043
+//
+//       const dehydratedState = JSON.parse(JSON.stringify(dehydrate(queryClient)));
+//
+//       return {
+//         props: {
+//           params: authorAffiliationParams,
+//           query: params,
+//           dehydratedState,
+//         },
+//       };
+//     } catch (error) {
+//       logger.error({ msg: 'GSSP error on author affiliations form', error });
+//       return {
+//         props: {
+//           params: authorAffiliationParams,
+//           query: params,
+//           error: parseAPIError(error),
+//         },
+//       };
+//     }
+//   } catch (e) {
+//     logger.error({ msg: 'GSSP error on search for author affiliations form', error: e });
+//     return {
+//       props: {
+//         query: params,
+//         error: parseAPIError(e),
+//       },
+//     };
+//   }
+// });


### PR DESCRIPTION
Removes GSSP to simplify the data fetching part
wraps component in error boundary
Moves fetching deeper so we can allow for modification of the years/num_authors during an error response
Small improvements, clean-up