### PR TITLE
Fix record doesn't load in feedback form when title is undefined

### DIFF
--- a/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
+++ b/src/components/FeedbackForms/MissingRecord/RecordPanel.tsx
@@ -314,7 +314,7 @@ export const RecordPanel = ({
         orcid_pub,
         pub_raw,
         pubdate,
-        title,
+        title = [],
         database = [],
         reference = [] as string[],
       } = data;
@@ -335,7 +335,7 @@ export const RecordPanel = ({
         bibcode: getValues('bibcode'),
         isNew,
         abstract,
-        title: title[0],
+        title: title?.[0] ?? ' ',
         publication: pub_raw,
         pubDate: pubdate,
         noAuthors: !author || authors.length === 0,


### PR DESCRIPTION
Define a default record title in incorrect record form when title is undefined. Since title is a required field in the form, an empty space is used as default, otherwise the form does not load properly.