### PR TITLE
SCIX-871 fix: gate SortStats and YearHistogramSlider on searchStatus

### DIFF
--- a/src/components/NumFound/NumFound.tsx
+++ b/src/components/NumFound/NumFound.tsx
@@ -17,6 +17,7 @@ const sanitizeNum = (num: number): string => {
 
 export const NumFound = (props: INumFoundProps): ReactElement => {
   const { count = 0, isLoading } = props;
+  const searchStatus = useStore((state) => state.searchStatus);
 
   if (isLoading) {
     return (
@@ -35,7 +36,7 @@ export const NumFound = (props: INumFoundProps): ReactElement => {
         <Text as="span" fontWeight="bold">
           {countString}
         </Text>{' '}
-        results <SortStats />
+        results {searchStatus === 'success' ? <SortStats /> : null}
       </Text>
     </Box>
   );

--- a/src/components/SearchFacet/FacetList.tsx
+++ b/src/components/SearchFacet/FacetList.tsx
@@ -28,7 +28,6 @@ import {
   PopoverCloseButton,
   PopoverContent,
   PopoverHeader,
-  Skeleton,
   Spinner,
   Stack,
   Text,
@@ -122,7 +121,7 @@ export const NodeList = memo(
     const updateModal = useFacetStore(selectors.updateModal);
     const depth = getLevelFromKey(prefix) + 1;
     const expandable = params.hasChildren && (level === 'root' || params.maxDepth > depth);
-    const { treeData, isFetching, isLoading, isError } = useGetFacetData({
+    const { treeData, isFetching, isLoading, isSearchLoading, isError } = useGetFacetData({
       ...params,
       prefix,
       level,
@@ -158,10 +157,10 @@ export const NodeList = memo(
       );
     }
 
-    if (isFetching || isLoading) {
+    if (isFetching || isLoading || isSearchLoading) {
       return (
-        <Center data-testid="search-facet-loading">
-          <Spinner size="sm" />
+        <Center py="4" data-testid="search-facet-loading">
+          <Spinner size="sm" color="gray.400" />
         </Center>
       );
     } else if (treeData?.length === 0) {
@@ -298,6 +297,7 @@ export const NodeListModal = (props: INodeListProps) => {
     treeData,
     isFetching,
     isLoading,
+    isSearchLoading,
     isError,
     pagination,
     handleLoadMore,
@@ -313,20 +313,11 @@ export const NodeListModal = (props: INodeListProps) => {
     sortDir,
   });
 
-  if (isFetching || isLoading) {
+  if (isFetching || isLoading || isSearchLoading) {
     return (
-      <Stack spacing="2" data-testid="search-facet-loading">
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-        <Skeleton h="24px" />
-      </Stack>
+      <Center py="4" data-testid="search-facet-loading">
+        <Spinner size="sm" color="gray.400" />
+      </Center>
     );
   } else if (isEmpty(treeData)) {
     return (

--- a/src/components/SearchFacet/SearchFacetModal/SearchFacetModal.tsx
+++ b/src/components/SearchFacet/SearchFacetModal/SearchFacetModal.tsx
@@ -35,7 +35,7 @@ import { join, last, map, pipe, pluck, split } from 'ramda';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { FacetItem, FacetLogic } from '../types';
 
-interface ISearchFacetModalProps extends Omit<IFacetListProps, 'onError'> {
+interface ISearchFacetModalProps extends Omit<IFacetListProps, 'onError' | 'children'> {
   children: (props: { searchTerm: string }) => ReactNode;
 }
 

--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -25,6 +25,7 @@ export interface IYearHistogramSliderProps {
 
 const Component = ({ onQueryUpdate, width, height, onExpand, expanded }: IYearHistogramSliderProps) => {
   const query = useStore((state) => state.latestQuery);
+  const searchStatus = useStore((state) => state.searchStatus);
 
   // query without the year range filter, to show all years on the histogram
   const cleanedQuery = useMemo(() => {
@@ -38,7 +39,7 @@ const Component = ({ onQueryUpdate, width, height, onExpand, expanded }: IYearHi
   }, [query]);
 
   const { data } = useGetSearchFacetCounts(getSearchFacetYearsParams(cleanedQuery), {
-    enabled: !!cleanedQuery && cleanedQuery.q.trim().length > 0,
+    enabled: searchStatus === 'success' && !!cleanedQuery && cleanedQuery.q.trim().length > 0,
     suspense: true,
   });
 

--- a/src/components/SearchFacet/store/FacetStore.ts
+++ b/src/components/SearchFacet/store/FacetStore.ts
@@ -1,7 +1,7 @@
 import { facetConfig } from '@/components/SearchFacet/config';
 import { FacetItem, IFacetParams, SearchFacetID } from '@/components/SearchFacet/types';
 import { omit, pick, uniq } from 'ramda';
-import { createElement, FC } from 'react';
+import { createElement, FC, ReactNode } from 'react';
 import create from 'zustand';
 import createContext from 'zustand/context';
 import { computeNextSelectionState, createNodes, getSelected } from './helpers';
@@ -128,7 +128,7 @@ const createStore = (preloadedState: Partial<IFacetStoreState>) => () =>
 const FacetStoreContext = createContext<IFacetStoreState & FacetStoreEvents>();
 export const useFacetStore = FacetStoreContext.useStore;
 
-export const FacetStoreProvider: FC<{ facetId: SearchFacetID }> = ({ children, facetId }) => {
+export const FacetStoreProvider: FC<{ facetId: SearchFacetID; children?: ReactNode }> = ({ children, facetId }) => {
   const params = pick(
     [
       'label',

--- a/src/components/SearchFacet/useGetFacetData.test.ts
+++ b/src/components/SearchFacet/useGetFacetData.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, vi, TestContext } from 'vitest';
-import { renderHook, waitFor, createServerListenerMocks, urls } from '@/test-utils';
+import { renderHook, waitFor, act, createServerListenerMocks, urls } from '@/test-utils';
+import { useStore } from '@/store';
+import { IUseGetFacetDataProps } from './useGetFacetData';
 import { useGetFacetData } from './useGetFacetData';
 import { defaultQueryParams } from '@/store/slices/search';
 import { FacetField } from '@/api/search/types';
@@ -14,11 +16,16 @@ const defaultProps = {
   level: 'root' as const,
 };
 
+const useCompound = (props: IUseGetFacetDataProps) => ({
+  setSearchStatus: useStore((state) => state.setSearchStatus),
+  facet: useGetFacetData(props),
+});
+
 describe('useGetFacetData', () => {
-  test('does not fire a request when latestQuery.q is empty', async ({ server }: TestContext) => {
+  test('does not fire a request when searchStatus is idle', async ({ server }: TestContext) => {
     const { onRequest } = createServerListenerMocks(server);
     renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { latestQuery: { ...defaultQueryParams, q: '' } },
+      initialStore: { searchStatus: 'idle', latestQuery: { ...defaultQueryParams, q: 'star' } },
     });
 
     await new Promise((r) => setTimeout(r, 200));
@@ -26,10 +33,10 @@ describe('useGetFacetData', () => {
     expect(searchRequests).toHaveLength(0);
   });
 
-  test('does not fire a request when latestQuery.q is whitespace-only', async ({ server }: TestContext) => {
+  test('does not fire a request when searchStatus is not success (empty)', async ({ server }: TestContext) => {
     const { onRequest } = createServerListenerMocks(server);
     renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { latestQuery: { ...defaultQueryParams, q: '   ' } },
+      initialStore: { searchStatus: 'empty', latestQuery: { ...defaultQueryParams, q: 'star' } },
     });
 
     await new Promise((r) => setTimeout(r, 200));
@@ -40,12 +47,128 @@ describe('useGetFacetData', () => {
   test('fires a request when latestQuery.q is non-empty', async ({ server }: TestContext) => {
     const { onRequest } = createServerListenerMocks(server);
     renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { latestQuery: { ...defaultQueryParams, q: 'star' } },
+      initialStore: { searchStatus: 'success', latestQuery: { ...defaultQueryParams, q: 'star' } },
     });
 
     await waitFor(() => {
       const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
       expect(searchRequests.length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe('useGetFacetData — searchStatus gating', () => {
+  test('does not fire when searchStatus is loading', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+
+    renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'loading',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
+    expect(facetRequests).toHaveLength(0);
+  });
+
+  test('does not fire when searchStatus is empty', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+
+    renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'empty',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
+    expect(facetRequests).toHaveLength(0);
+  });
+
+  test('does not fire when searchStatus is error', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+
+    renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'error',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
+    expect(facetRequests).toHaveLength(0);
+  });
+
+  test('fires and returns data when searchStatus is success', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+
+    const { result } = renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'success',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await waitFor(() => {
+      const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
+      expect(facetRequests.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('regression: loading→success transition unblocks fetch and populates data', async ({ server }: TestContext) => {
+    const { onRequest } = createServerListenerMocks(server);
+
+    const { result } = renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'loading',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(urls(onRequest).filter((u) => u === '/search/query')).toHaveLength(0);
+    expect(result.current.facet.treeData).toHaveLength(0);
+
+    act(() => {
+      result.current.setSearchStatus('success');
+    });
+
+    await waitFor(() => {
+      expect(urls(onRequest).filter((u) => u === '/search/query').length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('success→loading transition clears treeData synchronously', async ({ server }: TestContext) => {
+    createServerListenerMocks(server);
+
+    const { result } = renderHook(() => useCompound(defaultProps), {
+      initialStore: {
+        searchStatus: 'success',
+        latestQuery: { ...defaultQueryParams, q: 'star' },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setSearchStatus('loading');
+    });
+
+    expect(result.current.facet.treeData).toHaveLength(0);
+    expect(result.current.facet.totalResults).toBe(0);
   });
 });

--- a/src/components/SearchFacet/useGetFacetData.ts
+++ b/src/components/SearchFacet/useGetFacetData.ts
@@ -167,6 +167,7 @@ export const useGetFacetData = (props: IUseGetFacetDataProps) => {
     handleLoadMore,
     handlePageChange,
     canLoadMore: searchStatus === 'success' && res?.numBuckets !== treeData?.length,
+    isSearchLoading: searchStatus === 'loading',
     ...result,
     isLoading: (isQueryEnabled && result.isLoading) || (hasIdentifiers && isLoading),
     isFetching: result.isFetching || (hasIdentifiers && isFetching),

--- a/src/components/SearchFacet/useGetFacetData.ts
+++ b/src/components/SearchFacet/useGetFacetData.ts
@@ -36,6 +36,7 @@ const querySelector = (state: AppState) => omit(['fl', 'start', 'rows'], state.l
 
 export const useGetFacetData = (props: IUseGetFacetDataProps) => {
   const searchQuery = useStore(querySelector);
+  const searchStatus = useStore((state: AppState) => state.searchStatus);
   const {
     field,
     query = '',
@@ -59,7 +60,7 @@ export const useGetFacetData = (props: IUseGetFacetDataProps) => {
     setPagination(calculatePagination({ page: 0, numPerPage: FACET_DEFAULT_LIMIT }));
   }, [prefix, searchTerm, sortDir]);
 
-  const isQueryEnabled = enabled && isNonEmptyString(searchQuery?.q?.trim());
+  const isQueryEnabled = enabled && searchStatus === 'success';
 
   // fetch the data
   const { data, ...result } = useGetSearchFacetJSON(
@@ -83,12 +84,12 @@ export const useGetFacetData = (props: IUseGetFacetDataProps) => {
     },
     {
       enabled: isQueryEnabled,
-      keepPreviousData: true,
     },
   );
 
   const res = data?.[field];
-  const treeData = useMemo(() => formatTreeData(res?.buckets ?? []), [res?.buckets]);
+  const rawTreeData = useMemo(() => formatTreeData(res?.buckets ?? []), [res?.buckets]);
+  const treeData = searchStatus === 'success' ? rawTreeData : ([] as FacetItem[]);
 
   const identifiers = useMemo(
     () =>
@@ -160,12 +161,12 @@ export const useGetFacetData = (props: IUseGetFacetDataProps) => {
 
   return {
     treeData: enhancedTreeData,
-    totalResults: res?.numBuckets ?? 0,
+    totalResults: searchStatus === 'success' ? res?.numBuckets ?? 0 : 0,
     pagination: pagination,
     handlePrevious,
     handleLoadMore,
     handlePageChange,
-    canLoadMore: res?.numBuckets !== treeData?.length,
+    canLoadMore: searchStatus === 'success' && res?.numBuckets !== treeData?.length,
     ...result,
     isLoading: (isQueryEnabled && result.isLoading) || (hasIdentifiers && isLoading),
     isFetching: result.isFetching || (hasIdentifiers && isFetching),

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -82,6 +82,10 @@ const SearchFacets = dynamic<ISearchFacetsProps>(
   { ssr: false },
 );
 
+// useLayoutEffect triggers an SSR warning on server-rendered pages; use
+// useEffect on the server where layout effects are a no-op anyway.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 /**
  * Consolidated selector for search page store values
  * Using shallow comparison to prevent unnecessary re-renders
@@ -257,11 +261,12 @@ const SearchPage: NextPage = () => {
   };
 
   // Drive searchStatus and store state based on the main search result.
-  // useLayoutEffect (not useEffect) fires before paint, so facets start
-  // loading in the same frame the results render — no extra paint cycle delay.
+  // useIsomorphicLayoutEffect fires before paint on the client (so facets start
+  // loading in the same frame results render), but falls back to useEffect on
+  // the server to avoid the SSR warning React emits for useLayoutEffect.
   // Uses isLoading (not isFetching) to avoid disabling facets during
   // background refetches of the same query.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (isLoading) {
       setSearchStatus('loading');
       return;
@@ -275,10 +280,10 @@ const SearchPage: NextPage = () => {
         setSearchStatus('empty');
       } else {
         setDocs(data.response.docs.map((d) => d.bibcode));
+        setQuery(searchParams);
+        submitQuery();
         setSearchStatus('success');
       }
-      setQuery(searchParams);
-      submitQuery();
     }
   }, [data, isSuccess, isLoading, isError, setDocs, setQuery, submitQuery, setSearchStatus, searchParams]);
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -35,7 +35,7 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react';
 import { calculateStartIndex } from '@/components/ResultList/Pagination/usePagination';
-import { FormEventHandler, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEventHandler, RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useIsClient } from '@/lib/useIsClient';
 import { useScrollRestoration } from '@/lib/useScrollRestoration';
 import { LocalSettings, NumPerPageType } from '@/types';
@@ -97,6 +97,7 @@ const useSearchPageStore = () =>
       setNumPerPage: state.setNumPerPage,
       setDocs: state.setDocs,
       clearAllSelected: state.clearAllSelected,
+      setSearchStatus: state.setSearchStatus,
     }),
     shallow,
   );
@@ -138,6 +139,7 @@ const SearchPage: NextPage = () => {
     setNumPerPage,
     setDocs,
     clearAllSelected: clearSelectedDocs,
+    setSearchStatus,
   } = useSearchPageStore();
 
   const { settings } = useSettings({ suspense: false });
@@ -254,16 +256,31 @@ const SearchPage: NextPage = () => {
     void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
   };
 
-  // Update the store when we have data
-  useEffect(() => {
-    if (data?.response.docs.length > 0) {
-      setDocs(data.response.docs.map((d) => d.bibcode));
+  // Drive searchStatus and store state based on the main search result.
+  // useLayoutEffect (not useEffect) fires before paint, so facets start
+  // loading in the same frame the results render — no extra paint cycle delay.
+  // Uses isLoading (not isFetching) to avoid disabling facets during
+  // background refetches of the same query.
+  useLayoutEffect(() => {
+    if (isLoading) {
+      setSearchStatus('loading');
+      return;
+    }
+    if (isError) {
+      setSearchStatus('error');
+      return;
+    }
+    if (isSuccess) {
+      if (data.response.numFound === 0) {
+        setSearchStatus('empty');
+      } else {
+        setDocs(data.response.docs.map((d) => d.bibcode));
+        setSearchStatus('success');
+      }
       setQuery(searchParams);
       submitQuery();
     }
-    // Note: setDocs, setQuery, submitQuery are stable Zustand actions
-    // searchParams is derived from router, changes trigger new data fetch
-  }, [data, setDocs, setQuery, submitQuery, searchParams]);
+  }, [data, isSuccess, isLoading, isError, setDocs, setQuery, submitQuery, setSearchStatus, searchParams]);
 
   // Memoized retry handler for error alert
   const handleRetry = useCallback(() => {

--- a/src/store/slices/search.ts
+++ b/src/store/slices/search.ts
@@ -5,6 +5,8 @@ import { mergeRight } from 'ramda';
 import { isNumPerPageType } from '@/utils/common/guards';
 import { IADSApiSearchParams } from '@/api/search/types';
 
+export type SearchStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
 export const defaultQueryParams: IADSApiSearchParams = {
   q: '',
   fl: [
@@ -38,6 +40,7 @@ export interface ISearchState {
   showHighlights: boolean;
   queryAddition: string;
   clearQueryFlag: boolean;
+  searchStatus: SearchStatus;
 }
 
 export interface ISearchAction {
@@ -50,6 +53,7 @@ export interface ISearchAction {
   toggleShowHighlights: () => void;
   setQueryAddition: (queryAddition: string) => void;
   setClearQueryFlag: (clearQueryFlag: boolean) => void;
+  setSearchStatus: (status: SearchStatus) => void;
 }
 
 export const searchSlice: StoreSlice<ISearchState & ISearchAction> = (set) => ({
@@ -63,6 +67,7 @@ export const searchSlice: StoreSlice<ISearchState & ISearchAction> = (set) => ({
   showHighlights: false,
   queryAddition: null,
   clearQueryFlag: false,
+  searchStatus: 'idle' as SearchStatus,
 
   setNumPerPage: (numPerPage: NumPerPageType) =>
     set(
@@ -86,4 +91,5 @@ export const searchSlice: StoreSlice<ISearchState & ISearchAction> = (set) => ({
     set(({ showHighlights }) => ({ showHighlights: !showHighlights }), false, 'search/toggleShowHighlights'),
   setQueryAddition: (queryAddition: string) => set(() => ({ queryAddition }), false, 'search/setQueryAddition'),
   setClearQueryFlag: (clearQueryFlag: boolean) => set(() => ({ clearQueryFlag }), false, 'search/setClearQueryFlag'),
+  setSearchStatus: (searchStatus: SearchStatus) => set(() => ({ searchStatus }), false, 'search/setSearchStatus'),
 });

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,4 +1,4 @@
-import { AppState, StoreProvider, useCreateStore } from '@/store';
+import { AppState, StoreProvider, createStore } from '@/store';
 import { render, renderHook, RenderOptions } from '@testing-library/react';
 import { MockedRequest } from 'msw';
 import { SetupServerApi } from 'msw/node';
@@ -47,21 +47,26 @@ interface IProviderOptions {
   storePreset?: 'orcid-authenticated';
 }
 
-export const DefaultProviders = ({ children, options }: {
-  children: ReactElement | ReactNode,
-  options: IProviderOptions
+export const DefaultProviders = ({
+  children,
+  options,
+}: {
+  children: ReactElement | ReactNode;
+  options: IProviderOptions;
 }) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, cacheTime: 0, staleTime: 0 } } });
 
-  const store = isObject(options?.initialStore) ?
-    options.initialStore :
-    options?.storePreset ? getStateFromPreset(options.storePreset) : {};
+  const store = isObject(options?.initialStore)
+    ? options.initialStore
+    : options?.storePreset
+    ? getStateFromPreset(options.storePreset)
+    : {};
 
   return (
     <ThemeProvider theme={theme}>
       <MathJaxProvider>
         <QueryClientProvider client={queryClient}>
-          <StoreProvider createStore={useCreateStore(store)}>
+          <StoreProvider createStore={() => createStore(store)}>
             <Container maxW="container.lg">
               {children}
               <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
@@ -86,8 +91,11 @@ const getStateFromPreset = (preset: IProviderOptions['storePreset']): Partial<Ap
   }
 };
 
-const renderComponent = (ui: ReactElement, providerOptions?: IProviderOptions,
-  options?: Omit<RenderOptions, 'wrapper'>) => {
+const renderComponent = (
+  ui: ReactElement,
+  providerOptions?: IProviderOptions,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) => {
   const result = render(ui, {
     wrapper: ({ children }) => <DefaultProviders options={providerOptions}>{children}</DefaultProviders>,
     ...options,
@@ -96,8 +104,11 @@ const renderComponent = (ui: ReactElement, providerOptions?: IProviderOptions,
   return { user, ...result };
 };
 
-const renderHookComponent = <T extends AnyFunction, TResult = ReturnType<T>, TProps = Parameters<T>>(hook: Parameters<typeof renderHook<TResult, TProps>>[0],
-  providerOptions?: IProviderOptions, options?: Omit<Parameters<typeof renderHook<TResult, TProps>>[1], 'wrapper'>) => {
+const renderHookComponent = <T extends AnyFunction, TResult = ReturnType<T>, TProps = Parameters<T>>(
+  hook: Parameters<typeof renderHook<TResult, TProps>>[0],
+  providerOptions?: IProviderOptions,
+  options?: Omit<Parameters<typeof renderHook<TResult, TProps>>[1], 'wrapper'>,
+) => {
   return renderHook<TResult, TProps>(hook, {
     wrapper: ({ children }) => <DefaultProviders options={providerOptions}>{children}</DefaultProviders>,
     ...options,


### PR DESCRIPTION
NumFound's SortStats sub-component and YearHistogramSlider both read latestQuery
directly and fire API requests when the main search has errored, showing stale
citation stats and histogram data from the previous query.

- Gate SortStats rendering in NumFound on searchStatus === 'success' so the
  citation stats call never fires on stale latestQuery
- Add searchStatus === 'success' to the enabled condition in YearHistogramSlider
  so histogram data is not fetched against a stale query