### PR TITLE
feat: expand telemetry — Sentry spans, GA4 events, Sentry init fix

### DIFF
--- a/src/api/orcid/orcid.ts
+++ b/src/api/orcid/orcid.ts
@@ -147,8 +147,10 @@ const fetchExchangeToken: QueryFunction<IOrcidUser> = async ({ meta }) => {
     params,
   };
 
-  const { data } = await api.request<IOrcidUser>(config);
-  return data;
+  return trackUserFlow(PERF_SPANS.ORCID_OAUTH_TOTAL, async () => {
+    const { data } = await api.request<IOrcidUser>(config);
+    return data;
+  });
 };
 
 const getPreferences: QueryFunction<IOrcidResponse['getPreferences']> = async ({ meta }) => {
@@ -260,9 +262,9 @@ const addWorks: MutationFunction<IOrcidResponse['addWorks'], IOrcidMutationParam
     },
   };
 
-  const { data } = await api.request<{
-    bulk?: { work?: IOrcidWork; error?: OrcidErrorResponse }[];
-  }>(addWorksConfig);
+  const { data } = await trackUserFlow(PERF_SPANS.ORCID_CLAIM_TOTAL, () =>
+    api.request<{ bulk?: { work?: IOrcidWork; error?: OrcidErrorResponse }[] }>(addWorksConfig).then((r) => r.data),
+  );
 
   // it's possible we received multiple success/fails in a response, reformat to match the shape of PromiseSettledResult
   return Object.fromEntries(
@@ -296,9 +298,10 @@ const updateWork: MutationFunction<IOrcidResponse['updateWork'], IOrcidMutationP
     data: work,
   };
 
-  const { data } = await api.request<IOrcidResponse['updateWork']>(config);
-
-  return data;
+  return trackUserFlow(PERF_SPANS.ORCID_SYNC_TOTAL, async () => {
+    const { data } = await api.request<IOrcidResponse['updateWork']>(config);
+    return data;
+  });
 };
 const getName: QueryFunction<IOrcidResponse['name']> = async ({ meta }) => {
   const { params } = meta as { params: IOrcidParams['name'] };

--- a/src/api/orcid/orcid.ts
+++ b/src/api/orcid/orcid.ts
@@ -262,7 +262,7 @@ const addWorks: MutationFunction<IOrcidResponse['addWorks'], IOrcidMutationParam
     },
   };
 
