### PR TITLE
SCIX-645 - fix(abs): mitigate cls on abstract detail blocks

### DIFF
--- a/src/components/AbstractDetails/AbstractDetails.tsx
+++ b/src/components/AbstractDetails/AbstractDetails.tsx
@@ -180,8 +180,8 @@ const Keywords = memo(({ keywords }: { keywords: Array<string> }) => {
       {(keywords) => (
         <Flex flexWrap={'wrap'}>
           {keywords.map((keyword) => (
-            <Tag size="md" variant="subtle" whiteSpace="nowrap" m="1" key={keyword}>
-              <HStack spacing="2">
+            <Tag size="md" variant="subtle" whiteSpace="nowrap" m="1" px={2} py={1} key={keyword}>
+              <HStack spacing="1">
                 <Text>{keyword}</Text>
                 <SearchQueryLink
                   params={{ q: `keyword:"${keyword}"` }}
@@ -223,33 +223,31 @@ const UATKeywords = memo(({ keywords, ids }: { keywords: Array<string>; ids: Arr
       {(keywords) => (
         <Flex flexWrap={'wrap'}>
           {keywords.map((keyword, index) => (
-            <HStack key={keyword}>
-              <Tag size="md" variant="subtle" whiteSpace={'nowrap'} m="1" key={keyword}>
-                <HStack spacing="2">
-                  <Tooltip label={keyword}>
-                    <SimpleLink href={`https://astrothesaurus.org/uat/${encodeURIComponent(ids[index])}`} newTab>
-                      {shortenKeyword(keyword)}
-                    </SimpleLink>
+            <Tag size="md" variant="subtle" whiteSpace="nowrap" m="1" px={2} py={1} key={keyword}>
+              <HStack spacing="1">
+                <Tooltip label={keyword}>
+                  <SimpleLink href={`https://astrothesaurus.org/uat/${encodeURIComponent(ids[index])}`} newTab>
+                    {shortenKeyword(keyword)}
+                  </SimpleLink>
+                </Tooltip>
+                <SearchQueryLink
+                  params={{ q: `uat:"${keyword.split('/').pop()}"` }}
+                  textDecoration="none"
+                  _hover={{
+                    color: 'gray.900',
+                  }}
+                  aria-label={desc}
+                  fontSize="md"
+                >
+                  <Tooltip label={desc}>
+                    <Center>
+                      <Icon as={MagnifyingGlassIcon} transform="rotate(90deg)" boxSize={3} />
+                    </Center>
                   </Tooltip>
-                  <SearchQueryLink
-                    params={{ q: `uat:"${keyword.split('/').pop()}"` }}
-                    textDecoration="none"
-                    _hover={{
-                      color: 'gray.900',
-                    }}
-                    aria-label={desc}
-                    fontSize="md"
-                  >
-                    <Tooltip label={desc}>
-                      <Center>
-                        <Icon as={MagnifyingGlassIcon} transform="rotate(90deg)" />
-                      </Center>
-                    </Tooltip>
-                  </SearchQueryLink>
-                </HStack>
+                </SearchQueryLink>
                 <UATDropdown keyword={keyword} />
-              </Tag>
-            </HStack>
+              </HStack>
+            </Tag>
           ))}
         </Flex>
       )}
@@ -269,8 +267,8 @@ const PlanetaryFeatures = memo(({ features, ids }: { features: Array<string>; id
       {(features) => (
         <Flex flexWrap={'wrap'}>
           {features.map((feature, index) => (
-            <Tag size="md" variant="subtle" whiteSpace="nowrap" m="1" key={feature}>
-              <HStack spacing="2">
+            <Tag size="sm" variant="subtle" whiteSpace="nowrap" m="1" px={2} py={1} key={feature}>
+              <HStack spacing="1">
                 <SimpleLink
                   href={`${EXTERNAL_URLS.USGS_PLANETARY_FEATURES}${ids[index]}`}
                   aria-label={usgsLabel}

--- a/src/components/AbstractDetails/UATDropdown.tsx
+++ b/src/components/AbstractDetails/UATDropdown.tsx
@@ -3,10 +3,10 @@ import { useColorModeColors } from '@/lib/useColorModeColors';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { makeSearchParams } from '@/utils/common/search';
 import { ChevronDownIcon } from '@chakra-ui/icons';
-import { usePopper, VStack, Tooltip, Box, ListItem, List } from '@chakra-ui/react';
+import { usePopper, Tooltip, Box, ListItem, List, Flex } from '@chakra-ui/react';
 import { useSelect } from 'downshift';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CustomInfoMessage, LoadingMessage } from '../Feedbacks';
 
 export type UATTermItem = {
@@ -31,9 +31,21 @@ export const UATDropdown = ({ keyword }: { keyword: string }) => {
 
   const [options, setOptions] = useState<UATTermOption[]>([]);
 
+  const baseId = useMemo(() => {
+    const normalizedKeyword = keyword
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    return `uat-dropdown-${normalizedKeyword || 'keyword'}`;
+  }, [keyword]);
+
   const { isOpen, getToggleButtonProps, getMenuProps, highlightedIndex, getItemProps } = useSelect<UATTermOption>({
     items: options,
-    itemToString: (option) => option.label,
+    itemToString: (option) => option?.label ?? '',
+    id: baseId,
+    labelId: `${baseId}-label`,
+    menuId: `${baseId}-menu`,
+    toggleButtonId: `${baseId}-toggle`,
     onSelectedItemChange: ({ selectedItem: option }) => {
       if (option.type === 'item') {
         const params = { q: `uat:"${option.value}"` };
@@ -74,7 +86,7 @@ export const UATDropdown = ({ keyword }: { keyword: string }) => {
   });
 
   return (
-    <VStack>
+    <Flex direction="column" align="center" display="inline-flex" w="auto">
       <Tooltip label="related keywords">
         <Box
           variant="unstyled"
@@ -84,7 +96,7 @@ export const UATDropdown = ({ keyword }: { keyword: string }) => {
               return el;
             },
           })}
-          m={1}
+          ml={1}
           cursor="pointer"
           tabIndex={0}
         >
@@ -100,10 +112,11 @@ export const UATDropdown = ({ keyword }: { keyword: string }) => {
         borderColor="gray.200"
         boxShadow="lg"
         maxHeight="500px"
-        w="fit-content"
-        minW="200px"
-        maxW="400px"
+        w={isOpen ? 'fit-content' : '0'}
+        minW={isOpen ? '200px' : '0'}
+        maxW={isOpen ? '400px' : '0'}
         overflowY="scroll"
+        display={isOpen ? 'block' : 'none'}
         {...getMenuProps({
           ref: (el: HTMLUListElement) => {
             dropdownPopperRef(el);
@@ -154,6 +167,6 @@ export const UATDropdown = ({ keyword }: { keyword: string }) => {
           </>
         )}
       </Box>
-    </VStack>
+    </Flex>
   );
 };

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -43,12 +43,16 @@ const createQuery = (type: 'author' | 'orcid', value: string): IADSApiSearchPara
   return { q: `${type}:"${value}"`, sort: ['score desc'] };
 };
 
-const AbstractPage: NextPage = () => {
+interface AbstractPageProps {
+  initialDoc?: IDocsEntity | null;
+}
+
+const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc }) => {
   const router = useRouter();
   const isClient = useIsClient();
   const { isAuthenticated } = useSession();
   const { data } = useGetAbstract({ id: router.query.id as string });
-  const doc = path<IDocsEntity>(['docs', 0], data);
+  const doc = path<IDocsEntity>(['docs', 0], data) ?? initialDoc ?? undefined;
   useTrackAbstractView(doc);
 
   // process authors from doc
@@ -58,19 +62,22 @@ const AbstractPage: NextPage = () => {
   const handleFeedback = () => {
     void router.push({ pathname: feedbackItems.record.path, query: { bibcode: doc.bibcode } });
   };
+  const showAddToLibraryButton = isClient && isAuthenticated;
 
   return (
     <AbsLayout doc={doc} titleDescription={''} label="Abstract">
       <Box as="article" aria-labelledby="title">
         {doc && (
           <Stack direction="column" gap={2}>
-            {isClient ? (
-              <Flex wrap="wrap" as="section" aria-labelledby="author-list">
-                <VisuallyHidden as="h2" id="author-list">
-                  Authors
-                </VisuallyHidden>
-                {authors.map(([, author, orcid], index) => (
-                  <Box mr={1} key={`${author}-${index}`}>
+            <Flex wrap="wrap" as="section" aria-labelledby="author-list">
+              <VisuallyHidden as="h2" id="author-list">
+                Authors
+              </VisuallyHidden>
+              {authors.map(([, author, orcid], index) => {
+                const showOrcid = typeof orcid === 'string' && orcid.length > 0;
+                const isTerminalAuthor = index === MAX - 1 || index === doc.author_count - 1;
+                return (
+                  <Flex key={`${author}-${index}`} mr={1} align="center">
                     <Tooltip label="View all records by this author" shouldWrapChildren>
                       <SearchQueryLink
                         params={createQuery('author', author)}
@@ -81,54 +88,46 @@ const AbstractPage: NextPage = () => {
                         {author}
                       </SearchQueryLink>
                     </Tooltip>
-                    {typeof orcid === 'string' && (
-                      <Tooltip label="Search by ORCiD" shouldWrapChildren>
-                        <SearchQueryLink
-                          params={createQuery('orcid', orcid)}
-                          aria-label={`author "${author}", search by orKid`}
-                        >
-                          <OrcidActiveIcon fontSize={'large'} mx={1} />
-                        </SearchQueryLink>
-                      </Tooltip>
+                    {showOrcid ? (
+                      <Box as="span" display="inline-flex" justifyContent="center" mx={1}>
+                        <Tooltip label="Search by ORCiD" shouldWrapChildren>
+                          <SearchQueryLink
+                            params={createQuery('orcid', orcid)}
+                            aria-label={`author "${author}", search by orKid`}
+                          >
+                            <OrcidActiveIcon fontSize={'large'} />
+                          </SearchQueryLink>
+                        </Tooltip>
+                      </Box>
+                    ) : null}
+                    {isTerminalAuthor ? null : (
+                      <Text as="span" ml={showOrcid ? 1 : 0} mr={1}>
+                        ;
+                      </Text>
                     )}
-                    <>{index === MAX - 1 || index === doc.author_count - 1 ? '' : ';'}</>
-                  </Box>
-                ))}
-                {doc.author_count > MAX ? (
-                  <AllAuthorsModal bibcode={doc.bibcode} label={`and ${doc.author_count - MAX} more`} />
-                ) : (
-                  <>
-                    {doc.author_count > 0 && (
-                      <Tooltip label="List all authors and affiliations" shouldWrapChildren>
-                        <AllAuthorsModal bibcode={doc.bibcode} label={'show details'} />
-                      </Tooltip>
-                    )}
-                  </>
-                )}
-              </Flex>
-            ) : (
-              <Flex wrap="wrap">
-                {doc?.author?.map((author, index) => (
-                  <SearchQueryLink
-                    params={createQuery('author', author)}
-                    key={`${author}-${index}`}
-                    px={1}
-                    aria-label={`author "${author}", search by name`}
-                    flexShrink="0"
-                  >
-                    <>{author}</>
-                  </SearchQueryLink>
-                ))}
-                {doc?.author_count > MAX ? <Text>{` and ${doc?.author_count - MAX} more`}</Text> : null}
-              </Flex>
-            )}
+                  </Flex>
+                );
+              })}
+              {doc.author_count > MAX ? (
+                <AllAuthorsModal bibcode={doc.bibcode} label={`and ${doc.author_count - MAX} more`} />
+              ) : (
+                <>
+                  {doc.author_count > 0 && (
+                    <Tooltip label="List all authors and affiliations" shouldWrapChildren>
+                      <AllAuthorsModal bibcode={doc.bibcode} label={'show details'} />
+                    </Tooltip>
+                  )}
+                </>
+              )}
+            </Flex>
 
             <Flex justifyContent="space-between">
               <Box display={{ base: 'block', lg: 'none' }}>
                 <AbstractSources doc={doc} style="menu" />
               </Box>
-              <Flex>
-                {isAuthenticated && (
+              {/* Abstract actions row, this slot is spaced out so we don't cause hydration errors */}
+              <Flex minH={8} align="center" justify="center">
+                {showAddToLibraryButton ? (
                   <Tooltip label="add to library">
                     <IconButton
                       aria-label="Add to library"
@@ -137,11 +136,11 @@ const AbstractPage: NextPage = () => {
                       onClick={onOpenAddToLibrary}
                     />
                   </Tooltip>
-                )}
+                ) : null}
               </Flex>
             </Flex>
 
-            <Box as="section" py="2" aria-labelledby="abstract">
+            <Box as="section" pb="2" aria-labelledby="abstract">
               <VisuallyHidden as="h2" id="abstract">
                 Abstract
               </VisuallyHidden>
@@ -189,9 +188,12 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     queryClient.setQueryData(['user'], bsRes.token);
     ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
 
+    const initialDoc = data?.response?.docs?.[0] ?? null;
+
     return {
       props: {
         dehydratedState: dehydrate(queryClient),
+        initialDoc,
       },
     };
   } catch (error) {
@@ -199,6 +201,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     return {
       props: {
         pageError: 'Failed to load abstract data',
+        initialDoc: null,
       },
     };
   }


### PR DESCRIPTION
Adds a slot with min-height for abstract page actions (currently only add-to-library)
Fixes some spacing issues on the server-rendered UAT keyword pills

Generally mitigates the jump that happens after client requests roll in