### PR TITLE
feat(feedback): missing record form improvements

### DIFF
--- a/src/components/FeedbackForms/MissingRecord/AuthorsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/AuthorsField.tsx
@@ -1,9 +1,10 @@
 import { FormControl, FormLabel, Checkbox, FormErrorMessage } from '@chakra-ui/react';
 import { useFormContext, useFieldArray, useWatch, Controller } from 'react-hook-form';
-import { AuthorsTable } from './AuthorsTable';
+import { forwardRef } from 'react';
+import { AuthorsTable, AuthorsTableHandle } from './AuthorsTable';
 import { FormValues } from './types';
 
-export const AuthorsField = () => {
+export const AuthorsField = forwardRef<AuthorsTableHandle>(function AuthorsField(_, ref) {
   const {
     control,
     formState: { errors },
@@ -17,31 +18,25 @@ export const AuthorsField = () => {
 
   return (
     <>
-      <FormControl isInvalid={!!errors.authors}>
+      <FormControl isRequired isInvalid={!!errors.authors}>
         <FormLabel>Authors</FormLabel>
-        {!noAuthors && (
-          <>
-            <AuthorsTable editable={true} />
-          </>
-        )}
+        {!noAuthors && <AuthorsTable editable={true} ref={ref} />}
       </FormControl>
 
-      <>
-        {authors.length === 0 && (
-          <FormControl isInvalid={!!errors.noAuthors}>
-            <Controller
-              name="noAuthors"
-              control={control}
-              render={({ field: { onChange, value, ref } }) => (
-                <Checkbox onChange={onChange} ref={ref} isChecked={value}>
-                  Abstract has no author(s)
-                </Checkbox>
-              )}
-            />
-            <FormErrorMessage>{errors.noAuthors && errors.noAuthors.message}</FormErrorMessage>
-          </FormControl>
-        )}
-      </>
+      {authors.length === 0 && (
+        <FormControl isInvalid={!!errors.noAuthors}>
+          <Controller
+            name="noAuthors"
+            control={control}
+            render={({ field: { onChange, value, ref: inputRef } }) => (
+              <Checkbox onChange={onChange} ref={inputRef} isChecked={value}>
+                Abstract has no author(s)
+              </Checkbox>
+            )}
+          />
+          <FormErrorMessage>{errors.noAuthors && errors.noAuthors.message}</FormErrorMessage>
+        </FormControl>
+      )}
     </>
   );
-};
+});

--- a/src/components/FeedbackForms/MissingRecord/AuthorsTable.tsx
+++ b/src/components/FeedbackForms/MissingRecord/AuthorsTable.tsx
@@ -8,12 +8,30 @@ import {
   getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { useState, ChangeEvent, MouseEvent, useRef, useMemo, KeyboardEvent } from 'react';
+import {
+  useState,
+  ChangeEvent,
+  MouseEvent,
+  useRef,
+  useMemo,
+  KeyboardEvent,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { FormValues, IAuthor } from './types';
 import { PaginationControls } from '@/components/Pagination';
 
-export const AuthorsTable = ({ editable }: { editable: boolean }) => {
+const columnHelper = createColumnHelper<IAuthor>();
+
+export interface AuthorsTableHandle {
+  flush: () => void;
+}
+
+export const AuthorsTable = forwardRef<AuthorsTableHandle, { editable: boolean }>(function AuthorsTable(
+  { editable },
+  ref,
+) {
   const {
     fields: authors,
     append,
@@ -42,15 +60,11 @@ export const AuthorsTable = ({ editable }: { editable: boolean }) => {
 
   const newAuthorNameRef = useRef<HTMLInputElement>();
 
-  const isValidAuthor = (author: IAuthor) => {
-    return author && typeof author.name === 'string' && author.name.length > 1;
-  };
+  const isValidAuthor = (author: IAuthor) => author && typeof author.name === 'string' && author.name.length > 1;
 
   const newAuthorIsValid = isValidAuthor(newAuthor);
-
   const editAuthorIsValid = isValidAuthor(editAuthor.author);
 
-  const columnHelper = createColumnHelper<IAuthor>();
   const columns = useMemo(() => {
     return [
       columnHelper.display({
@@ -63,14 +77,14 @@ export const AuthorsTable = ({ editable }: { editable: boolean }) => {
       }),
       columnHelper.accessor('aff', {
         cell: (info) => info.getValue(),
-        header: 'Affilication',
+        header: 'Affiliation',
       }),
       columnHelper.accessor('orcid', {
         cell: (info) => info.getValue(),
         header: 'ORCiD',
       }),
     ];
-  }, [columnHelper]);
+  }, []);
 
   const table = useReactTable({
     columns,
@@ -97,8 +111,24 @@ export const AuthorsTable = ({ editable }: { editable: boolean }) => {
     append(newAuthor);
     // clear input fields
     setNewAuthor(null);
-    newAuthorNameRef.current.focus();
+    newAuthorNameRef.current?.focus();
   };
+
+  // Flush any in-progress row (new or being edited) when navigating away
+  useImperativeHandle(
+    ref,
+    () => ({
+      flush: () => {
+        if (editAuthorIsValid && editAuthor.index !== -1) {
+          handleApplyEditAuthor();
+        }
+        if (isValidAuthor(newAuthor)) {
+          handleAddAuthor();
+        }
+      },
+    }),
+    [newAuthor, editAuthor, editAuthorIsValid],
+  );
 
   // Changes to fields for existing authors
 
@@ -332,4 +362,4 @@ export const AuthorsTable = ({ editable }: { editable: boolean }) => {
       <PaginationControls table={table} entries={authors} my={5} />
     </>
   );
-};
+});

--- a/src/components/FeedbackForms/MissingRecord/DraftBanner.test.tsx
+++ b/src/components/FeedbackForms/MissingRecord/DraftBanner.test.tsx
@@ -1,0 +1,30 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen } from '@/test-utils';
+import { DraftBanner } from './DraftBanner';
+
+describe('DraftBanner', () => {
+  test('renders nothing when show is false', () => {
+    render(<DraftBanner show={false} onRestore={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('renders banner with message when show is true', () => {
+    render(<DraftBanner show={true} onRestore={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/unsaved draft/i)).toBeInTheDocument();
+  });
+
+  test('calls onRestore when Restore button is clicked', async () => {
+    const onRestore = vi.fn();
+    const { user } = render(<DraftBanner show={true} onRestore={onRestore} onDismiss={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: /restore/i }));
+    expect(onRestore).toHaveBeenCalledOnce();
+  });
+
+  test('calls onDismiss when Dismiss button is clicked', async () => {
+    const onDismiss = vi.fn();
+    const { user } = render(<DraftBanner show={true} onRestore={vi.fn()} onDismiss={onDismiss} />);
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/FeedbackForms/MissingRecord/DraftBanner.tsx
+++ b/src/components/FeedbackForms/MissingRecord/DraftBanner.tsx
@@ -1,0 +1,28 @@
+import { Alert, AlertDescription, AlertIcon, Button, HStack } from '@chakra-ui/react';
+
+interface DraftBannerProps {
+  show: boolean;
+  onRestore: () => void;
+  onDismiss: () => void;
+}
+
+export function DraftBanner({ show, onRestore, onDismiss }: DraftBannerProps) {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Alert status="info" borderRadius="md" mb={4}>
+      <AlertIcon />
+      <AlertDescription flex={1}>You have an unsaved draft for this form.</AlertDescription>
+      <HStack spacing={2}>
+        <Button size="sm" colorScheme="blue" onClick={onRestore}>
+          Restore
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </HStack>
+    </Alert>
+  );
+}

--- a/src/components/FeedbackForms/MissingRecord/FormChecklist.test.tsx
+++ b/src/components/FeedbackForms/MissingRecord/FormChecklist.test.tsx
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@/test-utils';
+import { FormProvider, useForm } from 'react-hook-form';
+import { FormValues } from './types';
+import { FormChecklist } from './FormChecklist';
+
+function Wrapper({ values }: { values: Partial<FormValues> }) {
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      name: '',
+      email: '',
+      isNew: true,
+      bibcode: '',
+      collection: [],
+      title: '',
+      noAuthors: false,
+      authors: [],
+      publication: '',
+      pubDate: '',
+      urls: [],
+      abstract: '',
+      keywords: [],
+      references: [],
+      comments: '',
+      ...values,
+    },
+  });
+  return (
+    <FormProvider {...methods}>
+      <FormChecklist />
+    </FormProvider>
+  );
+}
+
+describe('FormChecklist', () => {
+  test('renders 6 checklist items', () => {
+    render(<Wrapper values={{}} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(6);
+  });
+
+  test('all items incomplete when form is empty', () => {
+    render(<Wrapper values={{}} />);
+    screen.getAllByRole('listitem').forEach((item) => {
+      expect(item).toHaveAttribute('data-complete', 'false');
+    });
+  });
+
+  test('marks Name complete when name has a value', () => {
+    render(<Wrapper values={{ name: 'Alice' }} />);
+    expect(screen.getByTestId('checklist-name')).toHaveAttribute('data-complete', 'true');
+  });
+
+  test('marks Email complete when email is present', () => {
+    render(<Wrapper values={{ email: 'alice@example.com' }} />);
+    expect(screen.getByTestId('checklist-email')).toHaveAttribute('data-complete', 'true');
+  });
+
+  test('marks Title complete when title is present', () => {
+    render(<Wrapper values={{ title: 'My Paper' }} />);
+    expect(screen.getByTestId('checklist-title')).toHaveAttribute('data-complete', 'true');
+  });
+
+  test('marks Authors complete when authors list is non-empty', () => {
+    render(<Wrapper values={{ authors: [{ name: 'Alice', aff: '', orcid: '' }] }} />);
+    expect(screen.getByTestId('checklist-authors')).toHaveAttribute('data-complete', 'true');
+  });
+
+  test('marks Authors complete when noAuthors is true', () => {
+    render(<Wrapper values={{ noAuthors: true }} />);
+    expect(screen.getByTestId('checklist-authors')).toHaveAttribute('data-complete', 'true');
+  });
+
+  test('shows progress count', () => {
+    render(<Wrapper values={{ name: 'Alice', email: 'a@b.com' }} />);
+    expect(screen.getByText(/2 of 6/i)).toBeInTheDocument();
+  });
+
+  test('shows 0 of 6 when all fields empty', () => {
+    render(<Wrapper values={{}} />);
+    expect(screen.getByText(/0 of 6/i)).toBeInTheDocument();
+  });
+
+  test('shows 6 of 6 when all required fields complete', () => {
+    render(
+      <Wrapper
+        values={{
+          name: 'Alice',
+          email: 'a@b.com',
+          title: 'My Paper',
+          publication: 'Nature',
+          pubDate: '2024-01',
+          noAuthors: true,
+        }}
+      />,
+    );
+    expect(screen.getByText(/6 of 6/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/FeedbackForms/MissingRecord/FormChecklist.tsx
+++ b/src/components/FeedbackForms/MissingRecord/FormChecklist.tsx
@@ -1,0 +1,70 @@
+import { Box, HStack, List, ListItem, Text } from '@chakra-ui/react';
+import { CheckCircleIcon } from '@chakra-ui/icons';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { isNonEmptyString } from 'ramda-adjunct';
+import { isValidEmail } from '@/utils/common/isValidEmail';
+import { FormValues } from './types';
+
+interface ChecklistItem {
+  id: string;
+  label: string;
+  isComplete: boolean;
+}
+
+export function FormChecklist() {
+  const { control } = useFormContext<FormValues>();
+
+  const [name, email, title, publication, pubDate, authors, noAuthors] = useWatch<
+    FormValues,
+    ['name', 'email', 'title', 'publication', 'pubDate', 'authors', 'noAuthors']
+  >({
+    control,
+    name: ['name', 'email', 'title', 'publication', 'pubDate', 'authors', 'noAuthors'],
+  });
+
+  const items: ChecklistItem[] = [
+    { id: 'name', label: 'Name', isComplete: isNonEmptyString(name) },
+    { id: 'email', label: 'Email', isComplete: !!email && isValidEmail(email) },
+    { id: 'title', label: 'Title', isComplete: isNonEmptyString(title) },
+    {
+      id: 'authors',
+      label: 'Author(s)',
+      isComplete: (authors?.length ?? 0) > 0 || noAuthors === true,
+    },
+    { id: 'publication', label: 'Publication', isComplete: isNonEmptyString(publication) },
+    { id: 'pubDate', label: 'Publication Date', isComplete: isNonEmptyString(pubDate) },
+  ];
+
+  const completedCount = items.filter((i) => i.isComplete).length;
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} minW="200px">
+      <Text fontWeight="semibold" fontSize="sm" mb={2}>
+        Required Fields
+      </Text>
+      <Text fontSize="xs" color="gray.500" mb={3}>
+        {completedCount} of {items.length}
+      </Text>
+      <List spacing={2} role="list">
+        {items.map((item) => (
+          <ListItem
+            key={item.id}
+            data-testid={`checklist-${item.id}`}
+            data-complete={String(item.isComplete)}
+            role="listitem"
+          >
+            <HStack spacing={2}>
+              <CheckCircleIcon
+                color={item.isComplete ? 'green.500' : 'gray.300'}
+                aria-label={item.isComplete ? 'complete' : 'incomplete'}
+              />
+              <Text fontSize="sm" color={item.isComplete ? 'inherit' : 'gray.500'}>
+                {item.label}
+              </Text>
+            </HStack>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/components/FeedbackForms/MissingRecord/PubDateField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/PubDateField.tsx
@@ -5,14 +5,25 @@ import { FormValues } from './types';
 export const PubDateField = () => {
   const {
     register,
+    setValue,
     formState: { errors },
   } = useFormContext<FormValues>();
+
+  const { onChange: _onChange, ...rest } = register('pubDate');
 
   return (
     <FormControl isRequired isInvalid={!!errors.pubDate}>
       <FormLabel>Publication Date</FormLabel>
-      <Input {...register('pubDate')} placeholder="yyyy-mm-dd" />
-      <FormErrorMessage>{errors.pubDate && errors.pubDate.message}</FormErrorMessage>
+      <Input
+        {...rest}
+        placeholder="YYYY-MM"
+        maxLength={10}
+        onChange={(e) => {
+          e.target.value = e.target.value.replace(/[^\d-]/g, '');
+          setValue('pubDate', e.target.value, { shouldValidate: true, shouldDirty: true });
+        }}
+      />
+      <FormErrorMessage>{errors.pubDate?.message}</FormErrorMessage>
     </FormControl>
   );
 };

--- a/src/components/FeedbackForms/MissingRecord/RecordPanel.test.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordPanel.test.tsx
@@ -1,0 +1,160 @@
+import { render } from '@/test-utils';
+import { waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { RecordPanel } from './RecordPanel';
+import type { UserEvent } from '@testing-library/user-event';
+
+// --- mocks ---
+
+vi.mock('@/api/search/search', () => ({
+  useGetSingleRecord: vi.fn(() => ({
+    data: null as null,
+    isFetching: false,
+    isSuccess: false,
+    error: null as null,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/useGetResourceLinks', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/useGetResourceLinks')>('@/lib/useGetResourceLinks');
+  return {
+    ...actual,
+    useGetResourceLinks: vi.fn(() => ({
+      data: [] as import('@/lib/useGetResourceLinks').IResourceUrl[],
+      isSuccess: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('@/lib/useGetUserEmail', () => ({
+  useGetUserEmail: vi.fn((): string | null => null),
+}));
+
+vi.mock('@/api/feedback/feedback', () => ({
+  useFeedback: vi.fn(() => ({ mutate: vi.fn(), isLoading: false })),
+}));
+
+vi.mock('react-google-recaptcha-v3', () => ({
+  useGoogleReCaptcha: vi.fn(() => ({ executeRecaptcha: vi.fn() })),
+}));
+
+// --- helpers ---
+
+const defaultProps = {
+  onOpenAlert: vi.fn(),
+  onCloseAlert: vi.fn(),
+  isFocused: false,
+};
+
+type QueryHelpers = Pick<ReturnType<typeof render>, 'getByLabelText' | 'getByRole' | 'getByText'>;
+
+/**
+ * Fill all required fields so the form becomes valid.
+ * Uses the noAuthors checkbox instead of adding an author row.
+ */
+const fillRequiredFields = async (user: UserEvent, queries: QueryHelpers) => {
+  const { getByLabelText, getByRole } = queries;
+  await user.type(getByLabelText('Name*'), 'Jane Doe');
+  await user.type(getByLabelText('Email*'), 'jane@example.com');
+  await user.type(getByLabelText('Title*'), 'A Great Paper');
+  await user.type(getByLabelText('Publication*'), 'Nature');
+  await user.type(getByLabelText('Publication Date*'), '2024-01');
+  await user.click(getByRole('checkbox', { name: /Abstract has no author/i }));
+};
+
+// --- tests ---
+
+describe('RecordPanel — New Record mode (isNew=true)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders all required field labels', () => {
+    const { getByLabelText } = render(<RecordPanel {...defaultProps} isNew={true} />);
+
+    // Chakra appends '*' directly to the label text for required fields
+    expect(getByLabelText('Name*')).toBeInTheDocument();
+    expect(getByLabelText('Email*')).toBeInTheDocument();
+    expect(getByLabelText('Title*')).toBeInTheDocument();
+    expect(getByLabelText('Publication*')).toBeInTheDocument();
+    expect(getByLabelText('Publication Date*')).toBeInTheDocument();
+  });
+
+  test('Preview button is disabled when form is empty', () => {
+    const { getByRole } = render(<RecordPanel {...defaultProps} isNew={true} />);
+    const previewBtn = getByRole('button', { name: /preview/i });
+    expect(previewBtn).toBeDisabled();
+  });
+
+  test('Preview button becomes enabled when all required fields are filled', async () => {
+    const result = render(<RecordPanel {...defaultProps} isNew={true} />);
+    const { user, getByRole } = result;
+
+    const previewBtn = getByRole('button', { name: /preview/i });
+    expect(previewBtn).toBeDisabled();
+
+    await fillRequiredFields(user, result);
+
+    await waitFor(() => expect(previewBtn).not.toBeDisabled());
+  });
+
+  test('Preview button stays disabled when only some required fields are filled', async () => {
+    // Verifies that all required fields must be filled — not just one.
+    const result = render(<RecordPanel {...defaultProps} isNew={true} />);
+    const { user, getByRole, getByLabelText } = result;
+
+    const previewBtn = getByRole('button', { name: /preview/i });
+    expect(previewBtn).toBeDisabled();
+
+    // Fill everything except pubDate
+    await user.type(getByLabelText('Name*'), 'Jane Doe');
+    await user.type(getByLabelText('Email*'), 'jane@example.com');
+    await user.type(getByLabelText('Title*'), 'A Great Paper');
+    await user.type(getByLabelText('Publication*'), 'Nature');
+    await user.click(getByRole('checkbox', { name: /Abstract has no author/i }));
+
+    // Button should still be disabled — pubDate is missing
+    await waitFor(() => expect(previewBtn).toBeDisabled());
+  });
+
+  test('noAuthors checkbox is visible when no authors have been added', () => {
+    const { getByRole } = render(<RecordPanel {...defaultProps} isNew={true} />);
+    expect(getByRole('checkbox', { name: /Abstract has no author/i })).toBeInTheDocument();
+  });
+});
+
+describe('RecordPanel — Edit Record mode (isNew=false)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders bibcode input and Load button', () => {
+    const { getByLabelText, getByRole } = render(<RecordPanel {...defaultProps} isNew={false} />);
+
+    // In edit mode the label reads "SciX-ID / DOI / Bibcode"
+    expect(getByLabelText(/SciX-ID \/ DOI \/ Bibcode/i)).toBeInTheDocument();
+    expect(getByRole('button', { name: /load/i })).toBeInTheDocument();
+  });
+
+  test('Load button is disabled when bibcode field is empty', () => {
+    const { getByRole } = render(<RecordPanel {...defaultProps} isNew={false} />);
+
+    const loadBtn = getByRole('button', { name: /load/i });
+    expect(loadBtn).toBeDisabled();
+  });
+
+  test('Load button becomes enabled when bibcode field has a value', async () => {
+    const { user, getByRole, getByLabelText } = render(<RecordPanel {...defaultProps} isNew={false} />);
+
+    const loadBtn = getByRole('button', { name: /load/i });
+    expect(loadBtn).toBeDisabled();
+
+    const bibcodeInput = getByLabelText(/SciX-ID \/ DOI \/ Bibcode/i);
+    await user.type(bibcodeInput, '2024ApJ...123..456A');
+
+    await waitFor(() => expect(loadBtn).not.toBeDisabled());
+  });
+});

--- a/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
@@ -18,9 +18,10 @@ import {
 } from '@chakra-ui/react';
 
 import { omit } from 'ramda';
-import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { AuthorsField } from './AuthorsField';
+import { AuthorsTableHandle } from './AuthorsTable';
 import { BibcodeField } from './BibcodeField';
 import { DraftBanner } from './DraftBanner';
 import { FormChecklist } from './FormChecklist';
@@ -28,9 +29,9 @@ import { getDiffSections, getDiffString, processFormValues } from './DiffUtil';
 import { KeywordsField } from './KeywordsField';
 import { PubDateField } from './PubDateField';
 import { RecordWizard } from './RecordWizard';
-import { ReferencesField } from './ReferencesField';
+import { ReferencesField, ReferencesTableHandle } from './ReferencesField';
 import { DiffSection, FormValues, IAuthor, IKeyword, IReference } from './types';
-import { UrlsField } from './UrlsField';
+import { UrlsField, UrlsTableHandle } from './UrlsField';
 import { DiffSectionPanel } from './DiffSectionPanel';
 import { useFormDraft } from './useFormDraft';
 import { COLLECTIONS } from './types';
@@ -168,6 +169,10 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
     handleSubmit,
     setFocus,
   } = formMethods;
+
+  const authorsRef = useRef<AuthorsTableHandle>(null);
+  const referencesRef = useRef<ReferencesTableHandle>(null);
+  const urlsRef = useRef<UrlsTableHandle>(null);
 
   // New records use a fixed key; edit records scope to bibcode
   const draftKey = getDraftKey(isNew, bibcode);
@@ -395,6 +400,13 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
     setState('submitting');
   };
 
+  const handleStandardPreview = handleSubmit(() => {
+    authorsRef.current?.flush();
+    referencesRef.current?.flush();
+    urlsRef.current?.flush();
+    handlePreview();
+  });
+
   // submitted
   const handleOnSuccess = () => {
     onOpenAlert({ status: 'success', title: 'Feedback submitted successfully' });
@@ -527,7 +539,7 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
                   <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
                 </FormControl>
 
-                <AuthorsField />
+                <AuthorsField ref={authorsRef} />
 
                 <Stack direction={{ base: 'column', sm: 'row' }} gap={2} alignItems="start">
                   <FormControl isRequired isInvalid={!!errors.publication}>
@@ -539,7 +551,7 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
                   <PubDateField />
                 </Stack>
 
-                <UrlsField />
+                <UrlsField ref={urlsRef} />
 
                 <FormControl>
                   <FormLabel>Abstract</FormLabel>
@@ -549,7 +561,7 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
                 <KeywordsField />
 
                 {isNew ? (
-                  <ReferencesField />
+                  <ReferencesField ref={referencesRef} />
                 ) : (
                   <FormControl>
                     <FormLabel>References</FormLabel>
@@ -573,7 +585,7 @@ export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibco
                 </FormControl>
 
                 <HStack mt={2}>
-                  <Button isLoading={isLoading} isDisabled={!isValid} onClick={handleSubmit(handlePreview)}>
+                  <Button isLoading={isLoading} isDisabled={!isValid} onClick={handleStandardPreview}>
                     Preview
                   </Button>
                   <Button variant="outline" onClick={handleReset} isDisabled={isLoading}>

--- a/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
@@ -1,6 +1,8 @@
 import {
   AlertStatus,
+  Box,
   Button,
+  ButtonGroup,
   Checkbox,
   CheckboxGroup,
   Flex,
@@ -20,13 +22,18 @@ import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { AuthorsField } from './AuthorsField';
 import { BibcodeField } from './BibcodeField';
+import { DraftBanner } from './DraftBanner';
+import { FormChecklist } from './FormChecklist';
 import { getDiffSections, getDiffString, processFormValues } from './DiffUtil';
 import { KeywordsField } from './KeywordsField';
 import { PubDateField } from './PubDateField';
+import { RecordWizard } from './RecordWizard';
 import { ReferencesField } from './ReferencesField';
 import { DiffSection, FormValues, IAuthor, IKeyword, IReference } from './types';
 import { UrlsField } from './UrlsField';
 import { DiffSectionPanel } from './DiffSectionPanel';
+import { useFormDraft } from './useFormDraft';
+import { COLLECTIONS } from './types';
 import { AxiosError } from 'axios';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -34,21 +41,20 @@ import { SimpleLink } from '@/components/SimpleLink';
 import { PreviewModal } from '@/components/FeedbackForms';
 import { IResourceUrl, useGetResourceLinks } from '@/lib/useGetResourceLinks';
 import { useGetUserEmail } from '@/lib/useGetUserEmail';
-import { parsePublicationDate } from '@/utils/common/parsePublicationDate';
 import type { Database, IDocsEntity } from '@/api/search/types';
 import type { IFeedbackParams } from '@/api/feedback/types';
 import { useGetSingleRecord } from '@/api/search/search';
-
-const collections: { value: Database; label: string }[] = [
-  { value: 'astronomy', label: 'Astronomy and Astrophysics' },
-  { value: 'physics', label: 'Physics and Geophysics' },
-  { value: 'earthscience', label: 'Earth Science' },
-  { value: 'general', label: 'General' },
-];
+import { LocalSettings } from '@/types';
 
 type State = 'idle' | 'loading-record' | 'loading-urls' | 'submitting' | 'preview';
+type FormMode = 'expert' | 'guided';
 
-const isInvalidPubDate = (pubdate: string) => parsePublicationDate(pubdate) === null;
+// accepts YYYY-MM or YYYY-MM-DD; lax on day (00 is valid for ADS)
+const PUB_DATE_RE = /^\d{4}-\d{2}(-\d{2})?$/;
+
+function isInvalidPubDate(pubdate: string): boolean {
+  return !PUB_DATE_RE.test(pubdate);
+}
 
 const validationSchema = z
   .object({
@@ -95,26 +101,41 @@ const validationSchema = z
     return z.NEVER;
   });
 
-export const RecordPanel = ({
-  isNew,
-  onOpenAlert,
-  onCloseAlert,
-  isFocused,
-  bibcode,
-}: {
+function getDraftKey(isNew: boolean, bibcode?: string): string | null {
+  if (isNew) {
+    return LocalSettings.FEEDBACK_DRAFT_NEW;
+  }
+  if (bibcode) {
+    return `feedback-draft:edit-record:${bibcode}`;
+  }
+  return null;
+}
+
+function getInitialMode(): FormMode {
+  try {
+    const stored = localStorage.getItem(LocalSettings.FEEDBACK_FORM_MODE);
+    return stored === 'guided' ? 'guided' : 'expert';
+  } catch {
+    return 'expert';
+  }
+}
+
+interface RecordPanelProps {
   isNew: boolean;
   onOpenAlert: (params: { status: AlertStatus; title: string; description?: string }) => void;
   onCloseAlert: () => void;
   isFocused: boolean;
   bibcode?: string;
-}) => {
+}
+
+export function RecordPanel({ isNew, onOpenAlert, onCloseAlert, isFocused, bibcode }: RecordPanelProps) {
   const userEmail = useGetUserEmail();
 
   const initialFormValues = {
     name: '',
     email: userEmail ?? '',
     bibcode: bibcode ?? '',
-    isNew: isNew,
+    isNew,
     collection: [] as Database[],
     title: '',
     noAuthors: false,
@@ -128,14 +149,12 @@ export const RecordPanel = ({
     comments: '',
   };
 
-  // original form values from existing record
-  // used for diff view
   const [recordOriginalFormValues, setRecordOriginalFormValues] = useState<FormValues>(initialFormValues);
 
   const formMethods = useForm<FormValues>({
     defaultValues: recordOriginalFormValues,
     resolver: zodResolver(validationSchema),
-    mode: 'onSubmit',
+    mode: 'onTouched',
     reValidateMode: 'onBlur',
     shouldFocusError: true,
   });
@@ -149,6 +168,14 @@ export const RecordPanel = ({
     handleSubmit,
     setFocus,
   } = formMethods;
+
+  // New records use a fixed key; edit records scope to bibcode
+  const draftKey = getDraftKey(isNew, bibcode);
+
+  const { hasDraft, getDraftValues, clearDraft, cancelPendingSave } = useFormDraft(draftKey, formMethods);
+  const [showDraftBanner, setShowDraftBanner] = useState(hasDraft);
+
+  const [formMode, setFormMode] = useState<FormMode>(() => (isNew ? getInitialMode() : 'expert'));
 
   const { isOpen: isPreviewOpen, onOpen: openPreview, onClose: closePreview } = useDisclosure();
 
@@ -233,7 +260,7 @@ export const RecordPanel = ({
           diff: diffString,
         });
       } catch {
-        onOpenAlert({ status: 'error', title: 'There was a problem processing diff. Plesae try again.' });
+        onOpenAlert({ status: 'error', title: 'Could not generate diff preview. Please try again.' });
         setState('idle');
       }
     } else if (state === 'preview') {
@@ -371,6 +398,8 @@ export const RecordPanel = ({
   // submitted
   const handleOnSuccess = () => {
     onOpenAlert({ status: 'success', title: 'Feedback submitted successfully' });
+    clearDraft();
+    setShowDraftBanner(false);
     if (isNew) {
       reset();
     } else {
@@ -396,103 +425,170 @@ export const RecordPanel = ({
     setState('idle');
   };
 
+  const handleRestoreDraft = () => {
+    const draft = getDraftValues();
+    if (!draft) {
+      return;
+    }
+    cancelPendingSave();
+    // preserve authenticated email over any email stored in the draft
+    const mergedEmail = userEmail ?? draft.email;
+    reset({ ...draft, email: mergedEmail });
+    setShowDraftBanner(false);
+  };
+
+  const handleDismissDraft = () => {
+    clearDraft();
+    setShowDraftBanner(false);
+  };
+
+  const handleModeChange = (mode: FormMode) => {
+    setFormMode(mode);
+    try {
+      localStorage.setItem(LocalSettings.FEEDBACK_FORM_MODE, mode);
+    } catch {
+      // ignore storage errors
+    }
+  };
+
   return (
     <FormProvider {...formMethods}>
       <Stack direction="column" gap={4} m={0}>
-        <Flex direction={{ base: 'column', sm: 'row' }} gap={2} alignItems="start">
-          <FormControl isRequired isInvalid={!!errors.name}>
-            <FormLabel>Name</FormLabel>
-            <Input {...register('name', { required: true })} />
-            <FormErrorMessage>{errors.name && errors.name.message}</FormErrorMessage>
-          </FormControl>
-          <FormControl isRequired isInvalid={!!errors.email}>
-            <FormLabel>Email</FormLabel>
-            <Input {...register('email', { required: true })} type="email" />
-            <FormErrorMessage>{errors.email && errors.email.message}</FormErrorMessage>
-          </FormControl>
-        </Flex>
+        <DraftBanner show={showDraftBanner} onRestore={handleRestoreDraft} onDismiss={handleDismissDraft} />
 
-        <BibcodeField showLoadBtn={!isNew} onLoad={handleOnLoadingRecord} isLoading={isLoading} isRequired={!isNew} />
+        {isNew && (
+          <HStack>
+            <ButtonGroup size="sm" isAttached variant="outline">
+              <Button
+                isActive={formMode === 'expert'}
+                onClick={() => handleModeChange('expert')}
+                aria-pressed={formMode === 'expert'}
+              >
+                Standard
+              </Button>
+              <Button
+                isActive={formMode === 'guided'}
+                onClick={() => handleModeChange('guided')}
+                aria-pressed={formMode === 'guided'}
+              >
+                Guided
+              </Button>
+            </ButtonGroup>
+          </HStack>
+        )}
 
-        {(isNew || (!isNew && !!recordOriginalFormValues.title)) && (
-          <>
-            <FormControl>
-              <FormLabel>Collection</FormLabel>
-              <Controller
-                name="collection"
-                control={control}
-                render={({ field: { ref, ...rest } }) => (
-                  <CheckboxGroup {...rest}>
-                    <Stack direction={{ base: 'column', sm: 'row' }}>
-                      {collections.map((c) => (
-                        <Checkbox key={`collection-${c.value}`} value={c.value}>
-                          {c.label}
-                        </Checkbox>
-                      ))}
-                    </Stack>
-                  </CheckboxGroup>
+        {formMode !== 'guided' && (
+          <Flex direction={{ base: 'column', sm: 'row' }} gap={2} alignItems="start">
+            <FormControl isRequired isInvalid={!!errors.name}>
+              <FormLabel>Name</FormLabel>
+              <Input {...register('name', { required: true })} />
+              <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+            </FormControl>
+            <FormControl isRequired isInvalid={!!errors.email}>
+              <FormLabel>Email</FormLabel>
+              <Input {...register('email', { required: true })} type="email" />
+              <FormErrorMessage>{errors.email?.message}</FormErrorMessage>
+            </FormControl>
+          </Flex>
+        )}
+
+        {!(isNew && formMode === 'guided') && (
+          <BibcodeField showLoadBtn={!isNew} onLoad={handleOnLoadingRecord} isLoading={isLoading} isRequired={!isNew} />
+        )}
+
+        {isNew && formMode === 'guided' ? (
+          <RecordWizard onPreview={handleSubmit(handlePreview)} isLoading={isLoading} />
+        ) : (
+          (isNew || !!recordOriginalFormValues.title) && (
+            <Flex direction={{ base: 'column', md: 'row' }} gap={6} alignItems="start">
+              <Stack flex={1} spacing={4}>
+                <FormControl>
+                  <FormLabel>Collection</FormLabel>
+                  <Controller
+                    name="collection"
+                    control={control}
+                    render={({ field: { ref: _ref, ...rest } }) => (
+                      <CheckboxGroup {...rest}>
+                        <Stack direction={{ base: 'column', sm: 'row' }} justify="space-between">
+                          {COLLECTIONS.map((c) => (
+                            <Checkbox key={`collection-${c.value}`} value={c.value}>
+                              {c.label}
+                            </Checkbox>
+                          ))}
+                        </Stack>
+                      </CheckboxGroup>
+                    )}
+                  />
+                </FormControl>
+
+                <FormControl isRequired isInvalid={!!errors.title}>
+                  <FormLabel>Title</FormLabel>
+                  <Input {...register('title', { required: true })} />
+                  <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+                </FormControl>
+
+                <AuthorsField />
+
+                <Stack direction={{ base: 'column', sm: 'row' }} gap={2} alignItems="start">
+                  <FormControl isRequired isInvalid={!!errors.publication}>
+                    <FormLabel>Publication</FormLabel>
+                    <Input {...register('publication', { required: true })} />
+                    <FormErrorMessage>{errors.publication?.message}</FormErrorMessage>
+                  </FormControl>
+
+                  <PubDateField />
+                </Stack>
+
+                <UrlsField />
+
+                <FormControl>
+                  <FormLabel>Abstract</FormLabel>
+                  <Textarea {...register('abstract')} rows={10} />
+                </FormControl>
+
+                <KeywordsField />
+
+                {isNew ? (
+                  <ReferencesField />
+                ) : (
+                  <FormControl>
+                    <FormLabel>References</FormLabel>
+                    <Text>
+                      To add references, use the{' '}
+                      <SimpleLink href="/feedback/missingreferences" display="inline">
+                        Missing References
+                      </SimpleLink>{' '}
+                      form. To make changes to existing references, use the{' '}
+                      <SimpleLink href="/feedback/general" display="inline">
+                        General Feedback
+                      </SimpleLink>{' '}
+                      form.
+                    </Text>
+                  </FormControl>
                 )}
-              />
-            </FormControl>
 
-            <FormControl isRequired>
-              <FormLabel>Title</FormLabel>
-              <Input {...register('title', { required: true })} />
-            </FormControl>
+                <FormControl>
+                  <FormLabel>User Comments</FormLabel>
+                  <Textarea {...register('comments')} />
+                </FormControl>
 
-            <AuthorsField />
+                <HStack mt={2}>
+                  <Button isLoading={isLoading} isDisabled={!isValid} onClick={handleSubmit(handlePreview)}>
+                    Preview
+                  </Button>
+                  <Button variant="outline" onClick={handleReset} isDisabled={isLoading}>
+                    Reset
+                  </Button>
+                </HStack>
+              </Stack>
 
-            <Stack direction={{ base: 'column', sm: 'row' }} gap={2} alignItems="start">
-              <FormControl isRequired>
-                <FormLabel>Publication</FormLabel>
-                <Input {...register('publication', { required: true })} />
-              </FormControl>
-
-              <PubDateField />
-            </Stack>
-
-            <UrlsField />
-
-            <FormControl>
-              <FormLabel>Abstract</FormLabel>
-              <Textarea {...register('abstract')} rows={10} />
-            </FormControl>
-
-            <KeywordsField />
-
-            {isNew ? (
-              <ReferencesField />
-            ) : (
-              <FormControl>
-                <FormLabel>References</FormLabel>
-                <Text>
-                  To add references, use the{' '}
-                  <SimpleLink href="/feedback/missingreferences" display="inline">
-                    Missing References
-                  </SimpleLink>{' '}
-                  form. To make changes to existing references, use the{' '}
-                  <SimpleLink href="/feedback/general" display="inline">
-                    General Feedback
-                  </SimpleLink>{' '}
-                  form.
-                </Text>
-              </FormControl>
-            )}
-
-            <FormControl>
-              <FormLabel>User Comments</FormLabel>
-              <Textarea {...register('comments')} />
-            </FormControl>
-
-            <HStack mt={2}>
-              <Button isLoading={isLoading} isDisabled={!isValid} onClick={handleSubmit(handlePreview)}>
-                Preview
-              </Button>
-              <Button variant="outline" onClick={handleReset} isDisabled={isLoading}>
-                Reset
-              </Button>
-            </HStack>
-          </>
+              {isNew && (
+                <Box position={{ base: 'static', md: 'sticky' }} top={{ md: 4 }} alignSelf="flex-start">
+                  <FormChecklist />
+                </Box>
+              )}
+            </Flex>
+          )
         )}
       </Stack>
 
@@ -512,4 +608,4 @@ export const RecordPanel = ({
       )}
     </FormProvider>
   );
-};
+}

--- a/src/components/FeedbackForms/MissingRecord/RecordWizard.test.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordWizard.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@/test-utils';
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { RecordWizard } from './RecordWizard';
+import { FormValues } from './types';
+
+vi.mock('@/lib/useGetResourceLinks', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/useGetResourceLinks')>('@/lib/useGetResourceLinks');
+  return {
+    ...actual,
+    useGetResourceLinks: vi.fn(() => ({
+      data: [] as import('@/lib/useGetResourceLinks').IResourceUrl[],
+      isSuccess: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })),
+  };
+});
+
+// These field components are tested independently. Stub them here so the
+// wizard tests can focus on navigation and validation gating without
+// triggering jsdom incompatibilities (react-select portal, @zag-js focus tracking).
+vi.mock('./UrlsField', () => ({ UrlsField: () => <div data-testid="urls-field-mock" /> }));
+vi.mock('./AuthorsField', () => ({ AuthorsField: () => <div data-testid="authors-field-mock" /> }));
+vi.mock('./KeywordsField', () => ({ KeywordsField: () => <div data-testid="keywords-field-mock" /> }));
+vi.mock('./ReferencesField', () => ({ ReferencesField: () => <div data-testid="references-field-mock" /> }));
+
+// Stub Chakra Checkbox/CheckboxGroup to avoid @zag-js/focus-visible jsdom crash
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    Checkbox: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+      <label>
+        <input type="checkbox" value={value} />
+        {children}
+      </label>
+    ),
+    CheckboxGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const testSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email').min(1, 'Email is required'),
+  title: z.string().min(1, 'Title is required'),
+  publication: z.string().min(1, 'Publication is required'),
+  pubDate: z.string().min(1, 'Publication date is required'),
+  collection: z.array(z.string()),
+  isNew: z.boolean(),
+  bibcode: z.string(),
+  noAuthors: z.boolean(),
+  authors: z.array(z.any()),
+  urls: z.array(z.any()),
+  abstract: z.string(),
+  keywords: z.array(z.any()),
+  references: z.array(z.any()),
+  comments: z.string(),
+});
+
+const defaultValues: FormValues = {
+  name: '',
+  email: '',
+  isNew: true,
+  bibcode: '',
+  collection: [],
+  title: '',
+  noAuthors: false,
+  authors: [],
+  publication: '',
+  pubDate: '',
+  urls: [],
+  abstract: '',
+  keywords: [],
+  references: [],
+  comments: '',
+};
+
+function Wrapper({ onPreview = vi.fn() }: { onPreview?: () => void }) {
+  const methods = useForm<FormValues>({
+    defaultValues,
+    resolver: zodResolver(testSchema),
+    mode: 'onTouched',
+    shouldFocusError: false,
+  });
+  return (
+    <FormProvider {...methods}>
+      <RecordWizard onPreview={onPreview} isLoading={false} />
+    </FormProvider>
+  );
+}
+
+describe('RecordWizard', () => {
+  test('renders step 1 (Contact) with name and email fields', () => {
+    render(<Wrapper />);
+    expect(screen.getByLabelText('Name*')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email*')).toBeInTheDocument();
+  });
+
+  test('Back button is disabled on the first step', () => {
+    render(<Wrapper />);
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+
+  test('shows all 5 step labels in the stepper', () => {
+    render(<Wrapper />);
+    expect(screen.getByText('Contact')).toBeInTheDocument();
+    expect(screen.getByText('Publication')).toBeInTheDocument();
+    expect(screen.getByText('Authors')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByText('References')).toBeInTheDocument();
+  });
+
+  test('does not advance when required fields on step 1 are empty', async () => {
+    const { user } = render(<Wrapper />);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    // Still on step 1 — name and email fields visible
+    await waitFor(() => expect(screen.getByLabelText('Name*')).toBeInTheDocument());
+  });
+
+  test('advances to step 2 when Contact fields are valid', async () => {
+    const { user } = render(<Wrapper />);
+    await user.type(screen.getByLabelText('Name*'), 'Alice');
+    await user.type(screen.getByLabelText('Email*'), 'alice@example.com');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => expect(screen.getByLabelText('Title*')).toBeInTheDocument());
+  });
+
+  test('Back button returns to previous step', async () => {
+    const { user } = render(<Wrapper />);
+    await user.type(screen.getByLabelText('Name*'), 'Alice');
+    await user.type(screen.getByLabelText('Email*'), 'alice@example.com');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByLabelText('Title*'));
+    await user.click(screen.getByRole('button', { name: /back/i }));
+    await waitFor(() => expect(screen.getByLabelText('Name*')).toBeInTheDocument());
+  });
+
+  test('shows validation error when email is invalid', async () => {
+    const { user } = render(<Wrapper />);
+    await user.type(screen.getByLabelText('Name*'), 'Alice');
+    await user.type(screen.getByLabelText('Email*'), 'not-an-email');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    // zod's .email() fires before .min(1) — error is "Invalid email"
+    await waitFor(() => expect(screen.getByText(/invalid email/i)).toBeInTheDocument());
+  });
+});

--- a/src/components/FeedbackForms/MissingRecord/RecordWizard.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordWizard.tsx
@@ -1,0 +1,242 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  HStack,
+  Input,
+  Stack,
+  Step,
+  StepDescription,
+  StepIcon,
+  StepIndicator,
+  StepNumber,
+  Stepper,
+  StepSeparator,
+  StepStatus,
+  StepTitle,
+  Textarea,
+  useSteps,
+} from '@chakra-ui/react';
+import React, { useRef } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { AuthorsField } from './AuthorsField';
+import { AuthorsTableHandle } from './AuthorsTable';
+import { KeywordsField } from './KeywordsField';
+import { PubDateField } from './PubDateField';
+import { ReferencesField } from './ReferencesField';
+import { ReferencesTableHandle } from './ReferencesField';
+import { UrlsField } from './UrlsField';
+import { COLLECTIONS, FormValues } from './types';
+
+interface WizardStep {
+  title: string;
+  description: string;
+  fields: (keyof FormValues)[];
+}
+
+const STEPS: WizardStep[] = [
+  {
+    title: 'Contact',
+    description: 'Your info',
+    fields: ['name', 'email'],
+  },
+  {
+    title: 'Publication',
+    description: 'Record details',
+    fields: ['title', 'collection', 'publication', 'pubDate', 'bibcode'],
+  },
+  {
+    title: 'Authors',
+    description: 'Authorship',
+    fields: ['authors', 'noAuthors'],
+  },
+  {
+    title: 'Content',
+    description: 'Abstract & more',
+    fields: ['abstract', 'keywords', 'urls'],
+  },
+  {
+    title: 'References',
+    description: 'Wrap up',
+    fields: ['references', 'comments'],
+  },
+];
+
+// first focusable field per step; steps with only custom components are omitted
+const STEP_FOCUS: Partial<Record<number, keyof FormValues>> = {
+  0: 'name',
+  1: 'title',
+  3: 'abstract',
+  4: 'comments',
+};
+
+interface RecordWizardProps {
+  onPreview: (e?: React.BaseSyntheticEvent) => void;
+  isLoading: boolean;
+}
+
+export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
+  const {
+    activeStep,
+    goToNext,
+    goToPrevious,
+    setActiveStep: goToStep,
+  } = useSteps({
+    index: 0,
+    count: STEPS.length,
+  });
+
+  const authorsRef = useRef<AuthorsTableHandle>(null);
+  const referencesRef = useRef<ReferencesTableHandle>(null);
+  const {
+    trigger,
+    register,
+    control,
+    setFocus,
+    formState: { errors },
+  } = useFormContext<FormValues>();
+
+  const handleNext = async () => {
+    // Flush any in-progress row before validating
+    authorsRef.current?.flush();
+    referencesRef.current?.flush();
+    const valid = await trigger(STEPS[activeStep].fields);
+    if (valid) {
+      goToNext();
+      const nextStep = activeStep + 1;
+      const focusField = STEP_FOCUS[nextStep];
+      if (focusField) {
+        // defer until the next step's DOM is rendered
+        setTimeout(() => setFocus(focusField), 0);
+      }
+    }
+  };
+
+  const isLastStep = activeStep === STEPS.length - 1;
+
+  return (
+    <Box>
+      <Stepper index={activeStep} mb={8} size="sm" colorScheme="blue">
+        {STEPS.map((step, index) => {
+          const isCompleted = index < activeStep;
+          return (
+            <Step
+              key={index}
+              onClick={isCompleted ? () => goToStep(index) : undefined}
+              cursor={isCompleted ? 'pointer' : undefined}
+            >
+              <StepIndicator>
+                <StepStatus complete={<StepIcon />} incomplete={<StepNumber />} active={<StepNumber />} />
+              </StepIndicator>
+              <Box flexShrink={0}>
+                <StepTitle>{step.title}</StepTitle>
+                <StepDescription>{step.description}</StepDescription>
+              </Box>
+              <StepSeparator />
+            </Step>
+          );
+        })}
+      </Stepper>
+
+      <Box minH="300px">
+        {activeStep === 0 && (
+          <Flex direction={{ base: 'column', sm: 'row' }} gap={2}>
+            <FormControl isRequired isInvalid={!!errors.name}>
+              <FormLabel>Name</FormLabel>
+              <Input {...register('name')} />
+              <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+            </FormControl>
+            <FormControl isRequired isInvalid={!!errors.email}>
+              <FormLabel>Email</FormLabel>
+              <Input {...register('email')} type="email" />
+              <FormErrorMessage>{errors.email?.message}</FormErrorMessage>
+            </FormControl>
+          </Flex>
+        )}
+
+        {activeStep === 1 && (
+          <Stack spacing={4}>
+            <FormControl>
+              <FormLabel>Collection</FormLabel>
+              <Controller
+                name="collection"
+                control={control}
+                render={({ field: { ref: _ref, ...rest } }) => (
+                  <CheckboxGroup {...rest}>
+                    <Stack direction={{ base: 'column', sm: 'row' }} justify="space-between">
+                      {COLLECTIONS.map((c) => (
+                        <Checkbox key={`collection-${c.value}`} value={c.value}>
+                          {c.label}
+                        </Checkbox>
+                      ))}
+                    </Stack>
+                  </CheckboxGroup>
+                )}
+              />
+            </FormControl>
+            <FormControl isRequired isInvalid={!!errors.title}>
+              <FormLabel>Title</FormLabel>
+              <Input {...register('title')} />
+              <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+            </FormControl>
+            <Flex direction={{ base: 'column', sm: 'row' }} gap={2}>
+              <FormControl isRequired isInvalid={!!errors.publication}>
+                <FormLabel>Publication</FormLabel>
+                <Input {...register('publication')} />
+                <FormErrorMessage>{errors.publication?.message}</FormErrorMessage>
+              </FormControl>
+              <PubDateField />
+            </Flex>
+            <FormControl>
+              <FormLabel>Bibcode / DOI (optional)</FormLabel>
+              <Input {...register('bibcode')} placeholder="e.g. 2024ApJ...123..456A" />
+            </FormControl>
+          </Stack>
+        )}
+
+        {activeStep === 2 && <AuthorsField ref={authorsRef} />}
+
+        {activeStep === 3 && (
+          <Stack spacing={4}>
+            <FormControl>
+              <FormLabel>Abstract</FormLabel>
+              <Textarea {...register('abstract')} rows={8} />
+            </FormControl>
+            <KeywordsField />
+            <UrlsField />
+          </Stack>
+        )}
+
+        {activeStep === 4 && (
+          <Stack spacing={4}>
+            <ReferencesField ref={referencesRef} />
+            <FormControl>
+              <FormLabel>User Comments</FormLabel>
+              <Textarea {...register('comments')} />
+            </FormControl>
+          </Stack>
+        )}
+      </Box>
+
+      <HStack mt={6} justify="space-between">
+        <Button variant="outline" onClick={goToPrevious} isDisabled={activeStep === 0 || isLoading}>
+          Back
+        </Button>
+        {isLastStep ? (
+          <Button onClick={onPreview} isLoading={isLoading}>
+            Preview
+          </Button>
+        ) : (
+          <Button onClick={handleNext} isDisabled={isLoading}>
+            Next
+          </Button>
+        )}
+      </HStack>
+    </Box>
+  );
+}

--- a/src/components/FeedbackForms/MissingRecord/RecordWizard.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordWizard.tsx
@@ -30,7 +30,7 @@ import { KeywordsField } from './KeywordsField';
 import { PubDateField } from './PubDateField';
 import { ReferencesField } from './ReferencesField';
 import { ReferencesTableHandle } from './ReferencesField';
-import { UrlsField } from './UrlsField';
+import { UrlsField, UrlsTableHandle } from './UrlsField';
 import { COLLECTIONS, FormValues } from './types';
 
 interface WizardStep {
@@ -93,6 +93,7 @@ export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
 
   const authorsRef = useRef<AuthorsTableHandle>(null);
   const referencesRef = useRef<ReferencesTableHandle>(null);
+  const urlsRef = useRef<UrlsTableHandle>(null);
   const {
     trigger,
     register,
@@ -105,6 +106,7 @@ export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
     // Flush any in-progress row before validating
     authorsRef.current?.flush();
     referencesRef.current?.flush();
+    urlsRef.current?.flush();
     const valid = await trigger(STEPS[activeStep].fields);
     if (valid) {
       goToNext();
@@ -118,6 +120,13 @@ export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
   };
 
   const isLastStep = activeStep === STEPS.length - 1;
+
+  const handlePreview = (e?: React.BaseSyntheticEvent) => {
+    authorsRef.current?.flush();
+    referencesRef.current?.flush();
+    urlsRef.current?.flush();
+    onPreview(e);
+  };
 
   return (
     <Box>
@@ -208,7 +217,7 @@ export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
               <Textarea {...register('abstract')} rows={8} />
             </FormControl>
             <KeywordsField />
-            <UrlsField />
+            <UrlsField ref={urlsRef} />
           </Stack>
         )}
 
@@ -228,7 +237,7 @@ export function RecordWizard({ onPreview, isLoading }: RecordWizardProps) {
           Back
         </Button>
         {isLastStep ? (
-          <Button onClick={onPreview} isLoading={isLoading}>
+          <Button onClick={handlePreview} isLoading={isLoading}>
             Preview
           </Button>
         ) : (

--- a/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
@@ -1,20 +1,24 @@
 import { CheckIcon, CloseIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { FormControl, FormLabel, HStack, IconButton, Input, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import { Select, SelectOption } from '@/components/Select';
-import { ChangeEvent, KeyboardEvent, MouseEvent, useRef, useState } from 'react';
+import { ChangeEvent, KeyboardEvent, MouseEvent, forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { FormValues, IReference, ReferenceType, referenceTypes } from './types';
 import { SelectInstance } from 'react-select';
 import { useFieldArray } from 'react-hook-form';
 import { useIsClient } from '@/lib/useIsClient';
 
-export const ReferencesField = () => {
+export interface ReferencesTableHandle {
+  flush: () => void;
+}
+
+export const ReferencesField = forwardRef<ReferencesTableHandle>(function ReferencesField(_, ref) {
   return (
     <FormControl>
       <FormLabel>References</FormLabel>
-      <ReferencesTable editable />
+      <ReferencesTable editable ref={ref} />
     </FormControl>
   );
-};
+});
 
 const typeOptions: SelectOption<ReferenceType>[] = referenceTypes.map((r) => ({
   id: r,
@@ -22,7 +26,10 @@ const typeOptions: SelectOption<ReferenceType>[] = referenceTypes.map((r) => ({
   value: r as string,
 }));
 
-export const ReferencesTable = ({ editable }: { editable: boolean }) => {
+export const ReferencesTable = forwardRef<ReferencesTableHandle, { editable: boolean }>(function ReferencesTable(
+  { editable },
+  ref,
+) {
   const isClient = useIsClient();
 
   const { fields, append, remove, update } = useFieldArray<FormValues, 'references'>({
@@ -47,8 +54,7 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
   };
 
   const newReferenceIsValid = !!newReference && isValidReference(newReference);
-
-  const editReferenceisValid = editReference.reference && isValidReference(editReference.reference);
+  const editReferenceIsValid = editReference.reference && isValidReference(editReference.reference);
 
   // Changes to fields for adding new Reference
 
@@ -64,8 +70,24 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
     append(newReference);
     // clear input fields
     setNewReference({ type: 'Bibcode', reference: '' });
-    (newReferenceInputRef.current as SelectInstance).focus();
+    (newReferenceInputRef.current as SelectInstance)?.focus();
   };
+
+  // Flush any in-progress row (new or being edited) when navigating away
+  useImperativeHandle(
+    ref,
+    () => ({
+      flush: () => {
+        if (editReferenceIsValid && editReference.index !== -1) {
+          handleApplyEditReference();
+        }
+        if (newReferenceIsValid) {
+          handleAddReference();
+        }
+      },
+    }),
+    [newReferenceIsValid, editReferenceIsValid, editReference.index],
+  );
 
   // Changes to fields for existing Reference
 
@@ -79,7 +101,10 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
   };
 
   const handleEditReferenceChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setEditReference((prev) => ({ index: prev.index, reference: { ...prev.reference, reference: e.target.value } }));
+    setEditReference((prev) => ({
+      index: prev.index,
+      reference: { ...prev.reference, reference: e.target.value },
+    }));
   };
 
   const handleDeleteReference = (e: MouseEvent<HTMLButtonElement>) => {
@@ -97,7 +122,7 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
   };
 
   const handleKeydownEditRef = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && editReferenceisValid) {
+    if (e.key === 'Enter' && editReferenceIsValid) {
       handleApplyEditReference();
     }
   };
@@ -107,6 +132,7 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
       handleAddReference();
     }
   };
+
   // Row for adding new Reference
   const newReferenceTableRow = (
     <Tr>
@@ -196,7 +222,7 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
                     colorScheme="green"
                     data-index={index}
                     onClick={handleApplyEditReference}
-                    isDisabled={!editReferenceisValid}
+                    isDisabled={!editReferenceIsValid}
                   />
                   <IconButton
                     aria-label="cancel"
@@ -243,4 +269,4 @@ export const ReferencesTable = ({ editable }: { editable: boolean }) => {
       </Tbody>
     </Table>
   );
-};
+});

--- a/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
@@ -26,6 +26,12 @@ const typeOptions: SelectOption<ReferenceType>[] = referenceTypes.map((r) => ({
   value: r as string,
 }));
 
+const REFERENCE_PLACEHOLDERS: Record<ReferenceType, string> = {
+  Bibcode: 'e.g. 2024ApJ...123..456A',
+  DOI: 'e.g. 10.1234/journal.2024',
+  'Raw Text': 'e.g. Author et al. (2024) Journal, vol. 1',
+};
+
 export const ReferencesTable = forwardRef<ReferencesTableHandle, { editable: boolean }>(function ReferencesTable(
   { editable },
   ref,
@@ -158,6 +164,7 @@ export const ReferencesTable = forwardRef<ReferencesTableHandle, { editable: boo
           onChange={handleNewReferenceChange}
           value={newReference?.reference ?? ''}
           onKeyDown={handleKeydownNewRef}
+          placeholder={REFERENCE_PLACEHOLDERS[newReference.type]}
         />
       </Td>
       <Td>
@@ -211,6 +218,7 @@ export const ReferencesTable = forwardRef<ReferencesTableHandle, { editable: boo
                   onChange={handleEditReferenceChange}
                   value={editReference.reference.reference}
                   onKeyDown={handleKeydownEditRef}
+                  placeholder={REFERENCE_PLACEHOLDERS[editReference.reference.type]}
                 />
               </Td>
               <Td>

--- a/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/ReferencesField.tsx
@@ -92,7 +92,7 @@ export const ReferencesTable = forwardRef<ReferencesTableHandle, { editable: boo
         }
       },
     }),
-    [newReferenceIsValid, editReferenceIsValid, editReference.index],
+    [newReference, editReference, newReferenceIsValid, editReferenceIsValid],
   );
 
   // Changes to fields for existing Reference

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -123,7 +123,7 @@ export const UrlsTable = forwardRef<UrlsTableHandle, { editable: boolean }>(func
         }
       },
     }),
-    [newUrlIsValid, editUrlisValid, editUrl.index],
+    [newUrl, editUrl, newUrlIsValid, editUrlisValid],
   );
 
   // Changes to fields for existing url

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -78,12 +78,9 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
     if (!url || !type) {
       return false;
     }
-
-    const VALID_PROTOCOLS = ['http:', 'https:'];
-
     try {
-      const testUrl = new URL(url);
-      return VALID_PROTOCOLS.includes(testUrl.protocol);
+      const { protocol } = new URL(normalizeUrl(url));
+      return protocol === 'http:' || protocol === 'https:';
     } catch {
       return false;
     }

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -83,8 +83,8 @@ export const UrlsTable = forwardRef<UrlsTableHandle, { editable: boolean }>(func
       return false;
     }
     try {
-      const { protocol } = new URL(normalizeUrl(url));
-      return protocol === 'http:' || protocol === 'https:';
+      const { protocol, hostname } = new URL(normalizeUrl(url));
+      return (protocol === 'http:' || protocol === 'https:') && (hostname.includes('.') || hostname === 'localhost');
     } catch {
       return false;
     }

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -193,6 +193,7 @@ export const UrlsTable = forwardRef<UrlsTableHandle, { editable: boolean }>(func
           value={newUrl?.url ?? ''}
           onKeyDown={handleKeydownNewUrl}
           placeholder={URL_PLACEHOLDERS[newUrl.type]}
+          isInvalid={newUrl.url.length > 0 && !newUrlIsValid}
         />
       </Td>
       <Td>
@@ -242,6 +243,7 @@ export const UrlsTable = forwardRef<UrlsTableHandle, { editable: boolean }>(func
                   value={editUrl.url.url}
                   onKeyDown={handleKeydownEditUrl}
                   placeholder={URL_PLACEHOLDERS[editUrl.url.type]}
+                  isInvalid={editUrl.url.url.length > 0 && !editUrlisValid}
                 />
               </Td>
 

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -2,21 +2,25 @@ import { CheckIcon, CloseIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { FormControl, FormLabel, HStack, IconButton, Input, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import { Select, SelectOption } from '@/components/Select';
 
-import { ChangeEvent, KeyboardEvent, MouseEvent, useRef, useState } from 'react';
+import { ChangeEvent, KeyboardEvent, MouseEvent, forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { SelectInstance } from 'react-select';
 import { FormValues } from './types';
 import { IResourceUrl, ResourceUrlType, resourceUrlTypes } from '@/lib/useGetResourceLinks';
 import { useIsClient } from '@/lib/useIsClient';
 
-export const UrlsField = () => {
+export interface UrlsTableHandle {
+  flush: () => void;
+}
+
+export const UrlsField = forwardRef<UrlsTableHandle>(function UrlsField(_, ref) {
   return (
     <FormControl>
       <FormLabel>URLs</FormLabel>
-      <UrlsTable editable />
+      <UrlsTable editable ref={ref} />
     </FormControl>
   );
-};
+});
 
 const typeOptions: SelectOption<ResourceUrlType>[] = resourceUrlTypes.map((t) => ({
   id: t,
@@ -40,7 +44,7 @@ function normalizeUrl(raw: string): string {
   return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
 }
 
-export const UrlsTable = ({ editable }: { editable: boolean }) => {
+export const UrlsTable = forwardRef<UrlsTableHandle, { editable: boolean }>(function UrlsTable({ editable }, ref) {
   const isClient = useIsClient();
 
   const {
@@ -105,6 +109,22 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
     setNewUrl({ type: 'arXiv', url: '' });
     (newURLTypeInputRef.current as SelectInstance).focus();
   };
+
+  // Flush any in-progress row (new or being edited) when navigating away
+  useImperativeHandle(
+    ref,
+    () => ({
+      flush: () => {
+        if (editUrlisValid && editUrl.index !== -1) {
+          handleApplyEditUrl();
+        }
+        if (newUrlIsValid) {
+          handleAddUrl();
+        }
+      },
+    }),
+    [newUrlIsValid, editUrlisValid, editUrl.index],
+  );
 
   // Changes to fields for existing url
 
@@ -281,4 +301,4 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
       </Tbody>
     </Table>
   );
-};
+});

--- a/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
+++ b/src/components/FeedbackForms/MissingRecord/UrlsField.tsx
@@ -24,6 +24,22 @@ const typeOptions: SelectOption<ResourceUrlType>[] = resourceUrlTypes.map((t) =>
   value: t as string,
 }));
 
+const URL_PLACEHOLDERS: Record<ResourceUrlType, string> = {
+  arXiv: 'https://arxiv.org/abs/XXXXXXX',
+  PDF: 'https://example.com/paper.pdf',
+  DOI: 'https://doi.org/10.XXXX/XXXXX',
+  HTML: 'https://example.com/paper.html',
+  Other: 'https://',
+};
+
+function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
 export const UrlsTable = ({ editable }: { editable: boolean }) => {
   const isClient = useIsClient();
 
@@ -88,8 +104,7 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   };
 
   const handleAddUrl = () => {
-    append(newUrl);
-    // clear input fields
+    append({ ...newUrl, url: normalizeUrl(newUrl.url) });
     setNewUrl({ type: 'arXiv', url: '' });
     (newURLTypeInputRef.current as SelectInstance).focus();
   };
@@ -115,7 +130,7 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
   };
 
   const handleApplyEditUrl = () => {
-    update(editUrl.index, editUrl.url);
+    update(editUrl.index, { ...editUrl.url, url: normalizeUrl(editUrl.url.url) });
     setEditUrl({ index: -1, url: null });
   };
 
@@ -155,7 +170,13 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
         )}
       </Td>
       <Td>
-        <Input size="sm" onChange={handleNewUrlChange} value={newUrl?.url ?? ''} onKeyDown={handleKeydownNewUrl} />
+        <Input
+          size="sm"
+          onChange={handleNewUrlChange}
+          value={newUrl?.url ?? ''}
+          onKeyDown={handleKeydownNewUrl}
+          placeholder={URL_PLACEHOLDERS[newUrl.type]}
+        />
       </Td>
       <Td>
         <IconButton
@@ -203,6 +224,7 @@ export const UrlsTable = ({ editable }: { editable: boolean }) => {
                   onChange={handleEditUrlChange}
                   value={editUrl.url.url}
                   onKeyDown={handleKeydownEditUrl}
+                  placeholder={URL_PLACEHOLDERS[editUrl.url.type]}
                 />
               </Td>
 

--- a/src/components/FeedbackForms/MissingRecord/types.ts
+++ b/src/components/FeedbackForms/MissingRecord/types.ts
@@ -1,7 +1,6 @@
-import type { IResourceUrl } from '@/lib/useGetResourceLinks';
-
 import { ArrayChange, Change } from 'diff';
 import type { Database } from '@/api/search/types';
+import type { IResourceUrl } from '@/lib/useGetResourceLinks';
 
 export interface IAuthor {
   name: string;
@@ -11,7 +10,7 @@ export interface IAuthor {
 
 export const referenceTypes = ['Raw Text', 'DOI', 'Bibcode'] as const;
 
-export type ReferenceType = typeof referenceTypes[number];
+export type ReferenceType = (typeof referenceTypes)[number];
 
 export interface IReference {
   type: ReferenceType;
@@ -39,6 +38,13 @@ export type FormValues = {
   references: IReference[];
   comments: string;
 };
+
+export const COLLECTIONS: { value: Database; label: string }[] = [
+  { value: 'astronomy', label: 'Astronomy and Astrophysics' },
+  { value: 'physics', label: 'Physics and Geophysics' },
+  { value: 'earthscience', label: 'Earth Science' },
+  { value: 'general', label: 'General' },
+];
 
 export type DiffSection = {
   label: string;

--- a/src/components/FeedbackForms/MissingRecord/useFormDraft.test.ts
+++ b/src/components/FeedbackForms/MissingRecord/useFormDraft.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { useFormDraft } from './useFormDraft';
+import { FormValues } from './types';
+
+const DRAFT_KEY = 'feedback-draft:new-record';
+
+const defaultValues: FormValues = {
+  name: '',
+  email: '',
+  isNew: true,
+  bibcode: '',
+  collection: [],
+  title: '',
+  noAuthors: false,
+  authors: [],
+  publication: '',
+  pubDate: '',
+  urls: [],
+  abstract: '',
+  keywords: [],
+  references: [],
+  comments: '',
+};
+
+function setup(existingDraft?: Partial<FormValues>) {
+  if (existingDraft) {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify({ ...defaultValues, ...existingDraft }));
+  }
+  return renderHook(() => {
+    const methods = useForm<FormValues>({ defaultValues });
+    const draft = useFormDraft(DRAFT_KEY, methods);
+    return { methods, draft };
+  });
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe('useFormDraft', () => {
+  test('hasDraft is false when no draft saved', () => {
+    const { result } = setup();
+    expect(result.current.draft.hasDraft).toBe(false);
+  });
+
+  test('hasDraft is true when draft exists in localStorage on mount', () => {
+    const { result } = setup({ name: 'Alice' });
+    expect(result.current.draft.hasDraft).toBe(true);
+  });
+
+  test('clearDraft removes localStorage entry and sets hasDraft false', () => {
+    const { result } = setup({ name: 'Alice' });
+    act(() => result.current.draft.clearDraft());
+    expect(result.current.draft.hasDraft).toBe(false);
+    expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  test('getDraftValues returns parsed draft when one exists', () => {
+    const { result } = setup({ name: 'Alice', title: 'My Paper' });
+    const values = result.current.draft.getDraftValues();
+    expect(values?.name).toBe('Alice');
+    expect(values?.title).toBe('My Paper');
+  });
+
+  test('getDraftValues returns null when no draft', () => {
+    const { result } = setup();
+    expect(result.current.draft.getDraftValues()).toBeNull();
+  });
+
+  test('saveDraft writes to localStorage and sets hasDraft true', () => {
+    const { result } = setup();
+    act(() => result.current.draft.saveDraft({ ...defaultValues, name: 'Bob', title: 'Test' }));
+    const stored = JSON.parse(localStorage.getItem(DRAFT_KEY)!) as FormValues;
+    expect(stored.name).toBe('Bob');
+    expect(stored.title).toBe('Test');
+    expect(result.current.draft.hasDraft).toBe(true);
+  });
+
+  test('key=null disables draft entirely — no reads or writes', () => {
+    const { result } = renderHook(() => {
+      const methods = useForm<FormValues>({ defaultValues });
+      const draft = useFormDraft(null, methods);
+      return { methods, draft };
+    });
+    expect(result.current.draft.hasDraft).toBe(false);
+    expect(result.current.draft.getDraftValues()).toBeNull();
+    act(() => result.current.draft.saveDraft({ ...defaultValues, name: 'Ghost' }));
+    expect(result.current.draft.hasDraft).toBe(false);
+    expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  test('getDraftValues returns null when localStorage contains invalid JSON', () => {
+    localStorage.setItem(DRAFT_KEY, 'not-valid-json');
+    const { result } = setup();
+    expect(result.current.draft.getDraftValues()).toBeNull();
+  });
+});

--- a/src/components/FeedbackForms/MissingRecord/useFormDraft.ts
+++ b/src/components/FeedbackForms/MissingRecord/useFormDraft.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { UseFormReturn } from 'react-hook-form';
+import { isBrowser } from '@/utils/common/guards';
+import { FormValues } from './types';
+
+function readDraft(key: string): FormValues | null {
+  if (!isBrowser()) {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as FormValues) : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface FormDraft {
+  hasDraft: boolean;
+  getDraftValues: () => FormValues | null;
+  saveDraft: (values: FormValues) => void;
+  clearDraft: () => void;
+  cancelPendingSave: () => void;
+}
+
+export function useFormDraft(key: string | null, formMethods: UseFormReturn<FormValues>): FormDraft {
+  const [hasDraft, setHasDraft] = useState(() => key !== null && readDraft(key) !== null);
+
+  const saveDraft = useCallback(
+    (values: FormValues) => {
+      if (key === null || !isBrowser()) {
+        return;
+      }
+      try {
+        localStorage.setItem(key, JSON.stringify(values));
+        setHasDraft(true);
+      } catch {
+        // Storage write failures are non-fatal; form continues without draft persistence.
+      }
+    },
+    [key],
+  );
+
+  const debouncedSave = useDebouncedCallback(saveDraft, 500);
+
+  const clearDraft = useCallback(() => {
+    if (key === null || !isBrowser()) {
+      return;
+    }
+    debouncedSave.cancel();
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // Best-effort; storage may be unavailable.
+    }
+    setHasDraft(false);
+  }, [key, debouncedSave]);
+
+  const cancelPendingSave = useCallback(() => {
+    debouncedSave.cancel();
+  }, [debouncedSave]);
+
+  const getDraftValues = useCallback((): FormValues | null => (key !== null ? readDraft(key) : null), [key]);
+
+  // Auto-save on watch changes — only when the form is dirty (user has made edits).
+  // Gating on isDirty prevents reset() calls from overwriting a valid saved draft.
+  useEffect(() => {
+    if (key === null) {
+      return;
+    }
+    const subscription = formMethods.watch((values) => {
+      if (!formMethods.formState.isDirty) {
+        return;
+      }
+      debouncedSave(values as FormValues);
+    });
+    return () => {
+      subscription.unsubscribe();
+      debouncedSave.cancel();
+    };
+    // formMethods is stable for the lifetime of a given form instance; exclude from deps
+    // to avoid tearing down and re-creating the watch subscription on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, debouncedSave]);
+
+  return { hasDraft, getDraftValues, saveDraft, clearDraft, cancelPendingSave };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export enum LocalSettings {
   LAST_DISMISSED_SYS_MSG = 'last-sys-msg',
   CAROUSEL = 'carousels',
   LAST_LANDING_FORM = 'last-landing-form',
+  FEEDBACK_DRAFT_NEW = 'feedback-draft:new-record',
+  FEEDBACK_FORM_MODE = 'feedback-form:mode',
 }
 
 export enum AppErrorCode {
@@ -68,4 +70,3 @@ declare global {
     onResponse: unknown;
   };
 }
-


### PR DESCRIPTION
Improves the missing record submission UX.

- Auto-save draft to localStorage (500ms debounce) with restore banner on reload
- Live completion checklist for required fields in Standard mode
- Trying out an idea: Step-by-step guided wizard mode (Standard/Guided toggle)
- Form fixes: blur validation, missing error messages on Title/Publication, date input filtering