### PR TITLE
fix(ui): sort height alignment, paper form button sizes, facet gap

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -72,7 +72,8 @@ function SelectImpl<
         sort: {
           control: (provided) => ({
             ...provided,
-            height: '2.6em',
+            height: '40px',
+            minHeight: '40px',
             borderRadius: '2px 0 0 2px',
             borderRightWidth: '0',
             borderColor: colors.border,

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -236,7 +236,7 @@ const JournalQueryForm = ({ onSubmit, error }: SubFormProps) => {
           <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>
@@ -293,7 +293,7 @@ const ReferenceQueryForm = ({ onSubmit, error }: SubFormProps) => {
           <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>
@@ -350,7 +350,7 @@ const BibcodeQueryForm = ({ onSubmit, error }: SubFormProps) => {
           <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -233,10 +233,10 @@ const JournalQueryForm = ({ onSubmit, error }: SubFormProps) => {
           </GridItem>
         </Grid>
         <Stack direction="row" mt={5}>
-          <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
+          <Button isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>
@@ -290,10 +290,10 @@ const ReferenceQueryForm = ({ onSubmit, error }: SubFormProps) => {
           <FormErrorMessage>{errors.reference && errors.reference.message}</FormErrorMessage>
         </FormControl>
         <Stack direction="row" mt={5}>
-          <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
+          <Button isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>
@@ -347,10 +347,10 @@ const BibcodeQueryForm = ({ onSubmit, error }: SubFormProps) => {
         </FormControl>
 
         <Stack direction="row" mt={5}>
-          <Button size="sm" isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
+          <Button isDisabled={isSubmitting} type="submit" isLoading={isSubmitting}>
             Search
           </Button>
-          <Button size="sm" type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
+          <Button type="reset" variant="outline" onClick={handleReset} isDisabled={isSubmitting}>
             Reset
           </Button>
         </Stack>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -535,7 +535,7 @@ const SearchFacetFilters = (props: {
     );
   }
   return (
-    <Box as="aside" aria-labelledby="search-facets">
+    <>
       <Portal appendToParentPortal>
         <Button
           position="absolute"
@@ -552,7 +552,7 @@ const SearchFacetFilters = (props: {
           Show Filters
         </Button>
       </Portal>
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
- align sort dropdown height (40px) with adjacent asc/desc toggle button
- add missing `size="sm"` to Reset buttons on paper form (all three sub-forms)
- remove empty aside flex child when facets are hidden, eliminating left-side gap in results layout

<img width="875" height="775" alt="image" src="https://github.com/user-attachments/assets/2e395a28-81d1-448c-92a7-0c545a313a4c" />

<img width="1652" height="309" alt="image" src="https://github.com/user-attachments/assets/fe89bbf5-b70e-4ad5-8386-f06a9c59ec50" />

<img width="626" height="631" alt="image" src="https://github.com/user-attachments/assets/8f89fe08-0c22-4107-ac45-269e2e1a8517" />
