### PR TITLE
remove duplicate init call in rc-cache constructor

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -99,9 +99,7 @@ class Api {
   private pendingRequestsMap: Map<string, Promise<AxiosResponse>>;
 
   private constructor() {
-    this.service = axios.create(defaultRequestConfig);
     this.reset();
-    void this.init();
   }
 
   public getPendingRequests() {
@@ -363,7 +361,7 @@ class Api {
   };
 
   public reset() {
-    this.service = this.service = axios.create(defaultRequestConfig);
+    this.service = axios.create(defaultRequestConfig);
     void this.init();
     this.userData = null;
     this.udInvalidated = false;


### PR DESCRIPTION
Fixes this error that keeps popping up in the logs:
```{   "time": 1759331724939,  "level": 50,  "msg": "Client-side cache not created.", "error": {} }```

This pull request makes a minor fix to the `Api` class constructor and its `reset` method in `src/api/api.ts` to ensure proper initialization of the `service` property and remove redundant or unnecessary code.

- Fixed a typo in the `reset` method by removing the duplicate assignment to `this.service` (`src/api/api.ts`)
- Removed redundant initialization of the `service` property and call to `init()` in the constructor (`src/api/api.ts`)