-  const { data } = await trackUserFlow(PERF_SPANS.ORCID_CLAIM_TOTAL, () =>
+  const data = await trackUserFlow(PERF_SPANS.ORCID_CLAIM_TOTAL, () =>
     api.request<{ bulk?: { work?: IOrcidWork; error?: OrcidErrorResponse }[] }>(addWorksConfig).then((r) => r.data),
   );
 

--- a/src/components/CitationExporter/useCitationExporter.ts
+++ b/src/components/CitationExporter/useCitationExporter.ts
@@ -6,6 +6,7 @@ import { purifyString } from '@/utils/common/formatters';
 import { ExportApiJournalFormat, IExportApiParams } from '@/api/export/types';
 import { SolrSort } from '@/api/models';
 import { exportCitationKeys, fetchExportCitation, useGetExportCitation } from '@/api/export/export';
+import { useExportSpan } from '@/lib/useExportSpan';
 
 export interface IUseCitationExporterProps {
   records: ICitationExporterState['records'];
@@ -31,6 +32,8 @@ export const useCitationExporter = ({
   sort,
   ...rest
 }: IUseCitationExporterProps) => {
+  // Machine must only be created once — recreating it on prop change resets state.
+  // Props flow into the machine via dispatch actions below.
   const machine = useMemo(
     () =>
       generateMachine({
@@ -45,7 +48,7 @@ export const useCitationExporter = ({
         sort,
         ...rest,
       }),
-    [],
+    [], // eslint-disable-line react-hooks/exhaustive-deps
   );
   const [state, dispatch] = useMachine(machine);
   const queryClient = useQueryClient();
@@ -56,8 +59,9 @@ export const useCitationExporter = ({
     keyformat: [purifyString(state.context.params.keyformat[0])],
   };
 
-  // on mount, check the cache to see if we any records for this querykey, if not, we should trigger an initial load
-  // should usually have an entry since the data will be available from SSR
+  // On mount only: check cache and prefetch if missing. Must not re-run on
+  // subsequent renders — doing so would re-trigger the initial load on every
+  // format/record change, bypassing the state machine's normal flow.
   useEffect(() => {
     (async () => {
       const queryKey = exportCitationKeys.primary(params);
@@ -73,24 +77,24 @@ export const useCitationExporter = ({
         dispatch('SUBMIT');
       }
     })();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // trigger updates to machine state if incoming props change
-  useEffect(() => dispatch({ type: 'SET_SINGLEMODE', payload: singleMode }), [singleMode]);
+  useEffect(() => dispatch({ type: 'SET_SINGLEMODE', payload: singleMode }), [singleMode, dispatch]);
 
   // watch for format changes
   useEffect(() => {
     if (format !== params.format) {
       dispatch({ type: 'SET_FORMAT', payload: format });
     }
-  }, [format]);
+  }, [format, params.format, dispatch]);
 
   // if we're in singleMode and format is changed, trigger a submit
   useEffect(() => {
     if (singleMode) {
       dispatch('SUBMIT');
     }
-  }, [params.format, singleMode]);
+  }, [params.format, singleMode, dispatch]);
 
   // watch for changes to records
   useEffect(() => {
@@ -99,14 +103,14 @@ export const useCitationExporter = ({
     if (records[0] !== state.context.records[0]) {
       dispatch({ type: 'SET_RECORDS', payload: records });
     }
-  }, [records]);
+  }, [records, state.context.records, dispatch]);
 
   // watch for changes to sort
   useEffect(() => {
     if (sort !== params.sort) {
       dispatch({ type: 'SET_SORT', payload: sort });
     }
-  }, [sort]);
+  }, [sort, params.sort, dispatch]);
 
   // main result fetcher, this will not run unless we're in the 'fetching' state
   const result = useGetExportCitation(params, {
@@ -119,19 +123,21 @@ export const useCitationExporter = ({
     retry: false,
   });
 
+  useExportSpan(state.matches('fetching'), params.format, result.data);
+
   useEffect(() => {
     if (result.data) {
       // derive this state from data, since we don't know if it was fetched from cache or not
       dispatch({ type: 'DONE' });
     }
-  }, [result.data]);
+  }, [result.data, dispatch]);
 
   // safety hatch, in case for some reason we get stuck in fetching mode
   useEffect(() => {
-    if (state.matches('fetching') && result.data) {
+    if (state.value === 'fetching' && result.data) {
       dispatch('DONE');
     }
-  }, [state.value, result.data]);
+  }, [state.value, result.data, dispatch]);
 
   return { ...result, state, dispatch };
 };

--- a/src/components/CitationExporter/useCitationExporter.ts
+++ b/src/components/CitationExporter/useCitationExporter.ts
@@ -123,7 +123,7 @@ export const useCitationExporter = ({
     retry: false,
   });
 
-  useExportSpan(state.matches('fetching'), params.format, result.data);
+  useExportSpan(state.matches('fetching'), params.format, result.data, result.isError);
 
   useEffect(() => {
     if (result.data) {

--- a/src/components/Layout/AbsLayout.tsx
+++ b/src/components/Layout/AbsLayout.tsx
@@ -2,7 +2,7 @@ import { Box, Heading, Stack, Text } from '@chakra-ui/react';
 
 import { MathJax } from 'better-react-mathjax';
 import Head from 'next/head';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { BRAND_NAME_FULL } from '@/config';
 import { Metatags } from '@/components/Metatags';
 import { AbstractSources } from '@/components/AbstractSources';
@@ -10,6 +10,7 @@ import { AbstractSideNav } from '@/components/AbstractSideNav';
 import { stripHtml, unwrapStringValue } from '@/utils/common/formatters';
 import { IDocsEntity } from '@/api/search/types';
 import { AbstractSearchForm } from '@/components/AbstractSearchForm';
+import { sendGTMEvent } from '@next/third-parties/google';
 
 interface IAbsLayoutProps {
   doc?: IDocsEntity;
@@ -19,6 +20,13 @@ interface IAbsLayoutProps {
 
 export const AbsLayout: FC<IAbsLayoutProps> = ({ children, doc, titleDescription, label }) => {
   const rawTitle = doc ? unwrapStringValue(doc.title) : '';
+
+  useEffect(() => {
+    if (!doc?.bibcode) {
+      return;
+    }
+    sendGTMEvent({ event: 'abstract_tab_view', tab: label.toLowerCase(), bibcode: doc.bibcode });
+  }, [label, doc?.bibcode]);
   const title = stripHtml(rawTitle);
   const suffix = `${BRAND_NAME_FULL} ${label}`;
   const pageTitle = title ? `${title} - ${suffix}` : suffix;

--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -30,6 +30,7 @@ import { useColorModeColors } from '@/lib/useColorModeColors';
 import { getFormattedNumericPubdate, unwrapStringValue } from '@/utils/common/formatters';
 import { IDocsEntity } from '@/api/search/types';
 import { keys, toPairs } from 'ramda';
+import { sendGTMEvent } from '@next/third-parties/google';
 
 const AbstractPreview = dynamic<IAbstractPreviewProps>(
   () =>
@@ -82,6 +83,11 @@ export const Item = (props: IItemProps): ReactElement => {
 
   // Scroll restoration - save position when navigating to abstract
   const { saveScrollPosition } = useScrollRestoration();
+
+  const handleAbstractClick = () => {
+    saveScrollPosition();
+    sendGTMEvent({ event: 'result_click', rank: index, bibcode });
+  };
 
   // citations
   const cite = useNormCite ? (
@@ -145,12 +151,12 @@ export const Item = (props: IItemProps): ReactElement => {
             href={`/abs/${encodedCanonicalID}/abstract`}
             fontWeight="semibold"
             className="article-title"
-            onClick={saveScrollPosition}
+            onClick={handleAbstractClick}
           >
             <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
           </SimpleLink>
           <Flex alignItems="start" ml={1}>
-            {!isClient || hideActions ? null : <ItemResourceDropdowns doc={doc} />}
+            {!isClient || hideActions ? null : <ItemResourceDropdowns doc={doc} rank={index} />}
           </Flex>
         </Flex>
         <Flex direction="column">

--- a/src/components/ResultList/Item/ItemResourceDropdowns.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.tsx
@@ -21,9 +21,12 @@ import { IDocsEntity } from '@/api/search/types';
 import { CopyMenuItem } from '@/components/CopyButton';
 import { useGetExportCitation } from '@/api/export/export';
 import { useSettings } from '@/lib/useSettings';
+import { sendGTMEvent } from '@next/third-parties/google';
+import { closeFullTextTimingSpan } from '@/lib/performance';
 
 export interface IItemResourceDropdownsProps {
   doc: IDocsEntity;
+  rank?: number;
   /** @deprecated No longer used — citation is fetched lazily. */
   defaultCitation?: string;
 }
@@ -32,9 +35,11 @@ export interface IItem {
   id: string;
   label: ReactElement | string;
   path?: string;
+  name?: string;
+  isOpen?: boolean;
 }
 
-export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): ReactElement => {
+export const ItemResourceDropdowns = ({ doc, rank }: IItemResourceDropdownsProps): ReactElement => {
   const router = useRouter();
   const toast = useToast();
   const { isOpen: isShareOpen, onOpen: onShareOpen, onClose: onShareClose } = useDisclosure();
@@ -59,14 +64,14 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
     if (value !== '') {
       onCopy();
     }
-  }, [value]);
+  }, [value, onCopy]);
 
   useEffect(() => {
     if (hasCopied) {
       toast({ status: 'info', title: 'Copied to Clipboard' });
       setValue('');
     }
-  }, [hasCopied]);
+  }, [hasCopied, setValue, toast]);
 
   const encodedCanonicalID = doc?.bibcode ? encodeURIComponent(doc.bibcode) : '';
 
@@ -94,6 +99,8 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
       ),
       path: source.url,
       id: `fullText-${source.name}`,
+      name: source.name,
+      isOpen: source.open,
       newTab: true,
     }));
 
@@ -128,9 +135,17 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
 
   const handleResourceClick: MouseEventHandler<HTMLElement> = (e) => {
     const id = e.currentTarget.dataset['id'];
-    const path = fullSourceItems.find((item) => id === item.id)?.path;
-    if (isBrowser() && path) {
-      window.open(path, '_blank', 'noopener');
+    const item = fullSourceItems.find((i) => id === i.id);
+    if (isBrowser() && item?.path) {
+      sendGTMEvent({
+        event: 'full_text_click',
+        source_name: item.name,
+        is_open_access: item.isOpen ?? false,
+        bibcode: doc.bibcode,
+        ...(rank !== undefined && { rank }),
+      });
+      closeFullTextTimingSpan();
+      window.open(item.path, '_blank', 'noopener');
     }
   };
 

--- a/src/components/ResultList/Item/ItemResourceDropdowns.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.tsx
@@ -101,14 +101,12 @@ export const ItemResourceDropdowns = ({ doc, rank }: IItemResourceDropdownsProps
       id: `fullText-${source.name}`,
       name: source.name,
       isOpen: source.open,
-      newTab: true,
     }));
 
     dataProductItems = dataProducts.map((dp) => ({
       label: dp.name,
       path: dp.url,
       id: `dataProd-${dp.name}`,
-      newTab: true,
     }));
   }
 

