### PR TITLE
Prepend DOI and ARXIV URL origin when adding new url in the form

### DIFF
--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -24,6 +24,10 @@ const typeOptions: SelectOption<ResourceUrlType>[] = resourceUrlTypes.map((t) =>
   value: t as string,
 }));
 
+const DOI_ORIGIN = 'https://doi.org';
+
+const ARXIV_ORIGIN = 'https://arxiv.org';
+
 export const UrlsTable = ({ editable }: { editable: boolean }) => {
   const isClient = useIsClient();
 
@@ -37,7 +41,7 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   });
 
   // New row being added
-  const [newUrl, setNewUrl] = useState<IResourceUrl>({ type: 'arXiv', url: '' });
+  const [newUrl, setNewUrl] = useState<IResourceUrl>({ type: 'arXiv', url: `${ARXIV_ORIGIN}/` });
 
   // Existing row being edited
   const [editUrl, setEditUrl] = useState<{ index: number; url: IResourceUrl }>({
@@ -67,7 +71,9 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
 
     try {
       const testUrl = new URL(url);
-      return VALID_PROTOCOLS.includes(testUrl.protocol);
+      return testUrl.origin === DOI_ORIGIN || testUrl.origin === ARXIV_ORIGIN
+        ? testUrl.pathname.length > 1
+        : VALID_PROTOCOLS.includes(testUrl.protocol);
     } catch {
       return false;
     }
@@ -80,7 +86,8 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   // Changes to fields for adding new url
 
   const handleNewTypeChange = (option: SelectOption<ResourceUrlType>) => {
-    setNewUrl((prev) => ({ ...prev, type: option.id }));
+    const origin = option.id === 'DOI' ? DOI_ORIGIN : option.id === 'arXiv' ? ARXIV_ORIGIN : '';
+    setNewUrl({ url: `${origin}/`, type: option.id });
   };
 
   const handleNewUrlChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -90,7 +97,7 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   const handleAddUrl = () => {
     append(newUrl);
     // clear input fields
-    setNewUrl({ type: 'arXiv', url: '' });
+    setNewUrl({ type: 'arXiv', url: `${ARXIV_ORIGIN}/` });
     (newURLTypeInputRef.current as SelectInstance).focus();
   };
 

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -8,6 +8,7 @@ import { SelectInstance } from 'react-select';
 import { FormValues } from './types';
 import { IResourceUrl, ResourceUrlType, resourceUrlTypes } from '@/lib/useGetResourceLinks';
 import { useIsClient } from '@/lib/useIsClient';
+import { EXTERNAL_URLS } from '@/config';
 
 export const UrlsField = () => {
   return (
@@ -24,9 +25,7 @@ const typeOptions: SelectOption<ResourceUrlType>[] = resourceUrlTypes.map((t) =>
   value: t as string,
 }));
 
-const DOI_ORIGIN = 'https://doi.org';
-
-const ARXIV_ORIGIN = 'https://arxiv.org';
+const { DOI_ORIGIN, ARXIV_ORIGIN } = EXTERNAL_URLS;
 
 export const UrlsTable = ({ editable }: { editable: boolean }) => {
   const isClient = useIsClient();
@@ -86,8 +85,8 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   // Changes to fields for adding new url
 
   const handleNewTypeChange = (option: SelectOption<ResourceUrlType>) => {
-    const origin = option.id === 'DOI' ? DOI_ORIGIN : option.id === 'arXiv' ? ARXIV_ORIGIN : '';
-    setNewUrl({ url: `${origin}/`, type: option.id });
+    const origin = option.id === 'DOI' ? `${DOI_ORIGIN}/` : option.id === 'arXiv' ? `${ARXIV_ORIGIN}/` : '';
+    setNewUrl({ url: origin, type: option.id });
   };
 
   const handleNewUrlChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,8 @@ export const EXTERNAL_URLS = {
   CFA_SAO_HOME_PAGE: 'https://www.cfa.harvard.edu/sao' as const,
   UAT: 'http://astrothesaurus.org',
   ORCID: 'https://orcid.org',
+  DOI_ORIGIN: 'https://doi.org',
+  ARXIV_ORIGIN: 'https://arxiv.org',
 };
 
 export const TRACING_HEADERS = ['X-Original-Uri', 'X-Original-Forwarded-For', 'X-Forwarded-For', 'X-Amzn-Trace-Id'];


### PR DESCRIPTION
Avoid confusion of DOI and arxiv format in the URL by prepending the origin.

<img width="943" height="151" alt="Screenshot 2026-03-31 at 2 25 50 PM" src="https://github.com/user-attachments/assets/ec96f450-329d-4453-bfe2-9b327823254d" />
<img width="926" height="111" alt="Screenshot 2026-03-31 at 2 27 15 PM" src="https://github.com/user-attachments/assets/0db6ca40-b88d-4a1f-a7db-b9b787dbcf74" />
