### PR TITLE
Use abbreviated pub full name in search facet

### DIFF
--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -108,6 +108,7 @@ export type FacetField =
   | 'author_facet'
   | 'bibgroup_facet'
   | 'bibstem_facet'
+  | 'pub_abbrev'
   | 'data_facet'
   | 'keyword_facet'
   | 'vizier_facet'

--- a/src/components/SearchFacet/config.ts
+++ b/src/components/SearchFacet/config.ts
@@ -58,7 +58,7 @@ export const facetConfig: Record<SearchFacetID, Omit<ISearchFacetProps, 'onQuery
   },
   publications: {
     label: 'Publications',
-    field: 'bibstem_facet' as FacetField,
+    field: 'pub_abbrev' as FacetField,
     logic: defaultLogic,
     storeId: 'publications',
     isLowerCase: false,

--- a/src/components/SearchFacet/types.ts
+++ b/src/components/SearchFacet/types.ts
@@ -34,6 +34,7 @@ export const facetFields: FacetField[] = [
   'author_facet',
   'bibgroup_facet',
   'bibstem_facet',
+  'pub_abbrev',
   'data_facet',
   'keyword_facet',
   'vizier_facet',


### PR DESCRIPTION
This is a draft PR until `pub_abbrev` moves to production.
<img width="311" height="385" alt="Screenshot 2026-02-26 at 10 23 28 AM" src="https://github.com/user-attachments/assets/e08bfc29-84b3-40a8-be87-ac9a721aa38a" />
