### PR TITLE
Item Resource dropdown: accessibility and layout fixes

### DIFF
--- a/src/components/Libraries/DocumentList/DocumentItem.tsx
+++ b/src/components/Libraries/DocumentList/DocumentItem.tsx
@@ -121,11 +121,11 @@ export const DocumentItem = (props: IItemProps): ReactElement => {
           {!isClient || hideResources ? null : (
             <Flex alignItems="start" ml={1}>
               <ItemResourceDropdowns doc={doc} defaultCitation={defaultCitation} />
-              <IconButton
-                aria-label={isOpen ? 'Hide annotation' : 'Show annotation'}
-                aria-expanded={isOpen}
-                icon={
-                  <Tooltip label={isOpen ? 'Hide annotation' : 'Show annotation'}>
+              <Tooltip label={isOpen ? 'Hide annotation' : 'Show annotation'}>
+                <IconButton
+                  aria-label={isOpen ? 'Hide annotation' : 'Show annotation'}
+                  aria-expanded={isOpen}
+                  icon={
                     <HStack spacing="1px" align="center" mx="6px" my="2px">
                       <PencilSquareIcon width="20px" height="20px" />
                       <ChevronDownIcon
@@ -134,12 +134,12 @@ export const DocumentItem = (props: IItemProps): ReactElement => {
                         transition="transform 0.2s ease"
                       />
                     </HStack>
-                  </Tooltip>
-                }
-                variant="link"
-                size="sm"
-                onClick={onToggle}
-              />
+                  }
+                  variant="link"
+                  size="sm"
+                  onClick={onToggle}
+                />
+              </Tooltip>
             </Flex>
           )}
         </Flex>

--- a/src/components/Libraries/DocumentList/DocumentItem.tsx
+++ b/src/components/Libraries/DocumentList/DocumentItem.tsx
@@ -118,28 +118,30 @@ export const DocumentItem = (props: IItemProps): ReactElement => {
           <SimpleLink href={`/abs/${encodedCanonicalID}/abstract`} fontWeight="semibold">
             <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
           </SimpleLink>
-          <Flex alignItems="start" ml={1}>
-            <Tooltip label={isOpen ? 'Hide annotation' : 'Show annotation'}>
+          {!isClient || hideResources ? null : (
+            <Flex alignItems="start" ml={1}>
+              <ItemResourceDropdowns doc={doc} defaultCitation={defaultCitation} />
               <IconButton
                 aria-label={isOpen ? 'Hide annotation' : 'Show annotation'}
                 aria-expanded={isOpen}
                 icon={
-                  <HStack spacing="1px" align="center">
-                    <PencilSquareIcon width="18px" height="18px" />
-                    <ChevronDownIcon
-                      boxSize="14px"
-                      transform={isOpen ? 'rotate(180deg)' : 'rotate(0deg)'}
-                      transition="transform 0.2s ease"
-                    />
-                  </HStack>
+                  <Tooltip label={isOpen ? 'Hide annotation' : 'Show annotation'}>
+                    <HStack spacing="1px" align="center" mx="6px" my="2px">
+                      <PencilSquareIcon width="20px" height="20px" />
+                      <ChevronDownIcon
+                        boxSize="14px"
+                        transform={isOpen ? 'rotate(180deg)' : 'rotate(0deg)'}
+                        transition="transform 0.2s ease"
+                      />
+                    </HStack>
+                  </Tooltip>
                 }
                 variant="link"
-                size="xs"
+                size="sm"
                 onClick={onToggle}
               />
-            </Tooltip>
-            {!isClient || hideResources ? null : <ItemResourceDropdowns doc={doc} defaultCitation={defaultCitation} />}
-          </Flex>
+            </Flex>
+          )}
         </Flex>
         <Flex direction="column">
           <AuthorList author={author} authorCount={author_count} bibcode={doc.bibcode} maxAuthors={maxAuthors} />

--- a/src/components/ResultList/Item/ItemResourceDropdowns.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.tsx
@@ -167,89 +167,99 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
       {/* orcid menu */}
       <SimpleAction doc={doc} />
       {/* full resources menu */}
-      <Tooltip label="Full text sources" shouldWrapChildren isDisabled={isFullTextOpen}>
-        <Menu variant="compact" onOpen={() => setIsFullTextOpen(true)} onClose={() => setIsFullTextOpen(false)}>
-          <MenuButton
-            as={IconButton}
-            aria-label={fullSourceItems.length > 0 ? 'Full text sources' : 'No full text sources'}
-            icon={<DocumentTextIcon width="20px" height="20px" />}
-            isDisabled={fullSourceItems.length === 0}
-            variant="link"
-            size="sm"
-          />
-          {fullSourceItems.length > 0 && (
-            <MenuList>
-              {fullSourceItems.map((item) => (
-                <MenuItem key={item.id} data-id={item.id} onClick={handleResourceClick}>
-                  {item.label}
-                </MenuItem>
-              ))}
-            </MenuList>
-          )}
-        </Menu>
-      </Tooltip>
+
+      <Menu variant="compact" onOpen={() => setIsFullTextOpen(true)} onClose={() => setIsFullTextOpen(false)}>
+        <MenuButton
+          as={IconButton}
+          aria-label={fullSourceItems.length > 0 ? 'Full text sources' : 'No full text sources'}
+          icon={
+            <Tooltip label="Full text sources" isDisabled={isFullTextOpen}>
+              <DocumentTextIcon width="20px" height="20px" />
+            </Tooltip>
+          }
+          isDisabled={fullSourceItems.length === 0}
+          variant="link"
+          size="sm"
+        />
+        {fullSourceItems.length > 0 && (
+          <MenuList>
+            {fullSourceItems.map((item) => (
+              <MenuItem key={item.id} data-id={item.id} onClick={handleResourceClick}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </MenuList>
+        )}
+      </Menu>
 
       {/* reference and citation items menu */}
-      <Tooltip label="References and citations" shouldWrapChildren isDisabled={isRefsOpen}>
-        <Menu variant="compact" onOpen={() => setIsRefsOpen(true)} onClose={() => setIsRefsOpen(false)}>
-          <MenuButton
-            as={IconButton}
-            aria-label={referenceItems.length > 0 ? 'References and citations' : 'No references and citations'}
-            icon={<Bars4Icon width="20px" height="20" />}
-            isDisabled={referenceItems.length === 0}
-            variant="link"
-            size="sm"
-          />
-          {referenceItems.length > 0 && (
-            <MenuList>
-              {referenceItems.map((item) => (
-                <MenuItem key={item.id} data-id={item.id} onClick={handleReferenceClick}>
-                  {item.label}
-                </MenuItem>
-              ))}
-            </MenuList>
-          )}
-        </Menu>
-      </Tooltip>
+      <Menu variant="compact" onOpen={() => setIsRefsOpen(true)} onClose={() => setIsRefsOpen(false)}>
+        <MenuButton
+          as={IconButton}
+          aria-label={referenceItems.length > 0 ? 'References and citations' : 'No references and citations'}
+          icon={
+            <Tooltip label="References and citations" isDisabled={isRefsOpen}>
+              <Bars4Icon width="20px" height="20" />
+            </Tooltip>
+          }
+          isDisabled={referenceItems.length === 0}
+          variant="link"
+          size="sm"
+        />
+        {referenceItems.length > 0 && (
+          <MenuList>
+            {referenceItems.map((item) => (
+              <MenuItem key={item.id} data-id={item.id} onClick={handleReferenceClick}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </MenuList>
+        )}
+      </Menu>
 
       {/* data product items menu */}
-      <Tooltip label="Data products" shouldWrapChildren isDisabled={isDataOpen}>
-        <Menu variant="compact" onOpen={() => setIsDataOpen(true)} onClose={() => setIsDataOpen(false)}>
-          <MenuButton
-            as={IconButton}
-            aria-label={dataProductItems.length > 0 ? 'Data products' : 'No data products'}
-            icon={<CircleStackIcon width="20px" height="20px" />}
-            isDisabled={dataProductItems.length === 0}
-            variant="link"
-            size="sm"
-          />
-          {dataProductItems.length > 0 && (
-            <MenuList>
-              {dataProductItems.map((item) => (
-                <MenuItem key={item.id} data-id={item.id} onClick={handleDataProductClick}>
-                  {item.label}
-                </MenuItem>
-              ))}
-            </MenuList>
-          )}
-        </Menu>
-      </Tooltip>
-      {/* share menu */}
-      <Tooltip label="Share options" shouldWrapChildren isDisabled={isShareOpen}>
-        <Menu variant="compact" isOpen={isShareOpen} onOpen={onShareOpen} onClose={onShareClose}>
-          <MenuButton
-            as={IconButton}
-            aria-label="share options"
-            icon={<ShareIcon width="20px" height="20px" />}
-            variant="link"
-            size="sm"
-          />
+      <Menu variant="compact" onOpen={() => setIsDataOpen(true)} onClose={() => setIsDataOpen(false)}>
+        <MenuButton
+          as={IconButton}
+          aria-label={dataProductItems.length > 0 ? 'Data products' : 'No data products'}
+          icon={
+            <Tooltip label="Data products" isDisabled={isDataOpen}>
+              <CircleStackIcon width="20px" height="20px" />
+            </Tooltip>
+          }
+          isDisabled={dataProductItems.length === 0}
+          variant="link"
+          size="sm"
+        />
+        {dataProductItems.length > 0 && (
           <MenuList>
-            <MenuItem onClick={handleCopyAbstractUrl}>Copy URL</MenuItem>
-            <CopyMenuItem text={citation} onCopyComplete={handleCitationCopied} label="Copy Citation" asHtml />
+            {dataProductItems.map((item) => (
+              <MenuItem key={item.id} data-id={item.id} onClick={handleDataProductClick}>
+                {item.label}
+              </MenuItem>
+            ))}
           </MenuList>
-        </Menu>
-      </Tooltip>
+        )}
+      </Menu>
+
+      {/* share menu */}
+      <Menu variant="compact" isOpen={isShareOpen} onOpen={onShareOpen} onClose={onShareClose}>
+        <MenuButton
+          as={IconButton}
+          aria-label="share options"
+          icon={
+            <Tooltip label="Share options" isDisabled={isShareOpen}>
+              <ShareIcon width="20px" height="20px" />
+            </Tooltip>
+          }
+          variant="link"
+          size="sm"
+        />
+        <MenuList>
+          <MenuItem onClick={handleCopyAbstractUrl}>Copy URL</MenuItem>
+          <CopyMenuItem text={citation} onCopyComplete={handleCitationCopied} label="Copy Citation" asHtml />
+        </MenuList>
+      </Menu>
     </Flex>
   );
 };

--- a/src/components/ResultList/Item/ItemResourceDropdowns.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.tsx
@@ -169,18 +169,16 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
       {/* full resources menu */}
 
       <Menu variant="compact" onOpen={() => setIsFullTextOpen(true)} onClose={() => setIsFullTextOpen(false)}>
-        <MenuButton
-          as={IconButton}
-          aria-label={fullSourceItems.length > 0 ? 'Full text sources' : 'No full text sources'}
-          icon={
-            <Tooltip label="Full text sources" isDisabled={isFullTextOpen}>
-              <DocumentTextIcon width="20px" height="20px" />
-            </Tooltip>
-          }
-          isDisabled={fullSourceItems.length === 0}
-          variant="link"
-          size="sm"
-        />
+        <Tooltip label="Full text sources" isDisabled={isFullTextOpen}>
+          <MenuButton
+            as={IconButton}
+            aria-label={fullSourceItems.length > 0 ? 'Full text sources' : 'No full text sources'}
+            icon={<DocumentTextIcon width="20px" height="20px" />}
+            isDisabled={fullSourceItems.length === 0}
+            variant="link"
+            size="sm"
+          />
+        </Tooltip>
         {fullSourceItems.length > 0 && (
           <MenuList>
             {fullSourceItems.map((item) => (
@@ -194,18 +192,16 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
 
       {/* reference and citation items menu */}
       <Menu variant="compact" onOpen={() => setIsRefsOpen(true)} onClose={() => setIsRefsOpen(false)}>
-        <MenuButton
-          as={IconButton}
-          aria-label={referenceItems.length > 0 ? 'References and citations' : 'No references and citations'}
-          icon={
-            <Tooltip label="References and citations" isDisabled={isRefsOpen}>
-              <Bars4Icon width="20px" height="20" />
-            </Tooltip>
-          }
-          isDisabled={referenceItems.length === 0}
-          variant="link"
-          size="sm"
-        />
+        <Tooltip label="References and citations" isDisabled={isRefsOpen}>
+          <MenuButton
+            as={IconButton}
+            aria-label={referenceItems.length > 0 ? 'References and citations' : 'No references and citations'}
+            icon={<Bars4Icon width="20px" height="20" />}
+            isDisabled={referenceItems.length === 0}
+            variant="link"
+            size="sm"
+          />
+        </Tooltip>
         {referenceItems.length > 0 && (
           <MenuList>
             {referenceItems.map((item) => (
@@ -219,18 +215,16 @@ export const ItemResourceDropdowns = ({ doc }: IItemResourceDropdownsProps): Rea
 
       {/* data product items menu */}
       <Menu variant="compact" onOpen={() => setIsDataOpen(true)} onClose={() => setIsDataOpen(false)}>
-        <MenuButton
-          as={IconButton}
-          aria-label={dataProductItems.length > 0 ? 'Data products' : 'No data products'}
-          icon={
-            <Tooltip label="Data products" isDisabled={isDataOpen}>
-              <CircleStackIcon width="20px" height="20px" />
-            </Tooltip>
-          }
-          isDisabled={dataProductItems.length === 0}
-          variant="link"
-          size="sm"
-        />
+        <Tooltip label="Data products" isDisabled={isDataOpen}>
+          <MenuButton
+            as={IconButton}
+            aria-label={dataProductItems.length > 0 ? 'Data products' : 'No data products'}
+            icon={<CircleStackIcon width="20px" height="20px" />}
+            isDisabled={dataProductItems.length === 0}
+            variant="link"
+            size="sm"
+          />
+        </Tooltip>
         {dataProductItems.length > 0 && (
           <MenuList>
             {dataProductItems.map((item) => (


### PR DESCRIPTION
* The tooltip was causing the dropdown menus to be no longer accessible by keyboard. 
  * Move the tooltip from the menu to the icon 
* Fix inconsistent menu icons size and layout

Before:
<img width="299" height="36" alt="Screenshot 2026-05-14 at 3 00 48 PM" src="https://github.com/user-attachments/assets/590d9b17-18cf-4426-90ce-e887da63d165" />

After:
<img width="322" height="40" alt="Screenshot 2026-05-14 at 3 01 04 PM" src="https://github.com/user-attachments/assets/c63bbd01-5de2-407e-b6a0-b6c3a5421c95" />
