### PR TITLE
SCIX-834 fix(search): improve search error alert UX

### DIFF
--- a/src/__tests__/feedback/general.test.tsx
+++ b/src/__tests__/feedback/general.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@/test-utils';
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import General from '@/pages/feedback/general';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const mockQuery: Record<string, string> = {};
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: mockQuery,
+    asPath: '/feedback/general',
+    push: vi.fn(),
+    replace: vi.fn(),
+    pathname: '/feedback/general',
+  }),
+}));
+
+vi.mock('react-google-recaptcha-v3', () => ({
+  useGoogleReCaptcha: () => ({
+    executeRecaptcha: vi.fn(),
+  }),
+}));
+
+vi.mock('@/api/feedback/feedback', () => ({
+  useFeedback: () => ({
+    mutate: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+describe('General Feedback Page', () => {
+  afterEach(() => {
+    Object.keys(mockQuery).forEach((key) => delete mockQuery[key]);
+  });
+
+  test('shows info notice when error_details query param is present', () => {
+    mockQuery.error_details = 'Search syntax error near position 10';
+
+    render(<General />);
+
+    expect(screen.getByText(/error details from your search will be included/i)).toBeInTheDocument();
+  });
+
+  test('does not show info notice when error_details is absent', () => {
+    render(<General />);
+
+    expect(screen.queryByText(/error details from your search will be included/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/api/feedback/types.ts
+++ b/src/api/feedback/types.ts
@@ -21,6 +21,7 @@ export interface IGeneralFeedbackParams {
   current_page?: string;
   current_query?: string;
   url?: string;
+  error_details?: string;
 }
 
 export type Relationship = 'errata' | 'addenda' | 'series' | 'arxiv' | 'duplicate' | 'other';

--- a/src/components/SolrErrorAlert/SolrErrorAlert.test.tsx
+++ b/src/components/SolrErrorAlert/SolrErrorAlert.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { SearchErrorAlert } from './SolrErrorAlert';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { IADSApiSearchResponse } from '@/api/search/types';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: vi.fn(),
+    back: vi.fn(),
+    push: vi.fn(),
+    query: {},
+    pathname: '/search',
+  }),
+}));
+
+const makeAxiosError = (msg: string): AxiosError<IADSApiSearchResponse> => {
+  const error = new AxiosError<IADSApiSearchResponse>(msg);
+  error.response = {
+    data: {
+      error: { code: 400, msg },
+    } as unknown as IADSApiSearchResponse,
+    status: 400,
+    statusText: 'Bad Request',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+};
+
+describe('SearchErrorAlert', () => {
+  test('renders a "Report this issue" link', () => {
+    const error = makeAxiosError('syntax error: cannot parse query');
+    render(<SearchErrorAlert error={error} />);
+
+    const link = screen.getByRole('link', { name: /report this issue/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  test('link href contains /feedback/general and error_details=', () => {
+    const msg = 'syntax error: cannot parse query';
+    const error = makeAxiosError(msg);
+    render(<SearchErrorAlert error={error} />);
+
+    const link = screen.getByRole('link', { name: /report this issue/i });
+    expect(link).toHaveAttribute('href');
+    const href = link.getAttribute('href');
+    expect(href).toContain('/feedback/general');
+    const url = new URL(href, 'http://localhost');
+    expect(url.searchParams.get('error_details')).toBe(msg);
+  });
+
+  test('details section is collapsed by default', () => {
+    const error = makeAxiosError('syntax error: cannot parse query');
+    render(<SearchErrorAlert error={error} />);
+
+    const toggleBtn = screen.getByLabelText('toggle error details');
+    expect(toggleBtn).toHaveTextContent('Show Details');
+  });
+
+  test('link always includes from=search param', () => {
+    const error = new Error('something failed') as AxiosError<IADSApiSearchResponse>;
+    render(<SearchErrorAlert error={error} />);
+
+    const link = screen.getByRole('link', { name: /report this issue/i });
+    const href = link.getAttribute('href') ?? '';
+    expect(href).toContain('/feedback/general');
+    expect(href).toContain('from=search');
+  });
+});

--- a/src/pages/feedback/general.tsx
+++ b/src/pages/feedback/general.tsx
@@ -1,4 +1,7 @@
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
   AlertStatus,
   Button,
   Flex,
@@ -94,6 +97,8 @@ const General: NextPage = () => {
 
   const router = useRouter();
 
+  const errorDetails = typeof router.query.error_details === 'string' ? router.query.error_details : undefined;
+
   const onSubmit = useCallback<SubmitHandler<FormValues>>(
     async (params) => {
       if (params === null) {
@@ -130,6 +135,7 @@ const General: NextPage = () => {
             current_page: router.query.from ? (router.query.from as string) : undefined,
             current_query: makeSearchParams(currentQuery),
             url: router.asPath,
+            error_details: errorDetails,
             comments,
           },
           {
@@ -176,6 +182,7 @@ const General: NextPage = () => {
       currentQuery,
       router.query.from,
       router.asPath,
+      errorDetails,
       userEmail,
       engineName,
       engineVersion,
@@ -223,6 +230,14 @@ const General: NextPage = () => {
           </SimpleLink>
           . You can also send general comments and questions to <strong>help [at] scixplorer.org</strong>.
         </Text>
+        {errorDetails && (
+          <Alert status="info" borderRadius="md" my={2}>
+            <AlertIcon />
+            <AlertDescription fontSize="sm">
+              Error details from your search will be included with this submission to help us investigate the issue.
+            </AlertDescription>
+          </Alert>
+        )}
         <Flex direction="column" gap={4}>
           <Stack direction={{ base: 'column', sm: 'row' }} gap={2}>
             <FormControl isRequired isInvalid={!!errors.name}>


### PR DESCRIPTION
Search error alert was showing raw details expanded by default with no
easy way to report issues. 

- Collapse error details by default
- Add "Report this issue" link that navigates to /feedback/general with error context in query params
- Add error_details field to feedback API payload so error context is forwarded with submissions
- Show info notice on feedback page when error context is present
- Redesign error card
- Add tests for error alert and feedback page 

<img width="1315" height="465" alt="image" src="https://github.com/user-attachments/assets/c382006d-81cc-4d48-ab7a-c7cc08cab998" />
<img width="968" height="251" alt="image" src="https://github.com/user-attachments/assets/7b25516c-935b-4aeb-97c4-c63df004a0bb" />
<img width="1107" height="519" alt="image" src="https://github.com/user-attachments/assets/129f69d5-76a2-4c66-8054-8d03062512b1" />