--- a/src/components/ResultList/SimpleResultList.tsx
+++ b/src/components/ResultList/SimpleResultList.tsx
@@ -7,6 +7,7 @@ import { Item, IItemProps } from './Item';
 import { useHighlights } from './useHighlights';
 import { IDocsEntity } from '@/api/search/types';
 import { handleBoundaryError } from '@/lib/errorHandler';
+import { useResultsRenderSpan } from '@/lib/useRenderSpan';
 
 export interface ISimpleResultListProps extends HTMLAttributes<HTMLDivElement> {
   docs: IDocsEntity[];
@@ -65,6 +66,8 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
 
   const isClient = useIsClient();
   const start = indexStart + 1;
+
+  useResultsRenderSpan(docs);
 
   const { highlights, showHighlights, isFetchingHighlights } = useHighlights();
 

--- a/src/components/SearchFacet/SearchFacet.tsx
+++ b/src/components/SearchFacet/SearchFacet.tsx
@@ -242,6 +242,7 @@ export interface ISearchFacetsProps {
 
 export const SearchFacets = (props: ISearchFacetsProps) => {
   const { onQueryUpdate } = props;
+
   const facets = useStore((state) => state.settings.searchFacets.order);
   const getHiddenFacets = useStore((state) => state.getHiddenSearchFacets);
   const setFacets = useStore((state) => state.setSearchFacetOrder);
@@ -253,6 +254,9 @@ export const SearchFacets = (props: ISearchFacetsProps) => {
 
   const [showHiddenFacets, setShowHiddenFacets] = useState(false);
   const [draggingFacetId, setDraggingFacetId] = useState<SearchFacetID>();
+  // getHiddenFacets is a stable store selector — adding it does not make the
+  // memo reactive. facets is the actual reactive dep that drives recomputation.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const hiddenFacets = useMemo(() => getHiddenFacets(), [facets]);
 
   // hold temporary order of visible and hidden facets during drag and drop
@@ -267,7 +271,9 @@ export const SearchFacets = (props: ISearchFacetsProps) => {
       visible: without(ignoredFacets, facets),
       hidden: uniq([...getHiddenFacets(), ...ignoredFacets]),
     });
-    // unable to add facets to deps because it disallows ignored facets from being un-hidden
+    // facets intentionally excluded: adding it would prevent ignored facets from being un-hidden
+    // because facets and ignoredFacets update together, causing the effect to see stale state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ignoredFacets, getHiddenFacets]);
 
   useEffect(() => {

--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -1,7 +1,46 @@
 import * as Sentry from '@sentry/nextjs';
+import type { IADSApiSearchParams } from '@/api/search/types';
 
 export type ResultCountBucket = '0' | '1-10' | '11-100' | '100+';
 export type QueryType = 'simple' | 'fielded' | 'boolean';
+
+// Span slots: opened in Telemetry while the nav transaction is live, closed after paint.
+// Each slot is a module-level singleton — client-only, one browser instance per process.
+function makeSpanSlot(name: string, op: string) {
+  let _span: ReturnType<typeof Sentry.startInactiveSpan> | null = null;
+  return {
+    open(): void {
+      try {
+        _span?.end();
+        _span = Sentry.startInactiveSpan({ name, op });
+      } catch {}
+    },
+    close(attrs?: Record<string, string | number | boolean>): void {
+      if (!_span) {
+        return;
+      }
+      try {
+        if (attrs) {
+          _span.setAttributes(attrs);
+        }
+        _span.setStatus({ code: 1 });
+        _span.end();
+      } catch {}
+      _span = null;
+    },
+  };
+}
+
+const resultsSlot = makeSpanSlot('search.results.render', 'ui.render');
+const facetsSlot = makeSpanSlot('search.facets.render', 'ui.render');
+const fullTextSlot = makeSpanSlot('ux.full_text_time', 'user.flow');
+
+export const openResultsRenderSpan = (): void => resultsSlot.open();
+export const closeResultsRenderSpan = (docCount: number): void => resultsSlot.close({ doc_count: docCount });
+export const openFacetsRenderSpan = (): void => facetsSlot.open();
+export const closeFacetsRenderSpan = (): void => facetsSlot.close();
+export const openFullTextTimingSpan = (): void => fullTextSlot.open();
+export const closeFullTextTimingSpan = (): void => fullTextSlot.close();
 
 export interface PerformanceSpanTags {
   query_type?: QueryType;
@@ -10,14 +49,17 @@ export interface PerformanceSpanTags {
 }
 
 export async function trackUserFlow<T>(name: string, fn: () => Promise<T>, tags?: PerformanceSpanTags): Promise<T> {
+  // `started` disambiguates Sentry-init failure (run fn bare) from fn throwing (rethrow).
+  let started = false;
   try {
-    return Sentry.startSpan(
+    return await Sentry.startSpan(
       {
         name,
         op: 'user.flow',
         attributes: tags,
       },
       async (span) => {
+        started = true;
         try {
           const result = await fn();
           span.setStatus({ code: 1 });
@@ -31,9 +73,11 @@ export async function trackUserFlow<T>(name: string, fn: () => Promise<T>, tags?
         }
       },
     );
-  } catch {
-    // If Sentry fails, execute the function without tracking
-    return fn();
+  } catch (err) {
+    if (!started) {
+      return fn();
+    }
+    throw err;
   }
 }
 
@@ -55,9 +99,12 @@ export function startRenderSpan(name: string, tags?: PerformanceSpanTags): { end
       },
     };
   } catch {
-    // If Sentry fails, return a no-op
-    return { end: () => {} };
+    return { end: () => undefined };
   }
+}
+
+export function getPageNumber(start = 0, rows = 10): number {
+  return Math.floor(start / rows) + 1;
 }
 
 export function getResultCountBucket(count: number): ResultCountBucket {
@@ -105,4 +152,19 @@ export const PERF_SPANS = {
   ORCID_SYNC_TOTAL: 'orcid.sync.total',
   ORCID_CLAIM_TOTAL: 'orcid.claim.total',
   ORCID_PROFILE_LOAD: 'orcid.profile.load',
+  UX_FULL_TEXT_TIME: 'ux.full_text_time',
 } as const;
+
+// Allowlist of structural Solr params safe to send as Sentry tags.
+// Never include q, fq, fl, or hl — they contain raw user input and may hold PII.
+const SAFE_QUERY_TAG_KEYS = new Set(['sort', 'start', 'rows', 'd', 'boostType']);
+
+export function sendQueryAsTags(query: IADSApiSearchParams): void {
+  for (const key of Object.keys(query)) {
+    if (!SAFE_QUERY_TAG_KEYS.has(key)) {
+      continue;
+    }
+    const raw = query[key];
+    Sentry.setTag(`query.${key}`, Array.isArray(raw) ? raw.join(' | ') : JSON.stringify(raw));
+  }
+}

--- a/src/lib/serverside/absCanonicalization.ts
+++ b/src/lib/serverside/absCanonicalization.ts
@@ -12,6 +12,7 @@ import { logger } from '@/logger';
 import { composeNextGSSP } from '@/ssr-utils';
 import { isAuthenticated } from '@/api/api';
 import { ErrorSeverity, ErrorSource, handleError } from '@/lib/errorHandler';
+import { trackUserFlow, PERF_SPANS } from '@/lib/performance';
 
 const log = logger.child({ module: 'abs-canonical' }, { msgPrefix: '[abs-canonical] ' });
 
@@ -109,12 +110,20 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
 
     try {
       const tracingHeaders = pickTracingHeaders(ctx.req.headers);
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${bootstrapResult.token.access_token}`,
-          ...tracingHeaders,
-        },
-      });
+      const spanName =
+        viewPath === 'citations'
+          ? PERF_SPANS.ABSTRACT_CITATIONS_LOAD
+          : viewPath === 'references'
+          ? PERF_SPANS.ABSTRACT_REFERENCES_LOAD
+          : PERF_SPANS.ABSTRACT_LOAD_TOTAL;
+      const response = await trackUserFlow(spanName, () =>
+        fetch(url, {
+          headers: {
+            Authorization: `Bearer ${bootstrapResult.token.access_token}`,
+            ...tracingHeaders,
+          },
+        }),
+      );
 
       if (!response.ok) {
         const error = new Error(`Abstract fetch failed with status ${response.status}`);

--- a/src/lib/serverside/bootstrap.ts
+++ b/src/lib/serverside/bootstrap.ts
@@ -5,6 +5,7 @@ import { isTokenExpired, pickUserData } from '@/auth-utils';
 import { ApiTargets } from '@/api/models';
 import { logger } from '@/logger';
 import { IUserData } from '@/api/user/types';
+import { trackUserFlow, PERF_SPANS } from '@/lib/performance';
 
 const log = logger.child({ module: 'bootstrap' }, { msgPrefix: '[bootstrap] ' });
 
@@ -22,9 +23,9 @@ export const bootstrap = async (req: IncomingMessage, res: ServerResponse) => {
       headers.append(key, value);
     });
 
-    const bsRes = await fetch(`${process.env.API_HOST_SERVER}${ApiTargets.BOOTSTRAP}`, {
-      headers,
-    });
+    const bsRes = await trackUserFlow(PERF_SPANS.AUTH_SESSION_VALIDATE, () =>
+      fetch(`${process.env.API_HOST_SERVER}${ApiTargets.BOOTSTRAP}`, { headers }),
+    );
 
     if (!bsRes.ok) {
       log.error({ status: bsRes.status, statusText: bsRes.statusText }, 'Failed to fetch bootstrap data');

--- a/src/lib/useExportSpan.ts
+++ b/src/lib/useExportSpan.ts
@@ -1,0 +1,36 @@
+import * as Sentry from '@sentry/nextjs';
+import { useEffect, useRef } from 'react';
+
+import { PERF_SPANS } from '@/lib/performance';
+
+// Tracks export generation as a user.flow span: opens on 'fetching', closes when data arrives.
+export function useExportSpan(isFetching: boolean, format: string, data: unknown): void {
+  const spanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+
+  useEffect(() => {
+    if (!isFetching) {
+      return;
+    }
+    try {
+      spanRef.current?.end();
+      spanRef.current = Sentry.startInactiveSpan({
+        name: PERF_SPANS.EXPORT_GENERATE_TOTAL,
+        op: 'user.flow',
+        attributes: { format },
+      });
+    } catch {}
+    // `format` captured at fetch-start; re-running on format change would double-open the span.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFetching]);
+
+  useEffect(() => {
+    if (!data || !spanRef.current) {
+      return;
+    }
+    try {
+      spanRef.current.setStatus({ code: 1 });
+      spanRef.current.end();
+      spanRef.current = null;
+    } catch {}
+  }, [data]);
+}

--- a/src/lib/useExportSpan.ts
+++ b/src/lib/useExportSpan.ts
@@ -3,8 +3,8 @@ import { useEffect, useRef } from 'react';
 
 import { PERF_SPANS } from '@/lib/performance';
 
-// Tracks export generation as a user.flow span: opens on 'fetching', closes when data arrives.
-export function useExportSpan(isFetching: boolean, format: string, data: unknown): void {
+// Tracks export generation as a user.flow span: opens on 'fetching', closes when data arrives or on error/unmount.
+export function useExportSpan(isFetching: boolean, format: string, data: unknown, isError?: boolean): void {
   const spanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
 
   useEffect(() => {
@@ -33,4 +33,24 @@ export function useExportSpan(isFetching: boolean, format: string, data: unknown
       spanRef.current = null;
     } catch {}
   }, [data]);
+
+  useEffect(() => {
+    if (!isError || !spanRef.current) {
+      return;
+    }
+    try {
+      spanRef.current.setStatus({ code: 2 });
+      spanRef.current.end();
+      spanRef.current = null;
+    } catch {}
+  }, [isError]);
+
+  useEffect(() => {
+    return () => {
+      try {
+        spanRef.current?.end();
+        spanRef.current = null;
+      } catch {}
+    };
+  }, []);
 }

--- a/src/lib/useRenderSpan.ts
+++ b/src/lib/useRenderSpan.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+import { IDocsEntity } from '@/api/search/types';
+import { closeFacetsRenderSpan, closeResultsRenderSpan } from '@/lib/performance';
+
+// Closes both render spans (opened in Telemetry) after the results list paints.
+// Both results and facets respond to the same docs state update and render in the
+// same React commit, so SimpleResultList's useEffect is a reliable proxy for both.
+export function useResultsRenderSpan(docs: IDocsEntity[]): void {
+  useEffect(() => {
+    if (docs.length === 0) {
+      return;
+    }
+    closeResultsRenderSpan(docs.length);
+    closeFacetsRenderSpan();
+  }, [docs]);
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,6 +29,14 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && process.env.NODE_ENV !=
   require('../mocks');
 }
 
+if (typeof window !== 'undefined' && process.env.TURBOPACK) {
+  // Turbopack (default in Next.js 16 dev) bypasses the Sentry webpack plugin.
+  // 'auto' = default Turbopack, '1' = explicit --turbopack. Both are truthy.
+  // In production/webpack builds, TURBOPACK is undefined so this never fires.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../sentry.client.config');
+}
+
 const TopProgressBar = dynamic<Record<string, never>>(
   () =>
     import('@/components/TopProgressBar').then((mod) => ({

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,8 +29,10 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && process.env.NODE_ENV !=
   require('../mocks');
 }
 
-if (typeof window !== 'undefined' && process.env.TURBOPACK === '1') {
-  // Turbopack bypasses withSentryConfig, so load the client init manually.
+if (typeof window !== 'undefined' && process.env.TURBOPACK) {
+  // Turbopack (default in Next.js 16 dev) bypasses the Sentry webpack plugin.
+  // 'auto' = default Turbopack, '1' = explicit --turbopack. Both are truthy.
+  // In production/webpack builds, TURBOPACK is undefined so this never fires.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('../../sentry.client.config');
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -55,6 +55,8 @@ import { SimpleLink } from '@/components/SimpleLink';
 import { makeSearchParams, normalizeSolrSort, parseQueryFromUrl } from '@/utils/common/search';
 import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
+import { sendGTMEvent } from '@next/third-parties/google';
+import { getQueryType } from '@/lib/performance';
 import { defaultParams } from '@/api/search/models';
 import { solrDefaultSortDirection, SolrSort, SolrSortField } from '@/api/models';
 import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
@@ -293,6 +295,19 @@ const SearchPage: NextPage = () => {
   const loading = isLoading || isFetching;
   const noResults = !loading && isSuccess && data?.response.numFound === 0;
   const hasResults = !loading && isSuccess && data?.response.numFound > 0;
+
+  // Track the last query that fired search_no_results to prevent duplicate events
+  // when noResults stays true across re-renders (e.g. unstable params.q reference).
+  const lastNoResultsQuery = useRef<string | null>(null);
+  useEffect(() => {
+    if (noResults && params.q !== lastNoResultsQuery.current) {
+      lastNoResultsQuery.current = params.q ?? null;
+      sendGTMEvent({ event: 'search_no_results', query: params.q, query_type: getQueryType(params.q ?? '') });
+    }
+    if (!noResults) {
+      lastNoResultsQuery.current = null;
+    }
+  }, [noResults, params.q]);
   const showFilters = !isPrint && isClient;
   const showListActions = !isPrint && (loading || hasResults);
 
@@ -667,7 +682,7 @@ const useTour = () => {
         tour.start();
       }, 1000);
     }
-  }, [isRendered]);
+  }, [isRendered, Shepherd]);
 };
 
 export { injectSessionGSSP as getServerSideProps } from '@/ssr-utils';

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -55,6 +55,8 @@ import { SimpleLink } from '@/components/SimpleLink';
 import { makeSearchParams, normalizeSolrSort, parseQueryFromUrl } from '@/utils/common/search';
 import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
+import { sendGTMEvent } from '@next/third-parties/google';
+import { getQueryType } from '@/lib/performance';
 import { defaultParams } from '@/api/search/models';
 import { solrDefaultSortDirection, SolrSort, SolrSortField } from '@/api/models';
 import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
@@ -315,6 +317,19 @@ const SearchPage: NextPage = () => {
   const loading = isLoading || isFetching;
   const noResults = !loading && isSuccess && data?.response.numFound === 0;
   const hasResults = !loading && isSuccess && data?.response.numFound > 0;
+
+  // Track the last query that fired search_no_results to prevent duplicate events
+  // when noResults stays true across re-renders (e.g. unstable params.q reference).
+  const lastNoResultsQuery = useRef<string | null>(null);
+  useEffect(() => {
+    if (noResults && params.q !== lastNoResultsQuery.current) {
+      lastNoResultsQuery.current = params.q ?? null;
+      sendGTMEvent({ event: 'search_no_results', query: params.q, query_type: getQueryType(params.q ?? '') });
+    }
+    if (!noResults) {
+      lastNoResultsQuery.current = null;
+    }
+  }, [noResults, params.q]);
   const showFilters = !isPrint && isClient;
   const showListActions = !isPrint && (loading || hasResults);
 
@@ -689,7 +704,7 @@ const useTour = () => {
         tour.start();
       }, 1000);
     }
-  }, [isRendered]);
+  }, [isRendered, Shepherd]);
 };
 
 export { injectSessionGSSP as getServerSideProps } from '@/ssr-utils';

--- a/src/pages/user/account/register.tsx
+++ b/src/pages/user/account/register.tsx
@@ -16,7 +16,7 @@ import { NextPage } from 'next';
 import Head from 'next/head';
 import { Control, SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useFocus } from '@/lib/useFocus';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRedirectWithNotification } from '@/components/Notification';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { RecaptchaMessage } from '@/components/RecaptchaMessage/RecaptchaMessage';
@@ -28,6 +28,8 @@ import { StandardAlertMessage } from '@/components/Feedbacks';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { IUserRegistrationCredentials } from '@/api/user/types';
 import { useRegisterUser } from '@/api/user/user';
+import * as Sentry from '@sentry/nextjs';
+import { PERF_SPANS } from '@/lib/performance';
 
 const initialParams: IUserRegistrationCredentials = {
   givenName: '',
@@ -41,6 +43,8 @@ const initialParams: IUserRegistrationCredentials = {
 const Register: NextPage = () => {
   const { executeRecaptcha } = useGoogleReCaptcha();
   const redirect = useRedirectWithNotification();
+  // mutate (not mutateAsync) keeps error handling through isError/error state only,
+  // avoiding the double-error-UI that mutateAsync causes by also throwing into the catch.
   const { mutate: submit, data, isError, isLoading, error } = useRegisterUser();
   const {
     register,
@@ -52,11 +56,32 @@ const Register: NextPage = () => {
     defaultValues: initialParams,
   });
   const [formError, setFormError] = useState<Error | string | null>(null);
+
+  // Span opened at submit, closed by whichever effect fires first (data or isError).
+  const registerSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+
   useEffect(() => {
-    if (data) {
-      void redirect('account-register-success', { path: '/user/account/login' });
+    if (!data) {
+      return;
     }
+    try {
+      registerSpanRef.current?.setStatus({ code: 1 });
+      registerSpanRef.current?.end();
+    } catch {}
+    registerSpanRef.current = null;
+    void redirect('account-register-success', { path: '/user/account/login' });
   }, [data, redirect]);
+
+  useEffect(() => {
+    if (!isError) {
+      return;
+    }
+    try {
+      registerSpanRef.current?.setStatus({ code: 2 });
+      registerSpanRef.current?.end();
+    } catch {}
+    registerSpanRef.current = null;
+  }, [isError]);
 
   const onFormSubmit: SubmitHandler<IUserRegistrationCredentials> = useCallback(
     async (params) => {
@@ -66,11 +91,17 @@ const Register: NextPage = () => {
       }
 
       try {
-        submit({
-          ...params,
-          recaptcha: await executeRecaptcha('register'),
+        registerSpanRef.current?.end();
+        // Span opens before executeRecaptcha so the full user-facing latency
+        // (recaptcha + network) is measured, not just the server round-trip.
+        registerSpanRef.current = Sentry.startInactiveSpan({
+          name: PERF_SPANS.AUTH_REGISTER_TOTAL,
+          op: 'user.flow',
         });
+        submit({ ...params, recaptcha: await executeRecaptcha('register') });
       } catch (e) {
+        registerSpanRef.current?.end();
+        registerSpanRef.current = null;
         setFormError(e as Error);
       }
     },

--- a/src/pages/user/account/register.tsx
+++ b/src/pages/user/account/register.tsx
@@ -100,6 +100,7 @@ const Register: NextPage = () => {
         });
         submit({ ...params, recaptcha: await executeRecaptcha('register') });
       } catch (e) {
+        registerSpanRef.current?.setStatus({ code: 2 });
         registerSpanRef.current?.end();
         registerSpanRef.current = null;
         setFormError(e as Error);

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -4,20 +4,25 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { AppState, StoreProvider, useCreateStore, useStore } from './store';
 import { DehydratedState, Hydrate, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { useCreateQueryClient } from './lib/useCreateQueryClient';
 import { logger } from './logger';
 import { theme } from './theme';
 import shallow from 'zustand/shallow';
 import * as Sentry from '@sentry/nextjs';
-import { IADSApiSearchParams } from './api/search/types';
-import { PERF_SPANS, getResultCountBucket, getQueryType } from '@/lib/performance';
+import {
+  PERF_SPANS,
+  getResultCountBucket,
+  getQueryType,
+  openResultsRenderSpan,
+  openFacetsRenderSpan,
+  openFullTextTimingSpan,
+  closeFullTextTimingSpan,
+  getPageNumber,
+  sendQueryAsTags,
+} from '@/lib/performance';
 import { useGlobalErrorHandler } from './lib/useGlobalErrorHandler';
 import { ShepherdJourneyProvider } from 'react-shepherd';
-
-const windowState = {
-  navigationStart: performance?.timeOrigin || performance?.timing?.navigationStart || 0,
-};
 
 type AppPageProps = {
   dehydratedState: DehydratedState;
@@ -65,68 +70,87 @@ const QCProvider: FC = ({ children }) => {
 };
 
 const Telemetry: FC = () => {
-  const query = useStore((state) => state.query, shallow);
+  const latestQuery = useStore((state) => state.latestQuery, shallow);
   const user = useStore((state) => state.user, shallow);
   const docs = useStore((state) => state.docs.current, shallow);
+  const searchSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+  const paginationSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
 
-  // Initialize global error handlers
   useGlobalErrorHandler();
 
   useEffect(() => {
     try {
-      if (user) {
-        Sentry.setUser({
-          id: user?.access_token,
-          anonymous: user.anonymous,
+      if (!user) {
+        // Clear any prior user context so post-logout events are not misclassified.
+        Sentry.setUser(null);
+        return;
+      }
+      // Never send credentials or PII — anonymous flag is enough to segment error rates.
+      Sentry.setUser({ anonymous: user.anonymous });
+    } catch (err) {
+      logger.error({ err }, 'Telemetry: setUser error');
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!latestQuery) {
+      return;
+    }
+    try {
+      sendQueryAsTags(latestQuery);
+      const page = getPageNumber(latestQuery.start, latestQuery.rows);
+      // End prior spans so rapid re-submits don't leak them.
+      searchSpanRef.current?.end();
+      searchSpanRef.current = null;
+      paginationSpanRef.current?.end();
+      paginationSpanRef.current = null;
+      closeFullTextTimingSpan();
+      // Open here: the nav transaction's idle timeout fires before docs arrive.
+      searchSpanRef.current = Sentry.startInactiveSpan({
+        name: PERF_SPANS.SEARCH_SUBMIT_TOTAL,
+        op: 'user.flow',
+        attributes: { query_type: getQueryType(latestQuery.q ?? ''), page },
+      });
+      if (page > 1) {
+        paginationSpanRef.current = Sentry.startInactiveSpan({
+          name: PERF_SPANS.SEARCH_PAGINATION_TOTAL,
+          op: 'user.flow',
+          attributes: { page },
         });
       }
-
-      if (query) {
-        sendQueryAsTags(query);
-      }
-
-      if (docs && docs.length > 0) {
-        logger.debug({ docs }, 'Telemetry: docs');
-        sendResultsLoaded(query, docs.length);
-      }
     } catch (err) {
-      logger.error({ err }, 'Telemetry: error');
+      logger.error({ err }, 'Telemetry: query span error');
     }
-  }, [query, user, docs]);
+  }, [latestQuery]);
+
+  useEffect(() => {
+    if (!docs || docs.length === 0) {
+      return;
+    }
+    logger.debug({ count: docs.length }, 'Telemetry: docs');
+    try {
+      const bucket = getResultCountBucket(docs.length);
+      if (searchSpanRef.current) {
+        searchSpanRef.current.setAttributes({ result_count_bucket: bucket });
+        searchSpanRef.current.setStatus({ code: 1 });
+        searchSpanRef.current.end();
+        searchSpanRef.current = null;
+      }
+      if (paginationSpanRef.current) {
+        paginationSpanRef.current.setAttributes({ result_count_bucket: bucket });
+        paginationSpanRef.current.setStatus({ code: 1 });
+        paginationSpanRef.current.end();
+        paginationSpanRef.current = null;
+      }
+      // Open while the nav transaction is still alive; both render spans closed
+      // together by useResultsRenderSpan in SimpleResultList after paint.
+      openResultsRenderSpan();
+      openFacetsRenderSpan();
+      openFullTextTimingSpan();
+    } catch (err) {
+      logger.error({ err }, 'Telemetry: docs span error');
+    }
+  }, [docs]);
 
   return <></>;
-};
-
-const sendQueryAsTags = (query: IADSApiSearchParams) => {
-  Object.keys(query).forEach((key) => {
-    const value = JSON.stringify(query[key]);
-    if (Array.isArray(value)) {
-      Sentry.setTag(`query.${key}`, value.join(' | '));
-    } else {
-      Sentry.setTag(`query.${key}`, value);
-    }
-  });
-};
-
-const sendResultsLoaded = (query: IADSApiSearchParams, docCount: number) => {
-  const loadedTime = performance.now();
-
-  // performance.now() already returns ms since navigation start
-  Sentry.setMeasurement('timing.results.shown', loadedTime, 'millisecond');
-
-  // Add new span-based tracking
-  Sentry.startSpan(
-    {
-      name: PERF_SPANS.SEARCH_SUBMIT_TOTAL,
-      op: 'user.flow',
-      startTime: windowState.navigationStart / 1000,
-      attributes: {
-        query_type: getQueryType(query.q ?? ''),
-        result_count_bucket: getResultCountBucket(docCount),
-      },
-    },
-    (span) => {
-      span.end((windowState.navigationStart + loadedTime) / 1000);
-    },
-  );
 };

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -10,8 +10,17 @@ import { logger } from './logger';
 import { theme } from './theme';
 import shallow from 'zustand/shallow';
 import * as Sentry from '@sentry/nextjs';
-import { IADSApiSearchParams } from './api/search/types';
-import { PERF_SPANS, getResultCountBucket, getQueryType } from '@/lib/performance';
+import {
+  PERF_SPANS,
+  getResultCountBucket,
+  getQueryType,
+  openResultsRenderSpan,
+  openFacetsRenderSpan,
+  openFullTextTimingSpan,
+  closeFullTextTimingSpan,
+  getPageNumber,
+  sendQueryAsTags,
+} from '@/lib/performance';
 import { useGlobalErrorHandler } from './lib/useGlobalErrorHandler';
 import { ShepherdJourneyProvider } from 'react-shepherd';
 
@@ -65,15 +74,19 @@ const Telemetry: FC = () => {
   const user = useStore((state) => state.user, shallow);
   const docs = useStore((state) => state.docs.current, shallow);
   const searchSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+  const paginationSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
 
   useGlobalErrorHandler();
 
   useEffect(() => {
-    if (!user) {
-      return;
-    }
     try {
-      Sentry.setUser({ id: user.access_token, anonymous: user.anonymous });
+      if (!user) {
+        // Clear any prior user context so post-logout events are not misclassified.
+        Sentry.setUser(null);
+        return;
+      }
+      // Never send credentials or PII — anonymous flag is enough to segment error rates.
+      Sentry.setUser({ anonymous: user.anonymous });
     } catch (err) {
       logger.error({ err }, 'Telemetry: setUser error');
     }
@@ -85,17 +98,26 @@ const Telemetry: FC = () => {
     }
     try {
       sendQueryAsTags(latestQuery);
-      // Close any in-flight span so rapid re-submits don't leak the prior one.
-      if (searchSpanRef.current) {
-        searchSpanRef.current.end();
-        searchSpanRef.current = null;
-      }
-      // Must open here: the navigation transaction's idle timeout closes before docs arrive.
+      const page = getPageNumber(latestQuery.start, latestQuery.rows);
+      // End prior spans so rapid re-submits don't leak them.
+      searchSpanRef.current?.end();
+      searchSpanRef.current = null;
+      paginationSpanRef.current?.end();
+      paginationSpanRef.current = null;
+      closeFullTextTimingSpan();
+      // Open here: the nav transaction's idle timeout fires before docs arrive.
       searchSpanRef.current = Sentry.startInactiveSpan({
         name: PERF_SPANS.SEARCH_SUBMIT_TOTAL,
         op: 'user.flow',
-        attributes: { query_type: getQueryType(latestQuery.q ?? '') },
+        attributes: { query_type: getQueryType(latestQuery.q ?? ''), page },
       });
+      if (page > 1) {
+        paginationSpanRef.current = Sentry.startInactiveSpan({
+          name: PERF_SPANS.SEARCH_PAGINATION_TOTAL,
+          op: 'user.flow',
+          attributes: { page },
+        });
+      }
     } catch (err) {
       logger.error({ err }, 'Telemetry: query span error');
     }
@@ -105,25 +127,30 @@ const Telemetry: FC = () => {
     if (!docs || docs.length === 0) {
       return;
     }
-    logger.debug({ docs }, 'Telemetry: docs');
+    logger.debug({ count: docs.length }, 'Telemetry: docs');
     try {
+      const bucket = getResultCountBucket(docs.length);
       if (searchSpanRef.current) {
-        searchSpanRef.current.setAttributes({ result_count_bucket: getResultCountBucket(docs.length) });
+        searchSpanRef.current.setAttributes({ result_count_bucket: bucket });
         searchSpanRef.current.setStatus({ code: 1 });
         searchSpanRef.current.end();
         searchSpanRef.current = null;
       }
+      if (paginationSpanRef.current) {
+        paginationSpanRef.current.setAttributes({ result_count_bucket: bucket });
+        paginationSpanRef.current.setStatus({ code: 1 });
+        paginationSpanRef.current.end();
+        paginationSpanRef.current = null;
+      }
+      // Open while the nav transaction is still alive; both render spans closed
+      // together by useResultsRenderSpan in SimpleResultList after paint.
+      openResultsRenderSpan();
+      openFacetsRenderSpan();
+      openFullTextTimingSpan();
     } catch (err) {
       logger.error({ err }, 'Telemetry: docs span error');
     }
   }, [docs]);
 
   return <></>;
-};
-
-const sendQueryAsTags = (query: IADSApiSearchParams) => {
-  Object.keys(query).forEach((key) => {
-    const raw = query[key];
-    Sentry.setTag(`query.${key}`, Array.isArray(raw) ? raw.join(' | ') : JSON.stringify(raw));
-  });
 };


### PR DESCRIPTION
No production visibility into query latency, paint timing, or user engagement. Dev environment also silently skipped Sentry initialization under Next.js 16 Turbopack because the webpack plugin is bypassed during dev.

- Add runtime guard in _app.tsx to manually require sentry.client.config.ts when Turbopack is active
- Add trackUserFlow helper in performance.ts wrapping key async flows in Sentry transactions
- Add useExportSpan and useRenderSpan hooks for component-level paint timing
- Adds several new instrumentations