### PR TITLE
test(e2e): add smoke tests, workflow tests, and Docker integration fixes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -141,3 +141,55 @@ pnpm test:e2e:docker
 lsof -ti:8000 | xargs kill -9
 lsof -ti:18080 | xargs kill -9
 ```
+
+## Page Object Model
+
+Tests use the Page Object Model (POM) pattern. Page objects live in `e2e/pages/` and encapsulate selectors and actions for each page.
+
+### Directory structure
+
+```
+e2e/
+├── fixtures/
+│   ├── nectar.fixture.ts   — Playwright fixtures (provides page objects + helpers)
+│   └── helpers.ts           — Cookie/response utility functions
+├── pages/
+│   ├── base.page.ts         — Abstract base class (navigation, cookies, scenarios)
+│   ├── home.page.ts         — Landing page
+│   ├── login.page.ts        — Login form page
+│   ├── search.page.ts       — Search results page
+│   ├── register.page.ts     — Registration page
+│   ├── forgot-password.page.ts — Forgot password page
+│   ├── verify.page.ts       — Email verification page
+│   ├── settings.page.ts     — User settings page
+│   └── index.ts             — Barrel export
+└── tests/
+    ├── middleware/           — Middleware integration tests
+    └── smoke/                — Smoke/navigation tests
+```
+
+### Adding a new page object
+
+1. Create `e2e/pages/my-page.page.ts` extending `BasePage`
+2. Set the `path` property (e.g., `/my-page`)
+3. Add selectors as private readonly properties
+4. Add action methods (e.g., `fillForm`, `submit`)
+5. Export from `e2e/pages/index.ts`
+6. Add a fixture in `e2e/fixtures/nectar.fixture.ts`
+
+### Using page objects in tests
+
+```typescript
+import { test, expect } from '../../fixtures/nectar.fixture';
+
+test('example', async ({ loginPage, searchPage }) => {
+  await loginPage.addSessionCookie('anonymous-session');
+  await loginPage.setScenarioHeader('bootstrap-anonymous');
+  await loginPage.goto();
+
+  await loginPage.fillCredentials('user@example.com', 'pass');
+  await loginPage.submit();
+});
+```
+
+Page objects are provided automatically via Playwright fixtures — destructure them in the test signature.

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -29,15 +29,16 @@ services:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - API_HOST_SERVER=http://stub:18080
       - API_HOST_CLIENT=http://stub:18080
-      - NEXT_PUBLIC_API_HOST_CLIENT=http://127.0.0.1:18080
+      - NEXT_PUBLIC_API_HOST_CLIENT=
       - BASE_URL=http://stub:18080
+      - E2E_API_PROXY=true
       - NEXT_PUBLIC_BASE_CANONICAL_URL=http://127.0.0.1:8000
       - ADS_SESSION_COOKIE_NAME=ads_session
       - SCIX_SESSION_COOKIE_NAME=scix_session
       - COOKIE_SECRET=test-secret-must-be-at-least-32-chars-long
       - AUTH_SECRET=test-auth-secret-must-be-at-least-32-chars
       - NEXT_PUBLIC_LOG_LEVEL=debug
-      - RATE_LIMIT_COUNT=100
+      - RATE_LIMIT_COUNT=10000
       - RATE_LIMIT_MAX=1500
       - RATE_LIMIT_TTL=60000
     depends_on:

--- a/e2e/fixtures/nectar.fixture.ts
+++ b/e2e/fixtures/nectar.fixture.ts
@@ -1,22 +1,119 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright fixture `use` is not React */
 import { test as base, expect } from '@playwright/test';
+import { HomePage } from '../pages/home.page';
+import { LoginPage } from '../pages/login.page';
+import { SearchPage } from '../pages/search.page';
+import { RegisterPage } from '../pages/register.page';
+import { ForgotPasswordPage } from '../pages/forgot-password.page';
+import { VerifyPage } from '../pages/verify.page';
+import { SettingsPage } from '../pages/settings.page';
+import { AbstractPage } from '../pages/abstract.page';
+import { ClassicFormPage } from '../pages/classic-form.page';
+import { PaperFormPage } from '../pages/paper-form.page';
+import { JournalsDbPage } from '../pages/journals-db.page';
+import { FeedbackPage } from '../pages/feedback.page';
+import { LibrariesPage } from '../pages/libraries.page';
+import { NotificationsPage } from '../pages/notifications.page';
 
 export type NectarTestContext = {
   nectarUrl: string;
+  homePage: HomePage;
+  loginPage: LoginPage;
+  searchPage: SearchPage;
+  registerPage: RegisterPage;
+  forgotPasswordPage: ForgotPasswordPage;
+  verifyPage: VerifyPage;
+  settingsPage: SettingsPage;
+  abstractPage: AbstractPage;
+  classicFormPage: ClassicFormPage;
+  paperFormPage: PaperFormPage;
+  journalsDbPage: JournalsDbPage;
+  feedbackPage: FeedbackPage;
+  librariesPage: LibrariesPage;
+  notificationsPage: NotificationsPage;
   setTestScenario: (scenario: string) => Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- __NEXT_DATA__ is untyped
   getNextData: () => Promise<any>;
   assertCookieRewritten: (cookie: string | undefined, expectedValue: string) => void;
+  resetStub: () => Promise<void>;
 };
+
+const STUB_URL = process.env.STUB_URL || 'http://127.0.0.1:18080';
 
 export const test = base.extend<NectarTestContext>({
   nectarUrl: async ({}, use) => {
     await use(process.env.NECTAR_URL || process.env.BASE_URL || 'http://127.0.0.1:8000');
   },
 
-  setTestScenario: async ({ context }, use) => {
-    let currentScenario: string | null = null;
+  // Suppress Shepherd.js tour dialogs in all tests by pre-setting the
+  // localStorage flags that the tour guards check before auto-starting.
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('seen-landing-tour', 'true');
+      localStorage.setItem('seen-results-tour', 'true');
+      localStorage.setItem('seen-abstract-tour', 'true');
+    });
+    await use(page);
+  },
 
+  homePage: async ({ page, context, nectarUrl }, use) => {
+    await use(new HomePage(page, context, nectarUrl));
+  },
+
+  loginPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new LoginPage(page, context, nectarUrl));
+  },
+
+  searchPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new SearchPage(page, context, nectarUrl));
+  },
+
+  registerPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new RegisterPage(page, context, nectarUrl));
+  },
+
+  forgotPasswordPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new ForgotPasswordPage(page, context, nectarUrl));
+  },
+
+  verifyPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new VerifyPage(page, context, nectarUrl));
+  },
+
+  settingsPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new SettingsPage(page, context, nectarUrl));
+  },
+
+  abstractPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new AbstractPage(page, context, nectarUrl));
+  },
+
+  classicFormPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new ClassicFormPage(page, context, nectarUrl));
+  },
+
+  paperFormPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new PaperFormPage(page, context, nectarUrl));
+  },
+
+  journalsDbPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new JournalsDbPage(page, context, nectarUrl));
+  },
+
+  feedbackPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new FeedbackPage(page, context, nectarUrl));
+  },
+
+  librariesPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new LibrariesPage(page, context, nectarUrl));
+  },
+
+  notificationsPage: async ({ page, context, nectarUrl }, use) => {
+    await use(new NotificationsPage(page, context, nectarUrl));
+  },
+
+  setTestScenario: async ({ context }, use) => {
     await use(async (scenario: string) => {
-      currentScenario = scenario;
       await context.route('**/*', async (route) => {
         const headers = route.request().headers();
         if (scenario) {
@@ -43,6 +140,12 @@ export const test = base.extend<NectarTestContext>({
       expect(cookie).toContain(`ads_session=${expectedValue}`);
       expect(cookie).toContain('SameSite=Lax');
       expect(cookie).not.toContain('Domain=');
+    });
+  },
+
+  resetStub: async ({ request }, use) => {
+    await use(async () => {
+      await request.post(`${STUB_URL}/__test__/reset`);
     });
   },
 });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Warms the Next.js dev server compilation cache before tests run.
+ *
+ * In Docker CI, the first browser request to each page triggers
+ * on-demand compilation of both server and client bundles, which can
+ * take 30-60s on slow runners — exceeding Playwright action timeouts.
+ *
+ * This setup launches a throwaway browser, navigates to key pages,
+ * and waits for them to fully load. Subsequent test navigations hit
+ * the already-compiled bundles and load quickly.
+ */
+import { chromium } from '@playwright/test';
+
+async function globalSetup() {
+  const baseUrl = process.env.BASE_URL || 'http://127.0.0.1:8000';
+
+  const browser = await chromium.launch({ args: ['--use-gl=egl'] });
+  const context = await browser.newContext();
+  await context.addCookies([{ name: 'ads_session', value: 'warmup', url: baseUrl }]);
+  const page = await context.newPage();
+  await page.setExtraHTTPHeaders({ 'x-test-scenario': 'bootstrap-anonymous' });
+
+  const pages = ['/', '/search?p=1&q=test'];
+
+  for (const path of pages) {
+    const url = `${baseUrl}${path}`;
+    try {
+      await page.goto(url, { timeout: 120_000, waitUntil: 'networkidle' });
+      console.log(`[warmup] ${url} — loaded`);
+    } catch {
+      console.warn(`[warmup] ${url} — timed out, continuing`);
+    }
+  }
+
+  await browser.close();
+}
+
+export default globalSetup;

--- a/e2e/pages/abstract.page.ts
+++ b/e2e/pages/abstract.page.ts
@@ -1,0 +1,37 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class AbstractPage extends BasePage {
+  protected readonly path = '/abs';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async gotoAbstract(bibcode: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}${this.path}/${bibcode}/abstract`);
+  }
+
+  async gotoSubpage(bibcode: string, subpage: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}${this.path}/${bibcode}/${subpage}`);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.locator('article[aria-labelledby="title"]').waitFor({ state: 'visible' });
+  }
+
+  async expectNavMenu(): Promise<void> {
+    await this.page.getByRole('navigation', { name: 'sidebar' }).waitFor({ state: 'visible' });
+  }
+
+  async clickNavTab(tabName: string): Promise<void> {
+    await this.page
+      .getByRole('navigation', { name: 'sidebar' })
+      .getByRole('link', { name: new RegExp(tabName) })
+      .click();
+  }
+
+  async expectSubviewTitle(text: string | RegExp): Promise<void> {
+    await this.page.locator('#abstract-subview-title').getByText(text).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/base.page.ts
+++ b/e2e/pages/base.page.ts
@@ -1,0 +1,94 @@
+import { Page, BrowserContext, Response, expect } from '@playwright/test';
+
+export abstract class BasePage {
+  constructor(protected readonly page: Page, protected readonly context: BrowserContext, readonly baseUrl: string) {}
+
+  protected abstract readonly path: string;
+
+  get url(): string {
+    return this.page.url();
+  }
+
+  buildUrl(params?: string): string {
+    const base = `${this.baseUrl}${this.path}`;
+    if (!params) {
+      return base;
+    }
+    const url = new URL(base);
+    const extra = new URLSearchParams(params.replace(/^\?/, ''));
+    extra.forEach((value, key) => url.searchParams.set(key, value));
+    return url.toString();
+  }
+
+  async goto(options?: { waitUntil?: 'load' | 'commit' | 'networkidle' }): Promise<Response | null> {
+    return this.page.goto(`${this.baseUrl}${this.path}`, options);
+  }
+
+  async gotoWithParams(
+    params: string,
+    options?: { waitUntil?: 'load' | 'commit' | 'networkidle' },
+  ): Promise<Response | null> {
+    return this.page.goto(this.buildUrl(params), options);
+  }
+
+  async gotoUrl(url: string, options?: { waitUntil?: 'load' | 'commit' | 'networkidle' }): Promise<Response | null> {
+    return this.page.goto(url, options);
+  }
+
+  async waitForUrl(
+    pattern: string | RegExp,
+    options?: { timeout?: number; waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' },
+  ): Promise<void> {
+    await this.page.waitForURL(pattern, options);
+  }
+
+  async waitForLoadState(state: 'load' | 'domcontentloaded' | 'networkidle'): Promise<void> {
+    await this.page.waitForLoadState(state);
+  }
+
+  async clearCookies(): Promise<void> {
+    await this.context.clearCookies();
+  }
+
+  async addSessionCookie(value: string): Promise<void> {
+    await this.context.addCookies([{ name: 'ads_session', value, url: this.baseUrl }]);
+  }
+
+  async setScenarioHeader(scenario: string): Promise<void> {
+    await this.page.setExtraHTTPHeaders({
+      'x-test-scenario': scenario,
+    });
+  }
+
+  async setScenarioViaRoute(scenario: string): Promise<void> {
+    await this.context.route('**/*', async (route) => {
+      const headers = route.request().headers();
+      headers['x-test-scenario'] = scenario;
+      await route.continue({ headers });
+    });
+  }
+
+  async setExtraHeaders(headers: Record<string, string>): Promise<void> {
+    await this.page.setExtraHTTPHeaders(headers);
+  }
+
+  async interceptRoute(pattern: string, handler: Parameters<Page['route']>[1]): Promise<void> {
+    await this.page.route(pattern, handler);
+  }
+
+  async getCookies() {
+    return this.context.cookies();
+  }
+
+  urlContains(substring: string): void {
+    expect(this.page.url()).toContain(substring);
+  }
+
+  urlEquals(expected: string): void {
+    expect(this.page.url()).toBe(expected);
+  }
+
+  urlMatches(pattern: RegExp): void {
+    expect(this.page.url()).toMatch(pattern);
+  }
+}

--- a/e2e/pages/classic-form.page.ts
+++ b/e2e/pages/classic-form.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class ClassicFormPage extends BasePage {
+  protected readonly path = '/classic-form';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.locator('[aria-labelledby="form-title"]').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/feedback.page.ts
+++ b/e2e/pages/feedback.page.ts
@@ -1,0 +1,18 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class FeedbackPage extends BasePage {
+  protected readonly path = '/feedback/general';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async gotoFeedbackType(type: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}/feedback/${type}`);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.locator('main').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/forgot-password.page.ts
+++ b/e2e/pages/forgot-password.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class ForgotPasswordPage extends BasePage {
+  protected readonly path = '/user/account/forgotpassword';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /forgot password/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/home.page.ts
+++ b/e2e/pages/home.page.ts
@@ -1,0 +1,29 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class HomePage extends BasePage {
+  protected readonly path = '/';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async search(query: string): Promise<void> {
+    // Set the input value and submit in a single synchronous evaluate.
+    // The search input is a Chakra Combobox with controlled state — using
+    // Playwright's fill() sets the DOM value, but React re-renders and
+    // clears it before a separate submit call can run. By setting the
+    // value and calling form.submit() in one JS execution frame, React
+    // cannot re-render between them.
+    await this.page.evaluate((q) => {
+      const input = document.querySelector('input[name="q"]') as HTMLInputElement;
+      input.value = q;
+      const form = document.querySelector('form[action="/search"]') as HTMLFormElement;
+      form.submit();
+    }, query);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByPlaceholder('all search terms').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,0 +1,15 @@
+export { BasePage } from './base.page';
+export { HomePage } from './home.page';
+export { LoginPage } from './login.page';
+export { SearchPage } from './search.page';
+export { RegisterPage } from './register.page';
+export { ForgotPasswordPage } from './forgot-password.page';
+export { VerifyPage } from './verify.page';
+export { SettingsPage } from './settings.page';
+export { AbstractPage } from './abstract.page';
+export { ClassicFormPage } from './classic-form.page';
+export { PaperFormPage } from './paper-form.page';
+export { JournalsDbPage } from './journals-db.page';
+export { FeedbackPage } from './feedback.page';
+export { LibrariesPage } from './libraries.page';
+export { NotificationsPage } from './notifications.page';

--- a/e2e/pages/journals-db.page.ts
+++ b/e2e/pages/journals-db.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class JournalsDbPage extends BasePage {
+  protected readonly path = '/journalsdb';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /journals database/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/libraries.page.ts
+++ b/e2e/pages/libraries.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class LibrariesPage extends BasePage {
+  protected readonly path = '/user/libraries';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.locator('#main-content').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -1,0 +1,45 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class LoginPage extends BasePage {
+  protected readonly path = '/user/account/login';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async gotoWithNext(nextUrl: string): Promise<void> {
+    await this.gotoWithParams(`?next=${encodeURIComponent(nextUrl)}`);
+  }
+
+  async fillCredentials(email: string, password: string): Promise<void> {
+    // Chakra UI's explicit id="email" breaks FormLabel for/id association,
+    // so getByLabel doesn't work. Use locator by input name instead.
+    await this.page.locator('input[name="email"]').fill(email);
+    await this.page.locator('input[name="password"]').fill(password);
+  }
+
+  async submit(): Promise<void> {
+    await this.page.getByRole('button', { name: /submit/i }).click();
+  }
+
+  async mockLoginSuccess(): Promise<void> {
+    await this.interceptRoute('**/api/auth/login', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+  }
+
+  async login(email: string, password: string): Promise<void> {
+    await this.fillCredentials(email, password);
+    await this.mockLoginSuccess();
+    await this.submit();
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /login/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/notifications.page.ts
+++ b/e2e/pages/notifications.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class NotificationsPage extends BasePage {
+  protected readonly path = '/user/notifications';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /email notifications/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/paper-form.page.ts
+++ b/e2e/pages/paper-form.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class PaperFormPage extends BasePage {
+  protected readonly path = '/paper-form';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /journal search/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/register.page.ts
+++ b/e2e/pages/register.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class RegisterPage extends BasePage {
+  protected readonly path = '/user/account/register';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByRole('heading', { name: /register/i }).waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/search.page.ts
+++ b/e2e/pages/search.page.ts
@@ -1,0 +1,29 @@
+import { Page, BrowserContext, Response, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class SearchPage extends BasePage {
+  protected readonly path = '/search';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async search(query: string): Promise<void> {
+    await this.page.evaluate((q) => {
+      const input = document.querySelector('input[name="q"]') as HTMLInputElement;
+      input.value = q;
+      const form = document.querySelector('form[action="/search"]') as HTMLFormElement;
+      form.submit();
+    }, query);
+  }
+
+  async gotoAndExpect(options?: { waitUntil?: 'load' | 'commit' | 'networkidle' }): Promise<Response> {
+    const response = await this.goto(options);
+    expect(response).not.toBeNull();
+    return response!;
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.getByPlaceholder('all search terms').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/settings.page.ts
+++ b/e2e/pages/settings.page.ts
@@ -1,0 +1,14 @@
+import { Page, BrowserContext } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class SettingsPage extends BasePage {
+  protected readonly path = '/user/settings';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async expectVisible(): Promise<void> {
+    await this.page.locator('#main-content').waitFor({ state: 'visible' });
+  }
+}

--- a/e2e/pages/verify.page.ts
+++ b/e2e/pages/verify.page.ts
@@ -1,0 +1,17 @@
+import { Page, BrowserContext, Response } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class VerifyPage extends BasePage {
+  protected readonly path = '/user/account/verify/register';
+
+  constructor(page: Page, context: BrowserContext, baseUrl: string) {
+    super(page, context, baseUrl);
+  }
+
+  async gotoWithToken(
+    token: string,
+    options?: { waitUntil?: 'load' | 'commit' | 'networkidle' },
+  ): Promise<Response | null> {
+    return this.page.goto(`${this.baseUrl}${this.path}/${token}`, options);
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,16 +1,25 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:8000';
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : '50%',
   reporter: 'list',
-  timeout: process.env.CI ? 60000 : 30000,
+  timeout: process.env.CI ? 90000 : 30000,
+
+  // Warm the Next.js dev server compilation cache before tests run.
+  // First requests trigger on-demand compilation that can exceed action
+  // timeouts on slow CI runners.
+  globalSetup: process.env.CI ? './global-setup.ts' : undefined,
 
   use: {
-    baseURL: process.env.BASE_URL || 'http://127.0.0.1:8000',
+    baseURL: BASE_URL,
+    actionTimeout: process.env.CI ? 60000 : 15000,
+    navigationTimeout: process.env.CI ? 90000 : 30000,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/e2e/tests/middleware/verify-routes.spec.ts
+++ b/e2e/tests/middleware/verify-routes.spec.ts
@@ -1,35 +1,23 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/nectar.fixture';
 import { extractCookie } from '../../fixtures/helpers';
 
-const NECTAR_URL = process.env.NECTAR_URL || process.env.BASE_URL || 'http://127.0.0.1:8000';
-const STUB_URL = process.env.STUB_URL || 'http://127.0.0.1:18080';
-
 test.describe('Verify Routes (Suite D)', () => {
-  test.beforeEach(async ({ context, request }) => {
-    await context.clearCookies();
-    await request.post(`${STUB_URL}/__test__/reset`);
+  test.beforeEach(async ({ verifyPage, resetStub }) => {
+    await verifyPage.clearCookies();
+    await resetStub();
   });
 
-  test('D1: Verify success redirects to login with propagated Set-Cookie', async ({ page, context }) => {
-    await context.addCookies([
-      {
-        name: 'ads_session',
-        value: 'test-session',
-        url: NECTAR_URL,
-      },
-    ]);
+  test('D1: Verify success redirects to login with propagated Set-Cookie', async ({ verifyPage, searchPage }) => {
+    await searchPage.addSessionCookie('test-session');
+    await searchPage.goto();
 
-    await page.goto(`${NECTAR_URL}/search`);
+    await verifyPage.setScenarioHeader('verify-success');
 
-    await page.setExtraHTTPHeaders({
-      'x-test-scenario': 'verify-success',
-    });
+    const response = await verifyPage.gotoWithToken('test-token');
+    await verifyPage.waitForUrl('**/user/account/login?notify=verify-account-success', { timeout: 5000 });
 
-    const response = await page.goto(`${NECTAR_URL}/user/account/verify/register/test-token`);
-    await page.waitForURL('**/user/account/login?notify=verify-account-success', { timeout: 5000 });
-
-    expect(page.url()).toContain('/user/account/login');
-    expect(page.url()).toContain('notify=verify-account-success');
+    verifyPage.urlContains('/user/account/login');
+    verifyPage.urlContains('notify=verify-account-success');
 
     const setCookieHeader = response?.headers()['set-cookie'];
     const adsSessionCookie = extractCookie(setCookieHeader, 'ads_session');
@@ -40,78 +28,42 @@ test.describe('Verify Routes (Suite D)', () => {
     }
   });
 
-  test('D2: Unknown verification token redirects to home with failure', async ({ page, context }) => {
-    await context.addCookies([
-      {
-        name: 'ads_session',
-        value: 'test-session',
-        url: NECTAR_URL,
-      },
-    ]);
+  test('D2: Unknown verification token redirects to home with failure', async ({ verifyPage }) => {
+    await verifyPage.addSessionCookie('test-session');
+    await verifyPage.setScenarioHeader('verify-unknown-token');
 
-    await page.setExtraHTTPHeaders({
-      'x-test-scenario': 'verify-unknown-token',
-    });
+    await verifyPage.gotoWithToken('bad-token');
 
-    await page.goto(`${NECTAR_URL}/user/account/verify/register/bad-token`);
-
-    expect(page.url()).toContain('/?notify=verify-account-failed');
+    verifyPage.urlContains('/?notify=verify-account-failed');
   });
 
-  test('D3: Already validated token redirects to home with was-valid message', async ({ page, context }) => {
-    await context.addCookies([
-      {
-        name: 'ads_session',
-        value: 'test-session',
-        url: NECTAR_URL,
-      },
-    ]);
+  test('D3: Already validated token redirects to home with was-valid message', async ({ verifyPage, searchPage }) => {
+    await searchPage.addSessionCookie('test-session');
+    await searchPage.goto();
 
-    await page.goto(`${NECTAR_URL}/search`);
+    await verifyPage.setScenarioHeader('verify-already-validated');
 
-    await page.setExtraHTTPHeaders({
-      'x-test-scenario': 'verify-already-validated',
-    });
+    await verifyPage.gotoWithToken('already-valid-token');
 
-    await page.goto(`${NECTAR_URL}/user/account/verify/register/already-valid-token`);
-
-    expect(page.url()).toContain('/?notify=verify-account-was-valid');
+    verifyPage.urlContains('/?notify=verify-account-was-valid');
   });
 
-  test('D4: Verify endpoint 500 error redirects to home with failure', async ({ page, context }) => {
-    await context.addCookies([
-      {
-        name: 'ads_session',
-        value: 'test-session',
-        url: NECTAR_URL,
-      },
-    ]);
+  test('D4: Verify endpoint 500 error redirects to home with failure', async ({ verifyPage }) => {
+    await verifyPage.addSessionCookie('test-session');
+    await verifyPage.setScenarioHeader('verify-failure');
 
-    await page.setExtraHTTPHeaders({
-      'x-test-scenario': 'verify-failure',
-    });
+    await verifyPage.gotoWithToken('error-token');
 
-    await page.goto(`${NECTAR_URL}/user/account/verify/register/error-token`);
-
-    expect(page.url()).toContain('/?notify=verify-account-failed');
+    verifyPage.urlContains('/?notify=verify-account-failed');
   });
 
-  test('D5: Missing access token (bootstrap fails) redirects to home with failure', async ({ page, context }) => {
-    await context.addCookies([
-      {
-        name: 'ads_session',
-        value: 'test-session',
-        url: NECTAR_URL,
-      },
-    ]);
+  test('D5: Missing access token (bootstrap fails) redirects to home with failure', async ({ verifyPage }) => {
+    await verifyPage.addSessionCookie('test-session');
+    await verifyPage.setScenarioHeader('bootstrap-failure');
 
-    await page.setExtraHTTPHeaders({
-      'x-test-scenario': 'bootstrap-failure',
-    });
+    await verifyPage.gotoWithToken('any-token');
 
-    await page.goto(`${NECTAR_URL}/user/account/verify/register/any-token`);
-
-    expect(page.url()).toContain('/?notify=');
-    expect(page.url()).toMatch(/notify=(verify-account-failed|api-connect-failed)/);
+    verifyPage.urlContains('/?notify=');
+    verifyPage.urlMatches(/notify=(verify-account-failed|api-connect-failed)/);
   });
 });

--- a/e2e/tests/smoke/abstract-pages.spec.ts
+++ b/e2e/tests/smoke/abstract-pages.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+const TEST_BIBCODE = '2024ApJ...test..001A';
+
+test.describe('Abstract Page Smoke Tests', () => {
+  test.beforeEach(async ({ abstractPage, resetStub }) => {
+    await abstractPage.clearCookies();
+    await resetStub();
+    await abstractPage.addSessionCookie('authenticated-session');
+    await abstractPage.setScenarioHeader('bootstrap-authenticated');
+  });
+
+  test('Abstract page renders with article structure', async ({ abstractPage }) => {
+    await abstractPage.gotoAbstract(TEST_BIBCODE);
+    await abstractPage.expectVisible();
+    await abstractPage.expectNavMenu();
+  });
+
+  const subpages = ['citations', 'references', 'coreads', 'similar', 'metrics', 'graphics'];
+
+  for (const subpage of subpages) {
+    test(`Abstract/${subpage} subpage renders`, async ({ abstractPage }) => {
+      await abstractPage.gotoSubpage(TEST_BIBCODE, subpage);
+      await abstractPage.expectNavMenu();
+    });
+  }
+});

--- a/e2e/tests/smoke/navigation.spec.ts
+++ b/e2e/tests/smoke/navigation.spec.ts
@@ -1,0 +1,91 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+test.describe('Public Page Smoke Tests', () => {
+  test.beforeEach(async ({ homePage, resetStub }) => {
+    await homePage.clearCookies();
+    await resetStub();
+  });
+
+  test('Home page renders search form', async ({ homePage }) => {
+    await homePage.addSessionCookie('anonymous-session');
+    await homePage.setScenarioHeader('bootstrap-anonymous');
+
+    await homePage.goto();
+    await homePage.expectVisible();
+  });
+
+  test('Search page renders for authenticated user', async ({ searchPage }) => {
+    await searchPage.addSessionCookie('authenticated-session');
+    await searchPage.setScenarioHeader('bootstrap-authenticated');
+
+    await searchPage.gotoAndExpect();
+    await searchPage.expectVisible();
+  });
+
+  test('Classic form page renders', async ({ classicFormPage }) => {
+    await classicFormPage.addSessionCookie('anonymous-session');
+    await classicFormPage.setScenarioHeader('bootstrap-anonymous');
+
+    await classicFormPage.goto();
+    await classicFormPage.expectVisible();
+  });
+
+  test('Paper form page renders', async ({ paperFormPage }) => {
+    await paperFormPage.addSessionCookie('anonymous-session');
+    await paperFormPage.setScenarioHeader('bootstrap-anonymous');
+
+    await paperFormPage.goto();
+    await paperFormPage.expectVisible();
+  });
+
+  test('Journals database page renders', async ({ journalsDbPage }) => {
+    await journalsDbPage.addSessionCookie('anonymous-session');
+    await journalsDbPage.setScenarioHeader('bootstrap-anonymous');
+
+    await journalsDbPage.goto();
+    await journalsDbPage.expectVisible();
+  });
+
+  test('Login page renders for anonymous user', async ({ loginPage }) => {
+    await loginPage.addSessionCookie('anonymous-session');
+    await loginPage.setScenarioHeader('bootstrap-anonymous');
+
+    await loginPage.goto();
+    await loginPage.expectVisible();
+  });
+
+  test('Register page renders for anonymous user', async ({ registerPage }) => {
+    await registerPage.addSessionCookie('anonymous-session');
+    await registerPage.setScenarioHeader('bootstrap-anonymous');
+
+    await registerPage.goto();
+    await registerPage.expectVisible();
+  });
+
+  test('Forgot password page renders for anonymous user', async ({ forgotPasswordPage }) => {
+    await forgotPasswordPage.addSessionCookie('anonymous-session');
+    await forgotPasswordPage.setScenarioHeader('bootstrap-anonymous');
+
+    await forgotPasswordPage.goto();
+    await forgotPasswordPage.expectVisible();
+  });
+});
+
+test.describe('Feedback Page Smoke Tests', () => {
+  test.beforeEach(async ({ feedbackPage, resetStub }) => {
+    await feedbackPage.clearCookies();
+    await resetStub();
+  });
+
+  const feedbackTypes = ['general', 'missingrecord', 'missingreferences', 'associatedarticles'];
+
+  for (const type of feedbackTypes) {
+    test(`Feedback/${type} page renders`, async ({ feedbackPage }) => {
+      await feedbackPage.addSessionCookie('anonymous-session');
+      await feedbackPage.setScenarioHeader('bootstrap-anonymous');
+
+      await feedbackPage.gotoFeedbackType(type);
+      await feedbackPage.expectVisible();
+    });
+  }
+});

--- a/e2e/tests/smoke/protected-pages.spec.ts
+++ b/e2e/tests/smoke/protected-pages.spec.ts
@@ -1,0 +1,26 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+test.describe('Protected Page Smoke Tests', () => {
+  test.beforeEach(async ({ searchPage, resetStub }) => {
+    await searchPage.clearCookies();
+    await resetStub();
+    await searchPage.addSessionCookie('authenticated-session');
+    await searchPage.setScenarioHeader('bootstrap-authenticated');
+    await searchPage.goto();
+  });
+
+  test('Libraries page renders for authenticated user', async ({ librariesPage }) => {
+    await librariesPage.goto();
+    await librariesPage.expectVisible();
+  });
+
+  test('Settings/application page renders for authenticated user', async ({ settingsPage }) => {
+    await settingsPage.goto();
+    await settingsPage.expectVisible();
+  });
+
+  test('Notifications page renders for authenticated user', async ({ notificationsPage }) => {
+    await notificationsPage.goto();
+    await notificationsPage.expectVisible();
+  });
+});

--- a/e2e/tests/workflows/abstract-navigation.spec.ts
+++ b/e2e/tests/workflows/abstract-navigation.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+const TEST_BIBCODE = '2024ApJ...test..001A';
+
+test.describe('Abstract Page Navigation Workflow', () => {
+  test.beforeEach(async ({ abstractPage, resetStub }) => {
+    await abstractPage.clearCookies();
+    await resetStub();
+    await abstractPage.addSessionCookie('authenticated-session');
+    await abstractPage.setScenarioHeader('bootstrap-authenticated');
+  });
+
+  test('User can navigate between abstract tabs', async ({ abstractPage }) => {
+    await abstractPage.gotoAbstract(TEST_BIBCODE);
+    await abstractPage.expectVisible();
+    await abstractPage.expectNavMenu();
+
+    await abstractPage.clickNavTab('Citations');
+    await abstractPage.waitForUrl(/\/citations/);
+    abstractPage.urlContains(`/abs/${TEST_BIBCODE}/citations`);
+
+    await abstractPage.clickNavTab('References');
+    await abstractPage.waitForUrl(/\/references/);
+    abstractPage.urlContains(`/abs/${TEST_BIBCODE}/references`);
+
+    await abstractPage.clickNavTab('Abstract');
+    await abstractPage.waitForUrl(/\/abstract/);
+    abstractPage.urlContains(`/abs/${TEST_BIBCODE}/abstract`);
+  });
+});

--- a/e2e/tests/workflows/auth-gated-navigation.spec.ts
+++ b/e2e/tests/workflows/auth-gated-navigation.spec.ts
@@ -1,0 +1,45 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+test.describe('Auth-Gated Navigation Workflow', () => {
+  test.beforeEach(async ({ loginPage, resetStub }) => {
+    await loginPage.clearCookies();
+    await resetStub();
+  });
+
+  test('Anonymous user accessing protected route is redirected to login with next param', async ({
+    page,
+    loginPage,
+  }) => {
+    await loginPage.addSessionCookie('anonymous-session');
+    await loginPage.setScenarioViaRoute('bootstrap-anonymous');
+
+    await page.goto(`${loginPage.baseUrl}/user/libraries`, {
+      waitUntil: 'commit',
+    });
+
+    await loginPage.waitForUrl(/\/user\/account\/login/);
+    loginPage.urlContains('next=');
+    loginPage.urlContains('notify=login-required');
+
+    await loginPage.expectVisible();
+  });
+
+  test('Authenticated user can submit login form and redirect to non-protected destination', async ({ loginPage }) => {
+    await loginPage.addSessionCookie('anonymous-session');
+    await loginPage.setScenarioHeader('bootstrap-anonymous');
+
+    // Navigate directly to login with a non-protected next destination
+    await loginPage.gotoWithNext('/search?q=test');
+
+    loginPage.urlContains('/user/account/login');
+
+    await loginPage.fillCredentials('test@example.com', 'password123');
+    await loginPage.mockLoginSuccess();
+    await loginPage.setScenarioHeader('bootstrap-authenticated');
+    await loginPage.submit();
+
+    await loginPage.waitForUrl(/\/search/, { waitUntil: 'commit' });
+    loginPage.urlContains('/search');
+    loginPage.urlContains('q=test');
+  });
+});

--- a/e2e/tests/workflows/search-flow.spec.ts
+++ b/e2e/tests/workflows/search-flow.spec.ts
@@ -1,0 +1,23 @@
+import { test } from '../../fixtures/nectar.fixture';
+
+test.describe('Search Flow Workflow', () => {
+  test.beforeEach(async ({ homePage, resetStub }) => {
+    await homePage.clearCookies();
+    await resetStub();
+  });
+
+  test('Anonymous user can search from home page and see results', async ({ homePage, searchPage }) => {
+    await homePage.addSessionCookie('anonymous-session');
+    await homePage.setScenarioHeader('bootstrap-anonymous');
+
+    await homePage.goto();
+    await homePage.expectVisible();
+
+    await homePage.search('black holes');
+
+    await searchPage.waitForUrl(/\/search/, { waitUntil: 'commit' });
+    searchPage.urlContains('q=black');
+
+    await searchPage.expectVisible();
+  });
+});

--- a/src/components/SearchFacet/useGetFacetData.test.ts
+++ b/src/components/SearchFacet/useGetFacetData.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, vi, TestContext } from 'vitest';
+import { renderHook, waitFor, createServerListenerMocks, urls } from '@/test-utils';
+import { useGetFacetData } from './useGetFacetData';
+import { defaultQueryParams } from '@/store/slices/search';
+import { FacetField } from '@/api/search/types';
+
+vi.mock('@/components/SearchFacet/store/FacetStore', () => ({
+  useFacetStore: () => vi.fn(),
+}));
+
+const defaultProps = {
+  field: 'author_facet_hier' as FacetField,
+  prefix: '0/',
+  level: 'root' as const,
+};
+
+describe('useGetFacetData', () => {
+  test('does not fire a request when latestQuery.q is empty', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+    renderHook(() => useGetFacetData(defaultProps), {
+      initialStore: { latestQuery: { ...defaultQueryParams, q: '' } },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
+    expect(searchRequests).toHaveLength(0);
+  });
+
+  test('does not fire a request when latestQuery.q is whitespace-only', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+    renderHook(() => useGetFacetData(defaultProps), {
+      initialStore: { latestQuery: { ...defaultQueryParams, q: '   ' } },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
+    expect(searchRequests).toHaveLength(0);
+  });
+
+  test('fires a request when latestQuery.q is non-empty', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+    renderHook(() => useGetFacetData(defaultProps), {
+      initialStore: { latestQuery: { ...defaultQueryParams, q: 'star' } },
+    });
+
+    await waitFor(() => {
+      const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
+      expect(searchRequests.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/SearchFacet/useGetFacetData.ts
+++ b/src/components/SearchFacet/useGetFacetData.ts
@@ -80,7 +80,7 @@ export const useGetFacetData = (props: IUseGetFacetDataProps) => {
       }),
     },
     {
-      enabled,
+      enabled: enabled && isNonEmptyString(searchQuery?.q?.trim()),
       keepPreviousData: true,
     },
   );

--- a/src/components/ServiceUnavailable/ServiceUnavailable.test.tsx
+++ b/src/components/ServiceUnavailable/ServiceUnavailable.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { ServiceUnavailable } from './ServiceUnavailable';
+
+const mockReload = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: mockReload,
+    back: mockBack,
+  }),
+}));
+
+describe('ServiceUnavailable', () => {
+  test('renders heading and description', () => {
+    render(<ServiceUnavailable recordId="2023ApJ...123..456A" />);
+
+    expect(screen.getByText('Temporarily Unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/having trouble loading record/)).toBeInTheDocument();
+    expect(screen.getByText('2023ApJ...123..456A')).toBeInTheDocument();
+  });
+
+  test('renders Try Again button that reloads the page', async () => {
+    const { user } = render(<ServiceUnavailable recordId="2023ApJ...123..456A" />);
+
+    const button = screen.getByRole('button', { name: /try again/i });
+    expect(button).toBeInTheDocument();
+    await user.click(button);
+    expect(mockReload).toHaveBeenCalled();
+  });
+
+  test('renders Go Back button that navigates back', async () => {
+    const { user } = render(<ServiceUnavailable recordId="2023ApJ...123..456A" />);
+
+    const button = screen.getByRole('button', { name: /go back/i });
+    expect(button).toBeInTheDocument();
+    await user.click(button);
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  test('displays status code when provided', () => {
+    render(<ServiceUnavailable recordId="2023ApJ...123..456A" statusCode={503} />);
+
+    expect(screen.getByText(/503/)).toBeInTheDocument();
+  });
+
+  test('does not display status code section when omitted', () => {
+    render(<ServiceUnavailable recordId="2023ApJ...123..456A" />);
+
+    expect(screen.queryByText(/error code/i)).not.toBeInTheDocument();
+  });
+
+  test('has accessible status role', () => {
+    render(<ServiceUnavailable recordId="2023ApJ...123..456A" />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/src/components/ServiceUnavailable/ServiceUnavailable.tsx
+++ b/src/components/ServiceUnavailable/ServiceUnavailable.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, Center, Code, Container, Heading, Icon, Text, VStack, useColorModeValue } from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
+import { useRouter } from 'next/router';
+
+interface ServiceUnavailableProps {
+  recordId: string;
+  statusCode?: number;
+}
+
+export const ServiceUnavailable = ({ recordId, statusCode }: ServiceUnavailableProps) => {
+  const cardBg = useColorModeValue('white', 'gray.800');
+  const borderColor = useColorModeValue('gray.200', 'gray.700');
+  const router = useRouter();
+
+  return (
+    <Center minH="400px" p={4}>
+      <Container maxW="lg">
+        <Box
+          bg={cardBg}
+          borderWidth="1px"
+          borderColor={borderColor}
+          borderRadius="sm"
+          boxShadow="md"
+          p={8}
+          textAlign="center"
+          role="status"
+          aria-live="polite"
+        >
+          <Icon as={WarningIcon} boxSize={12} color="orange.500" mb={5} />
+
+          <Heading variant="pageTitle" mb={3}>
+            Temporarily Unavailable
+          </Heading>
+
+          <Text color="gray.500" mb={4}>
+            We&apos;re having trouble loading record{' '}
+            <Code colorScheme="yellow" fontWeight="bold" fontSize="sm">
+              {recordId || 'N/A'}
+            </Code>
+            . The service is temporarily unavailable.
+          </Text>
+
+          <Text color="gray.500" mb={6} fontSize="sm">
+            This is usually temporary. Please try again in a moment.
+          </Text>
+
+          <VStack spacing={3} width="100%">
+            <Button size="md" width="full" colorScheme="blue" onClick={() => router.reload()}>
+              Try Again
+            </Button>
+            <Button size="md" width="full" variant="outline" onClick={() => router.back()}>
+              Go Back
+            </Button>
+          </VStack>
+
+          {statusCode ? (
+            <Box mt={6} pt={4} borderTopWidth="1px" borderColor={borderColor}>
+              <Text fontSize="xs" color="gray.400">
+                Error code: {statusCode}
+              </Text>
+            </Box>
+          ) : null}
+        </Box>
+      </Container>
+    </Center>
+  );
+};

--- a/src/components/ServiceUnavailable/index.ts
+++ b/src/components/ServiceUnavailable/index.ts
@@ -1,0 +1,1 @@
+export { ServiceUnavailable } from './ServiceUnavailable';

--- a/src/lib/serverside/absCanonicalization.ts
+++ b/src/lib/serverside/absCanonicalization.ts
@@ -19,6 +19,7 @@ type AbsProps = {
   initialDoc?: IDocsEntity | null;
   isAuthenticated?: boolean;
   pageError?: string;
+  statusCode?: number;
 };
 
 type IncomingGSSPResult = GetServerSidePropsResult<AbsProps>;
@@ -96,7 +97,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         context: { bootstrapError: bootstrapResult.error, url: ctx.resolvedUrl },
         tags: { feature: 'abs-canonical', stage: 'bootstrap' },
       });
-      return { props: { pageError: bootstrapResult.error, initialDoc: null } };
+      return { props: { pageError: bootstrapResult.error, initialDoc: null, statusCode: 500 } };
     }
 
     const params = getAbstractParams(requestedId);
@@ -127,6 +128,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
           props: {
             pageError: 'Failed to load abstract data',
             initialDoc: null,
+            statusCode: response.status,
           },
         };
       }
@@ -166,6 +168,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         props: {
           pageError: 'Failed to load abstract data',
           initialDoc: null,
+          statusCode: 500,
         },
       };
     }

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -14,6 +14,7 @@ import { useGetAuthors } from '@/components/AllAuthorsModal/useGetAuthors';
 import { OrcidActiveIcon } from '@/components/icons/Orcid';
 import { AbsLayout } from '@/components/Layout/AbsLayout';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 import { feedbackItems, getAbstractSteps } from '@/components/NavBar';
 import { SearchQueryLink } from '@/components/SearchQueryLink';
 import { AbstractSources } from '@/components/AbstractSources';
@@ -55,9 +56,10 @@ const safeDecode = (value?: string) => {
 interface AbstractPageProps {
   initialDoc?: IDocsEntity | null;
   isAuthenticated?: boolean;
+  statusCode?: number;
 }
 
-const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc, isAuthenticated }) => {
+const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc, isAuthenticated, statusCode }) => {
   const router = useRouter();
   const { data } = useGetAbstract({ id: router.query.id as string });
   const doc = path<IDocsEntity>(['docs', 0], data) ?? initialDoc ?? undefined;
@@ -86,7 +88,9 @@ const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc, isAuthenticated
   return (
     <AbsLayout doc={doc} titleDescription={''} label="Abstract">
       <Box as="article" aria-labelledby="title">
-        {!doc ? (
+        {!doc && statusCode !== undefined && statusCode >= 500 ? (
+          <ServiceUnavailable recordId={identifier || 'N/A'} statusCode={statusCode} />
+        ) : !doc ? (
           <RecordNotFound recordId={identifier || 'N/A'} onFeedback={handleFeedback} />
         ) : (
           <Stack direction="column" gap={2}>

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -10,9 +10,10 @@ import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalizatio
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 import { feedbackItems } from '@/components/NavBar';
 
-const CitationsPage: NextPage = () => {
+const CitationsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -46,7 +47,9 @@ const CitationsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers that cite" label="Citations">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const CoreadsPage: NextPage = () => {
+const CoreadsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -39,7 +40,9 @@ const CoreadsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers also read by those who read" label="Coreads">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/credits.tsx
+++ b/src/pages/abs/[id]/credits.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const CreditsPage: NextPage = () => {
+const CreditsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -46,7 +47,9 @@ const CreditsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers that credited" label="Credits">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -15,8 +15,9 @@ import { faImage } from '@fortawesome/free-solid-svg-icons';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const GraphicsPage: NextPage = () => {
+const GraphicsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const { data } = useGetAbstract({ id });
@@ -37,7 +38,9 @@ const GraphicsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Graphics from" label="Graphics">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/mentions.tsx
+++ b/src/pages/abs/[id]/mentions.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const MentionsPage: NextPage = () => {
+const MentionsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -46,7 +47,9 @@ const MentionsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers mentioned by" label="Mentions">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/metrics.tsx
+++ b/src/pages/abs/[id]/metrics.tsx
@@ -12,8 +12,9 @@ import { useGetMetrics } from '@/api/metrics/metrics';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const MetricsPage: NextPage = () => {
+const MetricsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const { data } = useGetAbstract({ id });
@@ -37,7 +38,9 @@ const MetricsPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Metrics for" label="Metrics">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const ReferencesPage: NextPage = () => {
+const ReferencesPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -46,7 +47,9 @@ const ReferencesPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers referenced by" label="References">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const SimilarPage: NextPage = () => {
+const SimilarPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
@@ -39,7 +40,9 @@ const SimilarPage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers similar to" label="Similar Papers">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>

--- a/src/pages/abs/[id]/toc.tsx
+++ b/src/pages/abs/[id]/toc.tsx
@@ -11,8 +11,9 @@ import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
 import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 
-const VolumePage: NextPage = () => {
+const VolumePage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   const router = useRouter();
   const id = router.query.id as string;
 
@@ -37,7 +38,9 @@ const VolumePage: NextPage = () => {
 
   return (
     <AbsLayout doc={doc} titleDescription="Papers in the same volume as" label="Volume Content">
-      {!doc ? (
+      {!doc && statusCode !== undefined && statusCode >= 500 ? (
+        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
+      ) : !doc ? (
         <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
       ) : (
         <>


### PR DESCRIPTION
Adds comprehensive e2e test coverage (45 tests) using the Page Object
Model pattern with Playwright running in Docker.

Changes:

- POM base class with session cookie, scenario header, and navigation helpers
- 16 page objects covering all major pages
- Public page smoke tests (home, search, forms, journals DB, auth pages, feedback)
- Protected page smoke tests (libraries, notifications, settings)
- Abstract subpage smoke tests (citations, references, coreads, similar, export)
- Workflow tests: anonymous search, abstract tab navigation, auth-gated nav
- Middleware tests: session bootstrap, auth routing, verify routes
- Stub backend extended with CORS, search/abstract routes, configurable scenarios
- Next.js afterFiles rewrites to proxy client-side API calls in Docker
- Shepherd.js tour suppression via localStorage in test fixture
- ServiceUnavailable component for 5xx errors in abstract pages
- Fix for empty-query facet requests on search page

Depends on PR #807 (POM foundation) — overlapping changes will resolve
once #807 is merged first.