### PR TITLE
test: add unit tests across pure utilities, forms, and ORCID helpers

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { pickTracingHeaders, TRACING_HEADERS } from '@/config';
 
 describe('pickTracingHeaders', () => {
-  it('extracts tracing headers from lowercase IncomingHttpHeaders', () => {
+  test('extracts tracing headers from lowercase IncomingHttpHeaders', () => {
     const headers = {
       'x-original-uri': '/some/path',
       'x-amzn-trace-id': 'Root=1-abc-def',
@@ -17,12 +17,12 @@ describe('pickTracingHeaders', () => {
     });
   });
 
-  it('handles missing headers gracefully', () => {
+  test('handles missing headers gracefully', () => {
     const result = pickTracingHeaders({});
     expect(result).toEqual({});
   });
 
-  it('ignores array-valued headers', () => {
+  test('ignores array-valued headers', () => {
     const headers = {
       'x-forwarded-for': ['1.2.3.4', '5.6.7.8'],
     };
@@ -31,7 +31,7 @@ describe('pickTracingHeaders', () => {
     expect(result).toEqual({});
   });
 
-  it('preserves original key casing from TRACING_HEADERS', () => {
+  test('preserves original key casing from TRACING_HEADERS', () => {
     const headers = {
       'x-original-uri': '/path',
       'x-original-forwarded-for': '1.2.3.4',

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -1,15 +1,15 @@
 import * as Q from '@/query';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 describe('Query Utilities', () => {
-  it('can join conditions with an operator', () => {
+  test('can join conditions with an operator', () => {
     expect(Q.joinConditions('AND', ['foo', 'bar', 'baz'])).toEqual('foo AND bar AND baz');
   });
 
   /**
    * Escaping
    */
-  it.concurrent.each<[string, Parameters<typeof Q.escape>, ReturnType<typeof Q.escape>]>([
+  test.concurrent.each<[string, Parameters<typeof Q.escape>, ReturnType<typeof Q.escape>]>([
     ['\\ is properly escaped', ['f\\oooooo'], 'f\\\\oooooo'],
     ['+ is properly escaped', ['foo+oooo'], 'foo\\+oooo'],
     ['- is properly escaped', ['f-oooooo'], 'f\\-oooooo'],
@@ -34,7 +34,7 @@ describe('Query Utilities', () => {
     return Promise.resolve();
   });
 
-  it.concurrent.each<[string, Parameters<typeof Q.splitQuery>, ReturnType<typeof Q.splitQuery>]>([
+  test.concurrent.each<[string, Parameters<typeof Q.splitQuery>, ReturnType<typeof Q.splitQuery>]>([
     ['simple case', ['(1 AND 2)'], ['(1 AND 2)']],
     ['2 clauses', ['(1 AND 2) AND (3 OR 4)'], ['(1 AND 2)', '(3 OR 4)']],
     ['single clauses', ['(1) AND (2) AND (3)'], ['(1)', '(2)', '(3)']],

--- a/src/api/orcid/models.test.ts
+++ b/src/api/orcid/models.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'vitest';
+import { isOrcidProfileEntry, isValidIOrcidUser, isValidOrcidId } from './models';
+
+describe('isValidOrcidId', () => {
+  test('returns true for valid ORCID ids', () => {
+    expect(isValidOrcidId('0000-0002-1825-0097')).toBe(true);
+    expect(isValidOrcidId('1234-5678-9012-345X')).toBe(true);
+  });
+
+  test('returns false for malformed ORCID ids', () => {
+    expect(isValidOrcidId('0000-0002-1825-009')).toBe(false);
+    expect(isValidOrcidId('0000-0002-1825-00977')).toBe(false);
+    expect(isValidOrcidId('0000000218250097')).toBe(false);
+    expect(isValidOrcidId('0000-0002-1825-009x')).toBe(false);
+    expect(isValidOrcidId('abcd-0002-1825-0097')).toBe(false);
+  });
+
+  test('returns false for non-string values', () => {
+    expect(isValidOrcidId(null)).toBe(false);
+    expect(isValidOrcidId(undefined)).toBe(false);
+    expect(isValidOrcidId(1234)).toBe(false);
+    expect(isValidOrcidId({})).toBe(false);
+  });
+});
+
+describe('isValidIOrcidUser', () => {
+  const validUser = {
+    access_token: 'token',
+    expires_in: 3600,
+    name: 'Ada Lovelace',
+    orcid: '0000-0002-1825-0097',
+    refresh_token: 'refresh',
+    scope: '/read-limited',
+    token_type: 'bearer',
+  };
+
+  test('returns true for a valid ORCID user object', () => {
+    expect(isValidIOrcidUser(validUser)).toBe(true);
+  });
+
+  test('returns true for boundary numeric values that still produce a valid date', () => {
+    expect(isValidIOrcidUser({ ...validUser, expires_in: 0 })).toBe(true);
+    expect(isValidIOrcidUser({ ...validUser, expires_in: -1 })).toBe(true);
+  });
+
+  test('returns false when required keys are missing', () => {
+    const { refresh_token, ...missingRefreshToken } = validUser;
+
+    expect(isValidIOrcidUser(missingRefreshToken)).toBe(false);
+  });
+
+  test('returns false for non-object values', () => {
+    expect(isValidIOrcidUser(null)).toBe(false);
+    expect(isValidIOrcidUser(undefined)).toBe(false);
+    expect(isValidIOrcidUser('user')).toBe(false);
+    expect(isValidIOrcidUser([])).toBe(false);
+  });
+
+  test('returns false when any required property has the wrong type', () => {
+    expect(isValidIOrcidUser({ ...validUser, access_token: 123 })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, expires_in: '3600' })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, name: false })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, orcid: 12 })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, refresh_token: null })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, scope: {} })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, token_type: [] })).toBe(false);
+  });
+
+  test('returns false when expires_in produces an invalid date', () => {
+    expect(isValidIOrcidUser({ ...validUser, expires_in: NaN })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, expires_in: Infinity })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, expires_in: -Infinity })).toBe(false);
+    expect(isValidIOrcidUser({ ...validUser, expires_in: Number.MAX_SAFE_INTEGER })).toBe(false);
+  });
+});
+
+describe('isOrcidProfileEntry', () => {
+  const validEntry = {
+    identifier: '2024MNRAS.123..456A',
+    status: 'verified',
+    title: 'A valid ORCID profile entry',
+    pubyear: '2024',
+    pubmonth: '06',
+    updated: '2024-06-02',
+    putcode: '12345',
+    source: ['ADS', 'ORCID'],
+  };
+
+  test('returns true for a fully valid profile entry', () => {
+    expect(isOrcidProfileEntry(validEntry)).toBe(true);
+  });
+
+  test('returns true for allowed status values and nullable fields', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, status: 'not in ADS', pubyear: null, pubmonth: null })).toBe(true);
+    expect(isOrcidProfileEntry({ ...validEntry, status: 'pending', pubmonth: undefined })).toBe(true);
+    expect(isOrcidProfileEntry({ ...validEntry, status: 'rejected', putcode: 12345 })).toBe(true);
+  });
+
+  test('returns false for nil or empty entries', () => {
+    expect(isOrcidProfileEntry(null)).toBe(false);
+    expect(isOrcidProfileEntry(undefined)).toBe(false);
+    expect(isOrcidProfileEntry('')).toBe(false);
+    expect(isOrcidProfileEntry({})).toBe(false);
+    expect(isOrcidProfileEntry([])).toBe(false);
+  });
+
+  test('returns false when required scalar fields have the wrong type', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, identifier: 123 })).toBe(false);
+    expect(isOrcidProfileEntry({ ...validEntry, title: 123 })).toBe(false);
+    expect(isOrcidProfileEntry({ ...validEntry, updated: 123 })).toBe(false);
+    expect(isOrcidProfileEntry({ ...validEntry, putcode: true })).toBe(false);
+  });
+
+  test('returns false for invalid status values', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, status: 'unknown' })).toBe(false);
+    expect(isOrcidProfileEntry({ ...validEntry, status: null })).toBe(false);
+  });
+
+  test('returns false when source is not an array of strings', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, source: 'ADS' })).toBe(false);
+    expect(isOrcidProfileEntry({ ...validEntry, source: ['ADS', 1] })).toBe(false);
+  });
+
+  test('returns false when pubmonth has the wrong type', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, pubmonth: 6 })).toBe(false);
+  });
+
+  test('accepts a non-string pubyear when pubmonth is undefined because of the current implementation', () => {
+    expect(isOrcidProfileEntry({ ...validEntry, pubyear: 2024, pubmonth: undefined })).toBe(true);
+  });
+});

--- a/src/api/orcid/orcid.test.ts
+++ b/src/api/orcid/orcid.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+
+import { OrcidKeys, orcidKeys } from '@/api/orcid/orcid';
+
+describe('orcidKeys', () => {
+  test('exchangeToken omits user from the query key params', () => {
+    const params = {
+      user: {
+        orcid: '0000-0000-0000-0001',
+        access_token: 'secret-token',
+      },
+      code: 'auth-code',
+      state: 'some-state',
+    };
+
+    expect(orcidKeys.exchangeToken(params)).toEqual([
+      OrcidKeys.EXCHANGE_TOKEN,
+      { code: 'auth-code', state: 'some-state' },
+    ]);
+  });
+
+  test('profile preserves formatting flags while omitting user', () => {
+    const params = {
+      user: {
+        orcid: '0000-0000-0000-0001',
+        access_token: 'secret-token',
+      },
+      full: false,
+      update: true,
+    };
+
+    expect(orcidKeys.profile(params)).toEqual([OrcidKeys.PROFILE, { full: false, update: true }]);
+  });
+
+  test('name and getWork keys keep non-user identifiers only', () => {
+    const user = {
+      orcid: '0000-0000-0000-0001',
+      access_token: 'secret-token',
+    };
+
+    expect(orcidKeys.name({ user })).toEqual([OrcidKeys.NAME, {}]);
+    expect(orcidKeys.getWork({ user, putcode: 12345 })).toEqual([OrcidKeys.GET_WORK, { putcode: 12345 }]);
+  });
+
+  test('preference keys follow the expected query and mutation shapes', () => {
+    const params = {
+      user: {
+        orcid: '0000-0000-0000-0001',
+        access_token: 'secret-token',
+      },
+    };
+
+    expect(orcidKeys.getPreferences(params)).toEqual([OrcidKeys.GET_PREFERENCES, {}]);
+    expect(orcidKeys.setPreferences()).toEqual([OrcidKeys.SET_PREFERENCES]);
+  });
+
+  test('addWorks and removeWorks return stable mutation keys', () => {
+    expect(orcidKeys.addWorks()).toEqual([OrcidKeys.ADD_WORKS]);
+    expect(orcidKeys.removeWorks()).toEqual([OrcidKeys.REMOVE_WORKS]);
+  });
+});

--- a/src/api/user/__tests__/user.test.ts
+++ b/src/api/user/__tests__/user.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { AxiosError } from 'axios';
 
 import api from '@/api/api';
@@ -11,7 +11,7 @@ describe('fetchUserSettings', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns default user settings on authorization errors', async () => {
+  test('returns default user settings on authorization errors', async () => {
     const error = new AxiosError('Forbidden', AxiosError.ERR_BAD_RESPONSE, {}, undefined, {
       status: 403,
       statusText: 'Forbidden',
@@ -38,7 +38,7 @@ describe('fetchUserSettings', () => {
     );
   });
 
-  it('rethrows non-authorization errors', async () => {
+  test('rethrows non-authorization errors', async () => {
     const error = new AxiosError('Internal Server Error', AxiosError.ERR_BAD_RESPONSE, {}, undefined, {
       status: 500,
       statusText: 'Internal Server Error',

--- a/src/components/AbstractSources/__tests__/createUrlByType.test.ts
+++ b/src/components/AbstractSources/__tests__/createUrlByType.test.ts
@@ -25,6 +25,18 @@ describe('createUrlByType', () => {
     expect(url).toContain('10.48550/arXiv.2507.19320');
   });
 
+  test('fully encodes / in non-DOI identifiers (e.g. legacy arXiv ids)', () => {
+    const url = createUrlByType('test', 'arxiv', 'hep-th/9901001');
+    expect(url).toContain('arxiv:hep-th%2F9901001');
+    expect(url).not.toContain('arxiv:hep-th/9901001');
+  });
+
+  test('encodes the bibcode for consistency with the gateway url', () => {
+    const url = createUrlByType('2020A&A...1..1X', 'doi', '10.1000/x');
+    expect(url).toContain('2020A%26A...1..1X');
+    expect(url).not.toContain('2020A&A');
+  });
+
   test('returns empty string for non-string arguments', () => {
     expect(createUrlByType(null as unknown as string, 'doi', '10.1000/x')).toBe('');
     expect(createUrlByType('bib', null as unknown as string, '10.1000/x')).toBe('');

--- a/src/components/AbstractSources/linkGenerator.ts
+++ b/src/components/AbstractSources/linkGenerator.ts
@@ -140,7 +140,11 @@ export const processLinkData = (doc: IDocsEntity, linkServer?: string): ProcessL
  */
 export const createUrlByType = function (bibcode: string, type: string, identifier: string): string {
   if (typeof bibcode === 'string' && typeof type === 'string' && typeof identifier === 'string') {
-    return `${GATEWAY_BASE_URL + bibcode}/${type}:${encodeDOIPath(identifier)}`;
+    // DOIs use path-safe encoding that preserves '/' as a path separator; all
+    // other identifiers (e.g. legacy arXiv ids like "hep-th/9901001") must fully
+    // encode '/' so it is not interpreted as an extra path segment.
+    const encodedIdentifier = type.toLowerCase() === 'doi' ? encodeDOIPath(identifier) : encodeURIComponent(identifier);
+    return `${GATEWAY_BASE_URL + encodeURIComponent(bibcode)}/${type}:${encodedIdentifier}`;
   }
   return '';
 };

--- a/src/components/AbstractSources/openUrlGenerator.ts
+++ b/src/components/AbstractSources/openUrlGenerator.ts
@@ -53,10 +53,10 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
   const parsed: Record<string, string | string[]> = {
     ...STATIC_FIELDS,
     'rft.spage': isArray(page) ? page[0].split('-')[0] : undefined,
-    id: isArray(doi) ? 'doi:' + encodeURIComponent(doi[0]) : undefined,
+    id: isArray(doi) ? 'doi:' + doi[0] : undefined,
     genre: genre,
     rft_id: [
-      isArray(doi) ? 'info:doi/' + encodeURIComponent(doi[0]) : undefined,
+      isArray(doi) ? 'info:doi/' + doi[0] : undefined,
       isString(bibcode) ? 'info:bibcode/' + bibcode : undefined,
     ],
     'rft.degree': degree,

--- a/src/components/AbstractSources/openUrlGenerator.ts
+++ b/src/components/AbstractSources/openUrlGenerator.ts
@@ -53,10 +53,10 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
   const parsed: Record<string, string | string[]> = {
     ...STATIC_FIELDS,
     'rft.spage': isArray(page) ? page[0].split('-')[0] : undefined,
-    id: isArray(doi) ? 'doi:' + doi[0] : undefined,
+    id: isArray(doi) ? 'doi:' + encodeURIComponent(doi[0]) : undefined,
     genre: genre,
     rft_id: [
-      isArray(doi) ? 'info:doi/' + doi[0] : undefined,
+      isArray(doi) ? 'info:doi/' + encodeURIComponent(doi[0]) : undefined,
       isString(bibcode) ? 'info:bibcode/' + bibcode : undefined,
     ],
     'rft.degree': degree,

--- a/src/components/AllAuthorsModal/__tests__/useGetAuthors.test.ts
+++ b/src/components/AllAuthorsModal/__tests__/useGetAuthors.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useGetAuthors } from '../useGetAuthors';
 import { IDocsEntity } from '@/api/search/types';
 
 describe('useGetAuthors', () => {
-  it('filters out empty string orcid values from result', () => {
+  test('filters out empty string orcid values from result', () => {
     const doc = {
       author: ['Smith, John', 'Doe, Jane'],
       aff: ['University A', 'University B'],
@@ -23,7 +23,7 @@ describe('useGetAuthors', () => {
     ]);
   });
 
-  it('preserves valid orcid values while filtering empty ones', () => {
+  test('preserves valid orcid values while filtering empty ones', () => {
     const doc = {
       author: ['Smith, John', 'Doe, Jane'],
       aff: ['University A', 'University B'],

--- a/src/components/EmailNotifications/Forms/ArxivForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/ArxivForm.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@/test-utils';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { ArxivForm } from './ArxivForm';
+import { arxivModel } from '../ArxivModel';
+
+const mocks = vi.hoisted(() => ({
+  addMutation: vi.fn(),
+  editMutation: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/api/vault/vault', () => ({
+  useAddNotification: () => ({
+    mutate: mocks.addMutation,
+    isLoading: false,
+  }),
+  useEditNotification: () => ({
+    mutate: mocks.editMutation,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => mocks.toast,
+  };
+});
+
+const getCheckboxByValue = (value: string) => {
+  const input = document.querySelector<HTMLInputElement>(`input[type="checkbox"][value="${value}"]`);
+  expect(input).not.toBeNull();
+  return input as HTMLInputElement;
+};
+
+const clickCheckboxByValue = async (user: ReturnType<typeof render>['user'], value: string) => {
+  const input = getCheckboxByValue(value);
+  const label = input.closest('label');
+  expect(label).not.toBeNull();
+  await user.click(label as HTMLLabelElement);
+};
+
+describe('ArxivForm', () => {
+  beforeEach(() => {
+    mocks.addMutation.mockReset();
+    mocks.editMutation.mockReset();
+    mocks.toast.mockReset();
+  });
+
+  test('clicking a parent selects all children, then deselects all children when clicked again', async () => {
+    const { user } = render(<ArxivForm onClose={vi.fn()} />);
+
+    const parent = getCheckboxByValue('astro-ph');
+    await clickCheckboxByValue(user, 'astro-ph');
+
+    expect(parent).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'expand Astrophysics' }));
+
+    expect(getCheckboxByValue('astro-ph.CO')).toBeChecked();
+    expect(getCheckboxByValue('astro-ph.EP')).toBeChecked();
+    expect(getCheckboxByValue('astro-ph.GA')).toBeChecked();
+    expect(getCheckboxByValue('astro-ph.HE')).toBeChecked();
+    expect(getCheckboxByValue('astro-ph.IM')).toBeChecked();
+    expect(getCheckboxByValue('astro-ph.SR')).toBeChecked();
+
+    await clickCheckboxByValue(user, 'astro-ph');
+
+    expect(parent).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.CO')).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.EP')).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.GA')).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.HE')).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.IM')).not.toBeChecked();
+    expect(getCheckboxByValue('astro-ph.SR')).not.toBeChecked();
+  });
+
+  test('clicking a child toggles only that child and updates the parent to indeterminate', async () => {
+    const { user } = render(<ArxivForm onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'expand Astrophysics' }));
+
+    const parent = getCheckboxByValue('astro-ph');
+    const child = getCheckboxByValue('astro-ph.EP');
+
+    expect(parent).not.toBeChecked();
+    expect(child).not.toBeChecked();
+
+    await clickCheckboxByValue(user, 'astro-ph.EP');
+
+    expect(child).toBeChecked();
+    expect(parent).toBePartiallyChecked();
+
+    await clickCheckboxByValue(user, 'astro-ph.EP');
+
+    expect(child).not.toBeChecked();
+    expect(parent).not.toBeChecked();
+  });
+
+  test('submitting with all children selected collapses the payload to the parent class key', async () => {
+    const { user } = render(<ArxivForm onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'expand Astrophysics' }));
+
+    for (const childKey of Object.keys(arxivModel['astro-ph'].children)) {
+      await clickCheckboxByValue(user, childKey);
+    }
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(mocks.addMutation).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.addMutation).toHaveBeenCalledWith(
+      {
+        type: 'template',
+        template: 'arxiv',
+        data: null,
+        classes: ['astro-ph'],
+      },
+      expect.objectContaining({
+        onSettled: expect.any(Function),
+      }),
+    );
+    expect(mocks.editMutation).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EmailNotifications/Forms/CitationForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/CitationForm.test.tsx
@@ -1,0 +1,143 @@
+import { render } from '@/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { CitationForm } from './CitationForm';
+import { isValidOrcidId } from '@/api/orcid/models';
+
+const addNotificationMock = vi.fn();
+const editNotificationMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock('@/api/vault/vault', () => ({
+  useAddNotification: () => ({
+    mutate: addNotificationMock,
+    isLoading: false,
+  }),
+  useEditNotification: () => ({
+    mutate: editNotificationMock,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+
+  return {
+    ...actual,
+    useToast: () => toastMock,
+  };
+});
+
+describe('CitationForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders create mode with empty input and disabled submit state', () => {
+    render(<CitationForm onClose={vi.fn()} template="citations" />);
+
+    expect(screen.getByTestId('create-citations-modal')).toBeInTheDocument();
+    expect(screen.getByLabelText('new author input')).toHaveValue('');
+    expect(screen.queryByText('Notification Name')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'add author' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  test('validates author names with the component regex and enables add for valid input', async () => {
+    const { user } = render(<CitationForm onClose={vi.fn()} template="authors" />);
+
+    const input = screen.getByLabelText('new author input');
+    const addButton = screen.getByRole('button', { name: 'add author' });
+
+    await user.type(input, 'Jane Doe');
+    expect(screen.getByText('Invalid')).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, 'Doe, Jane');
+
+    expect(screen.getByText('Author')).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
+  });
+
+  test('accepts canonical ORCID ids and rejects invalid ones', async () => {
+    const validOrcid = '0000-0002-1825-0097';
+    const invalidOrcid = '0000-0002-1825-009';
+
+    expect(isValidOrcidId(validOrcid)).toBe(true);
+    expect(isValidOrcidId(invalidOrcid)).toBe(false);
+
+    const { user } = render(<CitationForm onClose={vi.fn()} template="citations" />);
+
+    const input = screen.getByLabelText('new author input');
+    const addButton = screen.getByRole('button', { name: 'add author' });
+
+    await user.type(input, validOrcid);
+    expect(screen.getByText('Orcid')).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
+
+    await user.clear(input);
+    await user.type(input, invalidOrcid);
+
+    expect(screen.getByText('Invalid')).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+  });
+
+  test('submits a new citation notification with serialized authors', async () => {
+    const { user } = render(<CitationForm onClose={vi.fn()} onUpdated={vi.fn()} template="citations" />);
+
+    const input = screen.getByLabelText('new author input');
+
+    await user.type(input, 'Doe, Jane');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled());
+
+    await user.type(input, '0000-0002-1825-0097');
+    await user.click(screen.getByRole('button', { name: 'add author' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(addNotificationMock).toHaveBeenCalledTimes(1);
+    expect(addNotificationMock).toHaveBeenCalledWith(
+      {
+        data: 'author:"Doe, Jane" OR orcid:"0000-0002-1825-0097"',
+        template: 'citations',
+        type: 'template',
+      },
+      expect.objectContaining({
+        onSettled: expect.any(Function),
+      }),
+    );
+    expect(editNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test('renders edit mode name and submits existing authors with updated name', async () => {
+    const notification = {
+      id: 42,
+      name: 'Original Name',
+      data: 'author:"Doe, Jane" OR orcid:"0000-0002-1825-0097"',
+    };
+
+    const { user } = render(<CitationForm onClose={vi.fn()} notification={notification as never} />);
+
+    const nameInput = screen.getByDisplayValue('Original Name');
+    expect(nameInput).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Updated Name');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(editNotificationMock).toHaveBeenCalledTimes(1);
+    expect(editNotificationMock).toHaveBeenCalledWith(
+      {
+        id: 42,
+        data: 'author:"Doe, Jane" OR orcid:"0000-0002-1825-0097"',
+        name: 'Updated Name',
+      },
+      expect.objectContaining({
+        onSettled: expect.any(Function),
+      }),
+    );
+    expect(addNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EmailNotifications/Forms/KeywordsForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/KeywordsForm.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { KeywordsForm } from './KeywordsForm';
+import { isValidKeyword } from './Utils';
+
+const mocks = vi.hoisted(() => ({
+  addMutation: vi.fn(),
+  editMutation: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/api/vault/vault', () => ({
+  useAddNotification: () => ({
+    mutate: mocks.addMutation,
+    isLoading: false,
+  }),
+  useEditNotification: () => ({
+    mutate: mocks.editMutation,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => mocks.toast,
+  };
+});
+
+describe('KeywordsForm', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.addMutation.mockReset();
+    mocks.editMutation.mockReset();
+    mocks.toast.mockReset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  test('renders correctly with initial create state', () => {
+    render(<KeywordsForm onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('create-keyword-modal')).toBeInTheDocument();
+    expect(screen.getByText(/weekly updates on the most recent/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/notification name/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('keyword-input')).toHaveValue('');
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  test('shows debounced validation feedback for an invalid keyword', async () => {
+    render(<KeywordsForm onClose={vi.fn()} />);
+
+    const keywordInput = screen.getByTestId('keyword-input');
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+    const invalidKeyword = '(';
+
+    expect(isValidKeyword(invalidKeyword)).toBe(false);
+
+    fireEvent.change(keywordInput, { target: { value: invalidKeyword } });
+
+    expect(screen.queryByText(/invalid keyword syntax/i)).not.toBeInTheDocument();
+    expect(submitButton).toBeEnabled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid keyword syntax/i)).toBeInTheDocument();
+    });
+    expect(submitButton).toBeDisabled();
+  });
+
+  test('enables submit for a valid keyword after debounce', async () => {
+    render(<KeywordsForm onClose={vi.fn()} />);
+
+    const keywordInput = screen.getByTestId('keyword-input');
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+    const validKeyword = 'alpha (beta)';
+
+    expect(isValidKeyword(validKeyword)).toBe(true);
+
+    fireEvent.change(keywordInput, { target: { value: validKeyword } });
+    await vi.advanceTimersByTimeAsync(500);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/invalid keyword syntax/i)).not.toBeInTheDocument();
+    });
+    expect(submitButton).toBeEnabled();
+  });
+
+  test('submits a valid keyword through the add notification mutation', async () => {
+    const onClose = vi.fn();
+    const onUpdated = vi.fn();
+
+    render(<KeywordsForm onClose={onClose} onUpdated={onUpdated} />);
+
+    const keywordInput = screen.getByTestId('keyword-input');
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+
+    fireEvent.change(keywordInput, { target: { value: 'star OR planet' } });
+    await vi.advanceTimersByTimeAsync(500);
+
+    fireEvent.click(submitButton);
+
+    expect(mocks.addMutation).toHaveBeenCalledTimes(1);
+    expect(mocks.addMutation).toHaveBeenCalledWith(
+      {
+        type: 'template',
+        template: 'keyword',
+        data: 'star OR planet',
+      },
+      expect.objectContaining({
+        onSettled: expect.any(Function),
+      }),
+    );
+    expect(mocks.editMutation).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EmailNotifications/Forms/QueryForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/QueryForm.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/components/Select', () => ({
       aria-label={typeof label === 'string' ? label : 'select'}
       data-testid={id}
       value={String(value?.id ?? '')}
-      onChange={(event) => onChange(options.find((option) => String(option.id) === event.target.value))}
+      onChange={(event) => onChange(options.find((option) => String(option.id) === event.target.value)!)}
     >
       {options.map((option) => (
         <option key={String(option.id)} value={String(option.id)}>

--- a/src/components/EmailNotifications/Forms/QueryForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/QueryForm.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, waitFor } from '@/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { QueryForm } from './QueryForm';
+
+const mocks = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  toast: vi.fn(),
+  useVaultSearch: vi.fn(),
+  searchState: {
+    data: undefined as { qid: string } | undefined,
+    isFetching: false,
+    error: null as Error | null,
+  },
+}));
+
+vi.mock('@/api/vault/vault', () => ({
+  useAddNotification: () => ({
+    mutate: mocks.addNotification,
+    isLoading: false,
+  }),
+  useVaultSearch: (query: unknown, options: unknown) => mocks.useVaultSearch(query, options),
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => mocks.toast,
+  };
+});
+
+type MockOption = { id: string | number; label: string; value: string };
+type MockSelectProps = {
+  id: string;
+  label: unknown;
+  options: MockOption[];
+  value: MockOption;
+  onChange: (o: MockOption) => void;
+};
+
+vi.mock('@/components/Select', () => ({
+  Select: ({ id, label, options, value, onChange }: MockSelectProps) => (
+    <select
+      aria-label={typeof label === 'string' ? label : 'select'}
+      data-testid={id}
+      value={String(value?.id ?? '')}
+      onChange={(event) => onChange(options.find((option) => String(option.id) === event.target.value))}
+    >
+      {options.map((option) => (
+        <option key={String(option.id)} value={String(option.id)}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+describe('QueryForm', () => {
+  const query = { q: 'author:"Ada Lovelace"' };
+
+  beforeEach(() => {
+    mocks.addNotification.mockReset();
+    mocks.toast.mockReset();
+    mocks.useVaultSearch.mockReset();
+    mocks.searchState.data = undefined;
+    mocks.searchState.isFetching = false;
+    mocks.searchState.error = null;
+
+    mocks.useVaultSearch.mockImplementation((_query, options?: { enabled?: boolean }) => ({
+      data: options?.enabled ? mocks.searchState.data : undefined,
+      isFetching: options?.enabled ? mocks.searchState.isFetching : false,
+      error: options?.enabled ? mocks.searchState.error : null,
+    }));
+  });
+
+  const renderForm = () =>
+    render(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />, {
+      initialStore: {
+        query,
+      },
+    });
+
+  test('renders with the current query and keeps submit disabled when name is empty', () => {
+    renderForm();
+
+    expect(screen.getByDisplayValue(query.q)).toHaveAttribute('readonly');
+    expect(screen.getByTestId('create-query-modal')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+    expect(mocks.useVaultSearch).toHaveBeenLastCalledWith(
+      query,
+      expect.objectContaining({ enabled: false, staleTime: 0 }),
+    );
+  });
+
+  test('enables submit once a notification name is typed', async () => {
+    const { user } = renderForm();
+
+    await user.type(screen.getByTestId('create-query-name'), 'Saved query alert');
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+  });
+
+  test('submit switches the search hook to enabled', async () => {
+    mocks.searchState.isFetching = true;
+
+    const { user } = renderForm();
+
+    await user.type(screen.getByTestId('create-query-name'), 'Saved query alert');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(mocks.useVaultSearch).toHaveBeenLastCalledWith(
+        query,
+        expect.objectContaining({ enabled: true, staleTime: 0 }),
+      );
+    });
+  });
+
+  test('adds a notification with the returned qid after a successful search', async () => {
+    mocks.searchState.isFetching = true;
+
+    const { rerender, user } = renderForm();
+
+    await user.type(screen.getByTestId('create-query-name'), 'Saved query alert');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(mocks.useVaultSearch).toHaveBeenLastCalledWith(
+        query,
+        expect.objectContaining({ enabled: true, staleTime: 0 }),
+      );
+    });
+
+    mocks.searchState.isFetching = false;
+    mocks.searchState.data = { qid: 'Q123' };
+
+    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mocks.addNotification).toHaveBeenCalledWith(
+        {
+          qid: 'Q123',
+          frequency: 'daily',
+          name: 'Saved query alert',
+          type: 'query',
+          active: true,
+          stateful: true,
+        },
+        expect.objectContaining({
+          onSettled: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  test('shows an error toast when the search fails', async () => {
+    mocks.searchState.isFetching = true;
+
+    const { rerender, user } = renderForm();
+
+    await user.type(screen.getByTestId('create-query-name'), 'Saved query alert');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(mocks.useVaultSearch).toHaveBeenLastCalledWith(
+        query,
+        expect.objectContaining({ enabled: true, staleTime: 0 }),
+      );
+    });
+
+    mocks.searchState.isFetching = false;
+    mocks.searchState.error = new Error('Search failed');
+
+    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith({
+        status: 'error',
+        title: 'Error',
+        description: 'Search failed',
+      });
+    });
+    expect(mocks.addNotification).not.toHaveBeenCalled();
+  });
+
+  test('submits the selected frequency value', async () => {
+    mocks.searchState.isFetching = true;
+
+    const { rerender, user } = renderForm();
+
+    await user.type(screen.getByTestId('create-query-name'), 'Weekly alert');
+    await user.selectOptions(screen.getByTestId('frequency-select'), 'weekly');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(mocks.useVaultSearch).toHaveBeenLastCalledWith(
+        query,
+        expect.objectContaining({ enabled: true, staleTime: 0 }),
+      );
+    });
+
+    mocks.searchState.isFetching = false;
+    mocks.searchState.data = { qid: 'Q999' };
+
+    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mocks.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          qid: 'Q999',
+          frequency: 'weekly',
+          name: 'Weekly alert',
+        }),
+        expect.objectContaining({
+          onSettled: expect.any(Function),
+        }),
+      );
+    });
+  });
+});

--- a/src/components/EmailNotifications/Forms/Utils.test.tsx
+++ b/src/components/EmailNotifications/Forms/Utils.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+
+import { isValidKeyword } from './Utils';
+
+describe('isValidKeyword', () => {
+  test.each([
+    ['', true],
+    ['plain keyword', true],
+    ['(', false],
+    [')', false],
+    ['[', false],
+    [']', false],
+    ['{', false],
+    ['}', false],
+  ])('returns %s for single or empty input: %s', (keyword, expected) => {
+    expect(isValidKeyword(keyword)).toBe(expected);
+  });
+
+  test.each([
+    ['alpha (beta)', true],
+    ['alpha [beta]', true],
+    ['alpha (beta [gamma])', true],
+    ['alpha [beta (gamma)]', true],
+    ['([[]])', true],
+    ['([])[]', true],
+  ])('accepts balanced parentheses and brackets: %s', (keyword, expected) => {
+    expect(isValidKeyword(keyword)).toBe(expected);
+  });
+
+  test.each([
+    ['alpha (beta', false],
+    ['alpha beta)', false],
+    ['alpha [beta', false],
+    ['alpha beta]', false],
+    ['([)]', false],
+    ['[(])', false],
+    ['(]', false],
+    ['[)', false],
+    ['([)', false],
+  ])('rejects unbalanced or mismatched parentheses and brackets: %s', (keyword, expected) => {
+    expect(isValidKeyword(keyword)).toBe(expected);
+  });
+
+  test.each([
+    ['{}', false],
+    ['alpha {beta}', false],
+    ['({})', false],
+    ['[{}]', false],
+    ['alpha } beta', false],
+  ])('matches the current curly brace behavior in the implementation: %s', (keyword, expected) => {
+    expect(isValidKeyword(keyword)).toBe(expected);
+  });
+});

--- a/src/components/Metatags/json-ld-abstract/__tests__/authors.transform.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/authors.transform.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { authorsTransform } from '../authors';
 import type { IDocsEntity } from '@/api/search/types';
 
@@ -12,7 +12,7 @@ describe('authorsTransform', () => {
     vi.clearAllMocks();
   });
 
-  it('maps authors to Person and attaches valid ORCIDs', () => {
+  test('maps authors to Person and attaches valid ORCIDs', () => {
     const doc: Partial<IDocsEntity> = {
       author: ['Jane Doe', 'John Smith', 'Sam Lee'],
       orcid_user: [
@@ -48,7 +48,7 @@ describe('authorsTransform', () => {
     ]);
   });
 
-  it('is resilient when orcid_user is missing or shorter than author list', () => {
+  test('is resilient when orcid_user is missing or shorter than author list', () => {
     const doc: Partial<IDocsEntity> = {
       author: ['A', 'B', 'C'],
       // no orcid_user
@@ -60,7 +60,7 @@ describe('authorsTransform', () => {
     ]);
   });
 
-  it('ignores empty, whitespace, and invalid ORCID values', () => {
+  test('ignores empty, whitespace, and invalid ORCID values', () => {
     const doc: Partial<IDocsEntity> = {
       author: ['A1', 'A2', 'A3', 'A4'],
       orcid_user: [' ', '', 'not-an-orcid', '-'],
@@ -73,7 +73,7 @@ describe('authorsTransform', () => {
     ]);
   });
 
-  it('does not throw if inputs are not arrays (coerces to arrays)', () => {
+  test('does not throw if inputs are not arrays (coerces to arrays)', () => {
     const doc = {
       author: 'Single Author',
       orcid_user: '0000-0002-1825-0097',
@@ -93,7 +93,7 @@ describe('authorsTransform', () => {
     ]);
   });
 
-  it('handles non-string author entries without throwing', () => {
+  test('handles non-string author entries without throwing', () => {
     const doc = {
       author: [' A ', 42, null, undefined],
       orcid_user: [],

--- a/src/components/Metatags/json-ld-abstract/__tests__/docToJsonld.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/docToJsonld.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 // --- Import after mocks so they take effect ---
 import { docToJsonld } from '../docToJsonld';
 import { IDocsEntity } from '@/api/search/types';
@@ -31,7 +31,7 @@ describe('docToJsonld', () => {
     mockCollect.mockClear();
   });
 
-  it('builds a ScholarlyArticle JSON-LD with canonical SciXplorer URL/ID and mapped fields', () => {
+  test('builds a ScholarlyArticle JSON-LD with canonical SciXplorer URL/ID and mapped fields', () => {
     const doc: Partial<IDocsEntity> = {
       bibcode: '2025arXiv250312263A',
       title: ['The Science of the Einstein Telescope'],
@@ -95,7 +95,7 @@ describe('docToJsonld', () => {
     ]);
   });
 
-  it('URL-encodes the bibcode in @id and url', () => {
+  test('URL-encodes the bibcode in @id and url', () => {
     // Simulate an unusual bibcode that needs encoding to ensure code path is correct
     const doc: Partial<IDocsEntity> = {
       bibcode: '2025arXiv2503/12263A', // slash will be encoded
@@ -113,7 +113,7 @@ describe('docToJsonld', () => {
     expect(jsonld.url).toBe('https://scixplorer.org/abs/2025arXiv2503%2F12263A/abstract');
   });
 
-  it('strips HTML tags from abstract for JSON-LD', () => {
+  test('strips HTML tags from abstract for JSON-LD', () => {
     const doc: Partial<IDocsEntity> = {
       bibcode: '2025arXiv250312263A',
       title: ['X'],
@@ -129,7 +129,7 @@ describe('docToJsonld', () => {
     expect(jsonld.abstract).toBe('Einstein Telescope is the European project...');
   });
 
-  it('strips HTML tags from title for JSON-LD', () => {
+  test('strips HTML tags from title for JSON-LD', () => {
     const doc: Partial<IDocsEntity> = {
       bibcode: '2025arXiv250312263A',
       title: ['<b>The</b> <i>Science</i> of <span>ET</span>'],

--- a/src/components/Metatags/json-ld-abstract/__tests__/docToJsonld.utils.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/docToJsonld.utils.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { normalizePubdate, prune } from '../docToJsonld';
 
 describe('normalizePubdate', () => {
-  it('returns undefined for falsy or invalid inputs', () => {
+  test('returns undefined for falsy or invalid inputs', () => {
     expect(normalizePubdate(undefined)).toBeUndefined();
     expect(normalizePubdate('')).toBeUndefined();
     expect(normalizePubdate('  ')).toBeUndefined();
@@ -12,7 +12,7 @@ describe('normalizePubdate', () => {
     expect(normalizePubdate('2025-00-32')).toBeUndefined();
   });
 
-  it('passes through valid values including placeholders', () => {
+  test('passes through valid values including placeholders', () => {
     expect(normalizePubdate('2025')).toBe('2025');
     expect(normalizePubdate('2025-03')).toBe('2025-03');
     expect(normalizePubdate('2025-03-00')).toBe('2025-03-00');
@@ -21,7 +21,7 @@ describe('normalizePubdate', () => {
 });
 
 describe('prune', () => {
-  it('drops undefined, null, empty strings, and empty arrays by default', () => {
+  test('drops undefined, null, empty strings, and empty arrays by default', () => {
     const input: Record<string, unknown> = {
       a: undefined,
       b: null,

--- a/src/components/Metatags/json-ld-abstract/__tests__/encoding.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/encoding.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { encodingTransform } from '@/components/Metatags/json-ld-abstract/encoding';
 
 // minimal types (no `any`)
@@ -25,7 +25,7 @@ describe('buildEncodingsFromSources', () => {
     mockSources = [];
   });
 
-  it('maps PDF/HTML to MediaObject with absolutized URLs and MIME in encodingFormat', () => {
+  test('maps PDF/HTML to MediaObject with absolutized URLs and MIME in encodingFormat', () => {
     mockSources = [
       { url: '/link_gateway/BIB/EPRINT_PDF', name: 'Preprint PDF', type: 'PDF', description: 'Preprint PDF' },
       { url: '/link_gateway/BIB/EPRINT_HTML', name: 'Preprint HTML', type: 'HTML', description: 'Preprint Article' },
@@ -51,7 +51,7 @@ describe('buildEncodingsFromSources', () => {
     ]);
   });
 
-  it('falls back to shortName when name is missing', () => {
+  test('falls back to shortName when name is missing', () => {
     mockSources = [{ url: '/link_gateway/BIB/EPRINT_PDF', shortName: 'Preprint', type: 'PDF' }];
 
     const enc = encodingTransform({}, 'https://scixplorer.org');
@@ -64,7 +64,7 @@ describe('buildEncodingsFromSources', () => {
     });
   });
 
-  it('absolutizes even odd-looking relative paths (no throw), and also handles a normal entry', () => {
+  test('absolutizes even odd-looking relative paths (no throw), and also handles a normal entry', () => {
     mockSources = [
       { url: '::not a url::', name: 'Bad', type: 'PDF' }, // becomes encoded path
       { url: '/ok', name: 'OK', type: 'HTML' },
@@ -90,7 +90,7 @@ describe('buildEncodingsFromSources', () => {
     ]);
   });
 
-  it('leaves encodingFormat undefined for unknown types', () => {
+  test('leaves encodingFormat undefined for unknown types', () => {
     mockSources = [{ url: '/foo', name: 'Foo', type: 'XML' }];
 
     const enc = encodingTransform({}, 'https://scixplorer.org');
@@ -103,7 +103,7 @@ describe('buildEncodingsFromSources', () => {
     expect((enc[0] as { encodingFormat?: string }).encodingFormat).toBeUndefined();
   });
 
-  it('returns empty array when there are no sources', () => {
+  test('returns empty array when there are no sources', () => {
     mockSources = [];
 
     const enc = encodingTransform({}, 'https://scixplorer.org');

--- a/src/components/Metatags/json-ld-abstract/__tests__/helpers.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/helpers.test.ts
@@ -1,18 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { asArray } from '../helpers';
 
 describe('asArray', () => {
-  it('returns [] for null/undefined', () => {
+  test('returns [] for null/undefined', () => {
     expect(asArray(undefined)).toEqual([]);
     expect(asArray(null)).toEqual([]);
   });
 
-  it('returns same array for arrays', () => {
+  test('returns same array for arrays', () => {
     const arr = [1, 2, 3];
     expect(asArray(arr)).toBe(arr);
   });
 
-  it('wraps scalars in array', () => {
+  test('wraps scalars in array', () => {
     expect(asArray('x')).toEqual(['x']);
     expect(asArray(5)).toEqual([5]);
     expect(asArray({ a: 1 })).toEqual([{ a: 1 }]);

--- a/src/components/Metatags/json-ld-abstract/__tests__/volumes.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/volumes.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { volumeTransform } from '../volumes';
 
 describe('volumeTransform', () => {
-  it('returns undefined when pub is empty', () => {
+  test('returns undefined when pub is empty', () => {
     expect(volumeTransform({})).toBeUndefined();
     expect(volumeTransform({ pub: '   ' } as unknown as Partial<{ pub: string }>)).toBeUndefined();
   });
 
-  it('returns Periodical when volume is not found', () => {
+  test('returns Periodical when volume is not found', () => {
     const v = volumeTransform({ pub: 'Journal of Tests', pub_raw: 'id.A1' } as unknown as Partial<{
       pub: string;
       pub_raw: string;
@@ -15,7 +15,7 @@ describe('volumeTransform', () => {
     expect(v).toEqual({ '@type': 'Periodical', name: 'Journal of Tests' });
   });
 
-  it('returns PublicationVolume with volumeNumber and pagination when present', () => {
+  test('returns PublicationVolume with volumeNumber and pagination when present', () => {
     const v = volumeTransform({ pub: 'Astro Letters', pub_raw: 'Volume 42 id.A6' } as unknown as Partial<{
       pub: string;
       pub_raw: string;
@@ -28,7 +28,7 @@ describe('volumeTransform', () => {
     });
   });
 
-  it('handles pub_raw that lacks id code', () => {
+  test('handles pub_raw that lacks id code', () => {
     const v = volumeTransform({ pub: 'Space Journal', pub_raw: 'Volume 7' } as unknown as Partial<{
       pub: string;
       pub_raw: string;

--- a/src/components/NavBar/__tests__/AppModeUrlNotice.test.tsx
+++ b/src/components/NavBar/__tests__/AppModeUrlNotice.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { NavBar } from '../NavBar';
 import { AppMode } from '@/types';
 import { render, waitFor } from '@/test-utils';
@@ -68,7 +68,7 @@ describe('AppModeUrlNotice', () => {
     mockRouter = createMockRouter();
   });
 
-  it('applies discipline from URL param on /search and shows notice with switch back', async () => {
+  test('applies discipline from URL param on /search and shows notice with switch back', async () => {
     // The notice logic only runs on /search, so we must set the pathname.
     mockRouter = createMockRouter({ query: { d: 'heliophysics' }, pathname: '/search' });
 
@@ -82,7 +82,7 @@ describe('AppModeUrlNotice', () => {
     expect(mockRouter.query.d).toBe('astrophysics');
   });
 
-  it('does nothing when URL param is missing', async () => {
+  test('does nothing when URL param is missing', async () => {
     mockRouter = createMockRouter({ pathname: '/search' }); // No 'd' param
 
     const { queryByTestId } = render(<NavBar />, { initialStore: { mode: AppMode.ASTROPHYSICS } });
@@ -92,7 +92,7 @@ describe('AppModeUrlNotice', () => {
     expect(queryByTestId('app-mode-url-notice')).toBeNull();
   });
 
-  it('normalizes uppercase discipline param to lowercase in the URL', async () => {
+  test('normalizes uppercase discipline param to lowercase in the URL', async () => {
     mockRouter = createMockRouter({ query: { d: 'HELIOPHYSICS' }, pathname: '/search' });
 
     render(<NavBar />, { initialStore: { mode: AppMode.GENERAL } });

--- a/src/components/NavBar/__tests__/FeedbackDropdown.test.tsx
+++ b/src/components/NavBar/__tests__/FeedbackDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { FeedbackDropdown, feedbackItems } from '../FeedbackDropdown';
 import { ListType } from '../types';
 import { render, screen } from '@/test-utils';
@@ -41,7 +41,7 @@ const items = Object.values(feedbackItems);
 
 describe('FeedbackDropdown', () => {
   describe('dropdown variant', () => {
-    it('renders menu items as <a> elements with href', async () => {
+    test('renders menu items as <a> elements with href', async () => {
       mockRouter = createMockRouter();
 
       const { user } = render(<FeedbackDropdown type={ListType.DROPDOWN} />);
@@ -58,7 +58,7 @@ describe('FeedbackDropdown', () => {
       }
     });
 
-    it('includes correct path and from query param in href', async () => {
+    test('includes correct path and from query param in href', async () => {
       mockRouter = createMockRouter({ asPath: '/search?q=star' });
 
       const { user } = render(<FeedbackDropdown type={ListType.DROPDOWN} />);
@@ -76,7 +76,7 @@ describe('FeedbackDropdown', () => {
       }
     });
 
-    it('strips existing from param before encoding', async () => {
+    test('strips existing from param before encoding', async () => {
       mockRouter = createMockRouter({
         asPath: '/search?q=star&from=/abs/1234',
       });
@@ -97,7 +97,7 @@ describe('FeedbackDropdown', () => {
   });
 
   describe('accordion variant', () => {
-    it('renders list items with <a> elements containing href', () => {
+    test('renders list items with <a> elements containing href', () => {
       mockRouter = createMockRouter();
 
       render(<FeedbackDropdown type={ListType.ACCORDION} />);
@@ -112,7 +112,7 @@ describe('FeedbackDropdown', () => {
       }
     });
 
-    it('calls onFinished when a link is clicked', async () => {
+    test('calls onFinished when a link is clicked', async () => {
       mockRouter = createMockRouter();
       const onFinished = vi.fn();
 

--- a/src/components/SafeAbstract/SafeAbstract.integration.test.tsx
+++ b/src/components/SafeAbstract/SafeAbstract.integration.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { type ReactNode } from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { SafeAbstract } from './SafeAbstract';
 
 // Mock MathJax - passes through HTML content for testing
@@ -16,14 +16,14 @@ describe('SafeAbstract integration', () => {
   // Real-world abstract that caused the truncation bug
   const problematicAbstract = `We report a galaxy overdensity candidate at $z\\approx 10.5$ in the JWST Advanced Deep Extragalactic Survey (JADES). This overdensity contains 18 galaxies with consistent photometric redshifts and robust F115W dropouts within 8 comoving Mpc in projection. The galaxy number density is four times higher than the field expectation, accounting for one-third of comparably bright galaxies and nearly 50% of the total star formation rate at $10<z_\\mathrm{phot}<12$ in the GOODS-S field.`;
 
-  it('renders the full problematic abstract without truncation', () => {
+  test('renders the full problematic abstract without truncation', () => {
     render(<SafeAbstract html={problematicAbstract} />);
 
     // Key assertion: the text AFTER the problematic math should be present
     expect(screen.getByText(/GOODS-S field/)).toBeInTheDocument();
   });
 
-  it('preserves all text content even with complex math', () => {
+  test('preserves all text content even with complex math', () => {
     const { container } = render(<SafeAbstract html={problematicAbstract} />);
 
     // Full text should be present (excluding HTML tags)

--- a/src/components/SafeAbstract/SafeAbstract.test.tsx
+++ b/src/components/SafeAbstract/SafeAbstract.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { type ReactNode } from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SafeAbstract } from './SafeAbstract';
 
 // Configurable mock - can be set to throw for error testing
@@ -24,22 +24,22 @@ describe('SafeAbstract', () => {
     shouldMathJaxThrow = false;
   });
 
-  it('renders abstract text', () => {
+  test('renders abstract text', () => {
     render(<SafeAbstract html="Simple abstract text" />);
     expect(screen.getByText('Simple abstract text')).toBeInTheDocument();
   });
 
-  it('renders with MathJax wrapper', () => {
+  test('renders with MathJax wrapper', () => {
     render(<SafeAbstract html="Text with $math$" />);
     expect(screen.getByTestId('mathjax')).toBeInTheDocument();
   });
 
-  it('handles empty/undefined abstract', () => {
+  test('handles empty/undefined abstract', () => {
     const { container } = render(<SafeAbstract html="" />);
     expect(container.textContent).toBe('');
   });
 
-  it('escapes HTML inside math before rendering', () => {
+  test('escapes HTML inside math before rendering', () => {
     const { container } = render(<SafeAbstract html="$10<z<12$" />);
     // The < should be escaped so the full content renders
     expect(container.innerHTML).toContain('&lt;');
@@ -60,7 +60,7 @@ describe('SafeAbstract error handling', () => {
     shouldMathJaxThrow = false;
   });
 
-  it('shows fallback when MathJax throws', () => {
+  test('shows fallback when MathJax throws', () => {
     render(<SafeAbstract html="Some <em>math</em> here" />);
 
     // Should show plain text fallback (HTML tags stripped)

--- a/src/components/SearchFacet/__tests__/helpers.test.ts
+++ b/src/components/SearchFacet/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { formatFacetCSV } from '../helpers';
 import { FacetItem } from '../types';
 
@@ -11,51 +11,51 @@ const item = (val: string, count: number): FacetItem => ({
 });
 
 describe('formatFacetCSV', () => {
-  it('returns only the header for an empty list', () => {
+  test('returns only the header for an empty list', () => {
     expect(formatFacetCSV([])).toBe('Label,Count');
   });
 
-  it('strips the hierarchical prefix from the label', () => {
+  test('strips the hierarchical prefix from the label', () => {
     const result = formatFacetCSV([item('0/Smith, J', 42)]);
     expect(result).toBe('Label,Count\n"Smith, J",42');
   });
 
-  it('includes the count column', () => {
+  test('includes the count column', () => {
     const result = formatFacetCSV([item('0/Jones, B', 7)]);
     expect(result).toContain(',7');
   });
 
-  it('handles deeper hierarchy levels', () => {
+  test('handles deeper hierarchy levels', () => {
     const result = formatFacetCSV([item('1/Smith, J/Smith, John', 5)]);
     expect(result).toBe('Label,Count\n"Smith, John",5');
   });
 
-  it('escapes double-quotes in labels per RFC 4180', () => {
+  test('escapes double-quotes in labels per RFC 4180', () => {
     const result = formatFacetCSV([item('0/He said "hi"', 1)]);
     expect(result).toBe('Label,Count\n"He said ""hi""",1');
   });
 
-  it('wraps labels containing commas in quotes', () => {
+  test('wraps labels containing commas in quotes', () => {
     const result = formatFacetCSV([item('0/Doe, Jane', 10)]);
     expect(result).toBe('Label,Count\n"Doe, Jane",10');
   });
 
-  it('handles non-hierarchical keys (no slash)', () => {
+  test('handles non-hierarchical keys (no slash)', () => {
     const result = formatFacetCSV([item('astronomy', 100)]);
     expect(result).toBe('Label,Count\n"astronomy",100');
   });
 
-  it('handles a key with an empty last segment (e.g. "0/")', () => {
+  test('handles a key with an empty last segment (e.g. "0/")', () => {
     const result = formatFacetCSV([item('0/', 5)]);
     expect(result).toBe('Label,Count\n"",5');
   });
 
-  it('handles an empty string key', () => {
+  test('handles an empty string key', () => {
     const result = formatFacetCSV([item('', 0)]);
     expect(result).toBe('Label,Count\n"",0');
   });
 
-  it('produces one row per item', () => {
+  test('produces one row per item', () => {
     const items = [item('0/Alpha', 3), item('0/Beta', 7), item('0/Gamma', 1)];
     const lines = formatFacetCSV(items).split('\n');
     expect(lines).toHaveLength(4); // header + 3 rows

--- a/src/components/SearchFacet/store/__tests__/helpers.test.ts
+++ b/src/components/SearchFacet/store/__tests__/helpers.test.ts
@@ -1,6 +1,6 @@
 import { IFacetStoreState } from '@/components/SearchFacet/store/FacetStore';
 import { computeNextSelectionState } from '@/components/SearchFacet/store/helpers';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 
 describe('computeNextSelectionState', () => {
   const ids = {
@@ -36,7 +36,7 @@ describe('computeNextSelectionState', () => {
     };
   });
 
-  it('selects a non-hierarchial root item', () => {
+  test('selects a non-hierarchial root item', () => {
     const nextState = computeNextSelectionState(ids.rootAlt, nonHierarchialState);
     expect(nextState).toStrictEqual<typeof nonHierarchialState>({
       ...nonHierarchialState,
@@ -44,7 +44,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should select a root item if unselected', () => {
+  test('should select a root item if unselected', () => {
     const nextState = computeNextSelectionState(ids.root, state);
     expect(nextState).toEqual<typeof state>({
       ...state,
@@ -52,7 +52,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should part-select the parent if we select a child', () => {
+  test('should part-select the parent if we select a child', () => {
     const nextState = computeNextSelectionState(ids.grandChild, state);
     expect(nextState).toStrictEqual<typeof state>({
       ...state,
@@ -62,7 +62,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should unselect all children if parent is selected', () => {
+  test('should unselect all children if parent is selected', () => {
     const nextState = computeNextSelectionState(ids.root, {
       ...state,
       [ids.root]: { selected: false, partSelected: true },
@@ -75,7 +75,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should keep parent part-selected if unselecting a sibling', () => {
+  test('should keep parent part-selected if unselecting a sibling', () => {
     const nextState = computeNextSelectionState(ids.child2, {
       ...state,
       [ids.root]: { selected: false, partSelected: true },
@@ -89,7 +89,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should keep parent part-selected if unselecting a grandchild with a selected sibling', () => {
+  test('should keep parent part-selected if unselecting a grandchild with a selected sibling', () => {
     const nextState = computeNextSelectionState(ids.grandChild, {
       ...state,
       [ids.root]: { selected: false, partSelected: true },
@@ -105,7 +105,7 @@ describe('computeNextSelectionState', () => {
     });
   });
 
-  it('should unselect all children if parent is part-selected', () => {
+  test('should unselect all children if parent is part-selected', () => {
     const nextState = computeNextSelectionState(ids.root, {
       ...state,
       [ids.root]: { selected: false, partSelected: true },

--- a/src/components/Settings/ResetSettingsButton/ResetSettingsButton.test.tsx
+++ b/src/components/Settings/ResetSettingsButton/ResetSettingsButton.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { ResetSettingsButton } from './ResetSettingsButton';
 import { UserDataKeys } from '@/api/user/types';
 import { DEFAULT_USER_DATA } from '@/api/user/models';
@@ -20,12 +20,12 @@ describe('ResetSettingsButton', () => {
     mockUpdateSettings.mockClear();
   });
 
-  it('renders reset button', () => {
+  test('renders reset button', () => {
     render(<ResetSettingsButton settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT]} label="Reset Search Settings" />);
     expect(screen.getByRole('button', { name: /reset search settings/i })).toBeInTheDocument();
   });
 
-  it('opens confirmation dialog on click', async () => {
+  test('opens confirmation dialog on click', async () => {
     render(<ResetSettingsButton settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT]} label="Reset Search Settings" />);
     fireEvent.click(screen.getByRole('button', { name: /reset search settings/i }));
     await waitFor(() => {
@@ -34,7 +34,7 @@ describe('ResetSettingsButton', () => {
     expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
   });
 
-  it('calls updateSettings with default values when confirmed', async () => {
+  test('calls updateSettings with default values when confirmed', async () => {
     render(
       <ResetSettingsButton
         settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT, UserDataKeys.MIN_AUTHOR_RESULT]}
@@ -54,7 +54,7 @@ describe('ResetSettingsButton', () => {
     });
   });
 
-  it('closes dialog without action when cancelled', async () => {
+  test('closes dialog without action when cancelled', async () => {
     render(<ResetSettingsButton settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT]} label="Reset Search Settings" />);
     fireEvent.click(screen.getByRole('button', { name: /reset search settings/i }));
     await waitFor(() => {
@@ -67,7 +67,7 @@ describe('ResetSettingsButton', () => {
     expect(mockUpdateSettings).not.toHaveBeenCalled();
   });
 
-  it('displays tab-specific text when tabName is provided', async () => {
+  test('displays tab-specific text when tabName is provided', async () => {
     render(
       <ResetSettingsButton
         settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT]}
@@ -82,7 +82,7 @@ describe('ResetSettingsButton', () => {
     expect(screen.getByText(/search settings/i)).toBeInTheDocument();
   });
 
-  it('displays generic text when tabName is not provided', async () => {
+  test('displays generic text when tabName is not provided', async () => {
     render(<ResetSettingsButton settingsKeys={[UserDataKeys.PREFERRED_SEARCH_SORT]} label="Reset to defaults" />);
     fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }));
     await waitFor(() => {

--- a/src/components/Visualizations/Graphs/useBubblePlot.test.tsx
+++ b/src/components/Visualizations/Graphs/useBubblePlot.test.tsx
@@ -1,0 +1,234 @@
+import { renderHook } from '@testing-library/react';
+import { useColorMode } from '@chakra-ui/react';
+import type { IBubblePlot, IBubblePlotNodeData } from '../types';
+import { useBubblePlot } from './useBubblePlot';
+import { describe, expect, test } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+
+  return {
+    ...actual,
+    useColorMode: vi.fn(),
+  };
+});
+
+const mockedUseColorMode = vi.mocked(useColorMode);
+
+const createNode = (overrides: Partial<IBubblePlotNodeData> = {}): IBubblePlotNodeData => ({
+  bibcode: 'bibcode-1',
+  pubdate: '2000-01-01',
+  title: 'Paper',
+  read_count: 10,
+  citation_count: 5,
+  date: new Date('2000-01-01T00:00:00.000Z'),
+  year: 2000,
+  pub: 'AAS',
+  ...overrides,
+});
+
+const createGraph = (data: IBubblePlotNodeData[], groups?: string[]): IBubblePlot => ({
+  data,
+  groups,
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+});
+
+describe('useBubblePlot', () => {
+  test('builds linear x and y scales, year radius scale, and group colors from graph data', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+
+    const graph = createGraph(
+      [
+        createNode({
+          bibcode: 'paper-1',
+          citation_count: 5,
+          read_count: 10,
+          year: 2000,
+          pub: 'AAS',
+        }),
+        createNode({
+          bibcode: 'paper-2',
+          citation_count: 15,
+          read_count: 30,
+          year: 2010,
+          pub: 'PhRvL',
+        }),
+      ],
+      ['AAS', 'PhRvL'],
+    );
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph,
+        xKey: 'citation_count',
+        yKey: 'read_count',
+        rKey: 'year',
+        xScaleType: 'linear',
+        yScaleType: 'linear',
+        width: 400,
+        height: 200,
+      }),
+    );
+
+    expect(result.current).toMatchObject({
+      textColor: '#000000',
+    });
+    expect(result.current.groupColor.domain()).toEqual(['AAS', 'PhRvL']);
+    expect(result.current.groupColor('AAS')).toBe('hsla(282, 80%, 52%, 0.9)');
+    expect(result.current.groupColor('PhRvL')).toBe('hsla(1, 80%, 51%, 0.9)');
+    expect(result.current.xScaleFn.domain()).toEqual([5, 15]);
+    expect(result.current.xScaleFn.range()).toEqual([0, 400]);
+    expect(result.current.yScaleFn.domain()).toEqual([10, 30]);
+    expect(result.current.yScaleFn.range()).toEqual([200, 0]);
+    expect(result.current.rScaleFn.domain()).toEqual([2000, 2010]);
+    expect(result.current.rScaleFn.range()).toEqual([2, 14]);
+  });
+
+  test('uses a time scale for date x values and dark mode text color', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'dark' } as ReturnType<typeof useColorMode>);
+
+    const firstDate = new Date('2001-01-01T00:00:00.000Z');
+    const secondDate = new Date('2003-06-01T00:00:00.000Z');
+    const graph = createGraph([
+      createNode({ bibcode: 'paper-1', date: firstDate }),
+      createNode({ bibcode: 'paper-2', date: secondDate }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph,
+        xKey: 'date',
+        yKey: 'citation_count',
+        rKey: 'citation_count',
+        xScaleType: 'linear',
+        yScaleType: 'linear',
+        width: 600,
+        height: 300,
+      }),
+    );
+
+    expect(result.current.textColor).toBe('#ffffff');
+    expect(result.current.xScaleFn.domain()).toEqual([firstDate, secondDate]);
+    expect(result.current.xScaleFn.range()).toEqual([0, 600]);
+    expect(result.current.rScaleFn.range()).toEqual([4, 26]);
+  });
+
+  test('normalizes zero minimum values to one for log scales', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+
+    const graph = createGraph([
+      createNode({
+        bibcode: 'paper-1',
+        citation_count: 0,
+        read_count: 0,
+      }),
+      createNode({
+        bibcode: 'paper-2',
+        citation_count: 100,
+        read_count: 1000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph,
+        xKey: 'citation_count',
+        yKey: 'read_count',
+        rKey: 'citation_count',
+        xScaleType: 'log',
+        yScaleType: 'log',
+        width: 500,
+        height: 250,
+      }),
+    );
+
+    expect(result.current.xScaleFn.domain()).toEqual([1, 100]);
+    expect(result.current.yScaleFn.domain()).toEqual([1, 1000]);
+    expect(result.current.xScaleFn.range()).toEqual([0, 500]);
+    expect(result.current.yScaleFn.range()).toEqual([250, 0]);
+  });
+
+  test('returns usable scale objects for empty datasets', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph: createGraph([], []),
+        xKey: 'citation_count',
+        yKey: 'read_count',
+        rKey: 'citation_count',
+        xScaleType: 'linear',
+        yScaleType: 'linear',
+        width: 320,
+        height: 180,
+      }),
+    );
+
+    expect(result.current.groupColor.domain()).toEqual([]);
+    expect(result.current.xScaleFn.range()).toEqual([0, 320]);
+    expect(result.current.yScaleFn.range()).toEqual([180, 0]);
+    expect(result.current.rScaleFn.range()).toEqual([4, 26]);
+    expect(result.current.xScaleFn.domain().every((value) => Number.isNaN(value))).toBe(true);
+    expect(result.current.yScaleFn.domain().every((value) => Number.isNaN(value))).toBe(true);
+    expect(result.current.rScaleFn.domain().every((value) => Number.isNaN(value))).toBe(true);
+  });
+
+  test('ignores missing keyed values when computing extents', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+
+    const graph = createGraph([
+      createNode({
+        bibcode: 'paper-1',
+        citation_count: undefined as unknown as number,
+      }),
+      createNode({
+        bibcode: 'paper-2',
+        citation_count: 42,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph,
+        xKey: 'citation_count',
+        yKey: 'read_count',
+        rKey: 'citation_count',
+        xScaleType: 'linear',
+        yScaleType: 'linear',
+        width: 400,
+        height: 200,
+      }),
+    );
+
+    expect(result.current.xScaleFn.domain()).toEqual([42, 42]);
+    expect(result.current.rScaleFn.domain()).toEqual([42, 42]);
+  });
+
+  test('preserves single-item domains', () => {
+    mockedUseColorMode.mockReturnValue({ colorMode: 'light' } as ReturnType<typeof useColorMode>);
+
+    const graph = createGraph([createNode({ citation_count: 12, read_count: 7, year: 1999 })]);
+
+    const { result } = renderHook(() =>
+      useBubblePlot({
+        graph,
+        xKey: 'citation_count',
+        yKey: 'read_count',
+        rKey: 'year',
+        xScaleType: 'linear',
+        yScaleType: 'linear',
+        width: 100,
+        height: 50,
+      }),
+    );
+
+    expect(result.current.xScaleFn.domain()).toEqual([12, 12]);
+    expect(result.current.yScaleFn.domain()).toEqual([7, 7]);
+    expect(result.current.rScaleFn.domain()).toEqual([1999, 1999]);
+  });
+});

--- a/src/components/Visualizations/utils/graphUtils.test.ts
+++ b/src/components/Visualizations/utils/graphUtils.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  BasicStatsKey,
+  CitationsHistogramKey,
+  CitationsStatsKey,
+  PapersHistogramKey,
+  ReadsHistogramKey,
+  TimeSeriesKey,
+  type CitationsHistogramType,
+  type PapersHistogramType,
+  type ReadsHistogramType,
+  type TimeSeriesType,
+} from '@/api/metrics/types';
+import type { IFacetCountsFields, IDocsEntity, IBucket } from '@/api/search/types';
+import {
+  getCitationTableData,
+  getHIndexGraphData,
+  getIndicesTableData,
+  getPapersTableData,
+  getReadsTableData,
+  getResultsGraph,
+  getYearsGraph,
+  plotCitationsHist,
+  plotPapersHist,
+  plotReadsHist,
+  plotTimeSeriesGraph,
+} from './graphUtils';
+
+const createCitationsHistogram = (overrides: Partial<CitationsHistogramType> = {}): CitationsHistogramType => ({
+  [CitationsHistogramKey.RR]: { '2000': 3, '2001': 1 },
+  [CitationsHistogramKey.RN]: { '2000': 4, '2001': 0 },
+  [CitationsHistogramKey.NR]: { '2000': 0, '2001': 0 },
+  [CitationsHistogramKey.NN]: { '2000': 2, '2001': 2 },
+  [CitationsHistogramKey.RRN]: { '2000': 1.5, '2001': 0.5 },
+  [CitationsHistogramKey.RNN]: { '2000': 0, '2001': 0 },
+  [CitationsHistogramKey.NRN]: { '2000': 2.5, '2001': 0 },
+  [CitationsHistogramKey.NNN]: { '2000': 0, '2001': 0 },
+  ...overrides,
+});
+
+const createReadsHistogram = (overrides: Partial<ReadsHistogramType> = {}): ReadsHistogramType => ({
+  [ReadsHistogramKey.RR]: { '2000': 3, '2001': 0 },
+  [ReadsHistogramKey.AR]: { '2000': 5, '2001': 7 },
+  [ReadsHistogramKey.RRN]: { '2000': 1.5, '2001': 0 },
+  [ReadsHistogramKey.ARN]: { '2000': 2.5, '2001': 3 },
+  ...overrides,
+});
+
+const createPapersHistogram = (overrides: Partial<PapersHistogramType> = {}): PapersHistogramType => ({
+  [PapersHistogramKey.RP]: { '2000': 2, '2001': 1 },
+  [PapersHistogramKey.AP]: { '2000': 4, '2001': 3 },
+  [PapersHistogramKey.RPN]: { '2000': 0.5, '2001': 0.25 },
+  [PapersHistogramKey.APN]: { '2000': 1.5, '2001': 0.25 },
+  ...overrides,
+});
+
+describe('plotCitationsHist', () => {
+  test('builds non-normalized chart data and skips zero-only series', () => {
+    const histogram = createCitationsHistogram();
+
+    expect(plotCitationsHist(false, histogram, false)).toEqual({
+      data: [
+        {
+          year: '2000',
+          'Ref. citations to ref. papers': 3,
+          'Ref. citations to non ref. papers': 4,
+          'Non ref. citations to non ref. papers': 2,
+        },
+        {
+          year: '2001',
+          'Ref. citations to ref. papers': 1,
+          'Ref. citations to non ref. papers': 0,
+          'Non ref. citations to non ref. papers': 2,
+        },
+      ],
+      keys: [
+        'Ref. citations to ref. papers',
+        'Ref. citations to non ref. papers',
+        'Non ref. citations to non ref. papers',
+      ],
+      indexBy: 'year',
+    });
+  });
+
+  test('uses single-paper labels for normalized data', () => {
+    const histogram = createCitationsHistogram();
+
+    expect(plotCitationsHist(true, histogram, true)).toEqual({
+      data: [
+        {
+          year: '2000',
+          'Citations from ref. papers': 1.5,
+          'Citations from non ref. papers': 2.5,
+        },
+        {
+          year: '2001',
+          'Citations from ref. papers': 0.5,
+          'Citations from non ref. papers': 0,
+        },
+      ],
+      keys: ['Citations from ref. papers', 'Citations from non ref. papers'],
+      indexBy: 'year',
+    });
+  });
+
+  test('preserves years from the first series and leaves missing values undefined', () => {
+    const histogram = createCitationsHistogram({
+      [CitationsHistogramKey.RN]: { '2000': 4 },
+    });
+
+    expect(plotCitationsHist(false, histogram, false)).toEqual({
+      data: [
+        {
+          year: '2000',
+          'Ref. citations to ref. papers': 3,
+          'Ref. citations to non ref. papers': 4,
+          'Non ref. citations to non ref. papers': 2,
+        },
+        {
+          year: '2001',
+          'Ref. citations to ref. papers': 1,
+          'Ref. citations to non ref. papers': undefined,
+          'Non ref. citations to non ref. papers': 2,
+        },
+      ],
+      keys: [
+        'Ref. citations to ref. papers',
+        'Ref. citations to non ref. papers',
+        'Non ref. citations to non ref. papers',
+      ],
+      indexBy: 'year',
+    });
+  });
+});
+
+describe('plotReadsHist and plotPapersHist', () => {
+  test.each([
+    {
+      name: 'plotReadsHist non-normalized',
+      run: () => plotReadsHist(false, createReadsHistogram()),
+      expected: {
+        data: [
+          { year: '2000', Refereed: 3, 'Non-refereed': 2 },
+          { year: '2001', Refereed: 0, 'Non-refereed': 7 },
+        ],
+        keys: ['Refereed', 'Non-refereed'],
+        indexBy: 'year',
+      },
+    },
+    {
+      name: 'plotPapersHist normalized',
+      run: () => plotPapersHist(true, createPapersHistogram()),
+      expected: {
+        data: [
+          { year: '2000', Refereed: 0.5, 'Non-refereed': 1 },
+          { year: '2001', Refereed: 0.25, 'Non-refereed': 0 },
+        ],
+        keys: ['Refereed', 'Non-refereed'],
+        indexBy: 'year',
+      },
+    },
+  ])('$name', ({ run, expected }) => {
+    expect(run()).toEqual(expected);
+  });
+
+  test.each([
+    {
+      name: 'plotReadsHist omits the non-refereed key when all derived values are zero',
+      run: () =>
+        plotReadsHist(
+          false,
+          createReadsHistogram({
+            [ReadsHistogramKey.RR]: { '2000': 2, '2001': 1 },
+            [ReadsHistogramKey.AR]: { '2000': 2, '2001': 1 },
+          }),
+        ),
+      expected: {
+        data: [
+          { year: '2000', Refereed: 2 },
+          { year: '2001', Refereed: 1 },
+        ],
+        keys: ['Refereed'],
+        indexBy: 'year',
+      },
+    },
+    {
+      name: 'plotPapersHist keeps values from all publications when the refereed year is missing',
+      run: () =>
+        plotPapersHist(
+          false,
+          createPapersHistogram({
+            [PapersHistogramKey.RP]: { '2000': 2 },
+            [PapersHistogramKey.AP]: { '2000': 4, '2001': 3 },
+          }),
+        ),
+      expected: {
+        data: [{ year: '2000', Refereed: 2, 'Non-refereed': 2 }],
+        keys: ['Refereed', 'Non-refereed'],
+        indexBy: 'year',
+      },
+    },
+  ])('$name', ({ run, expected }) => {
+    expect(run()).toEqual(expected);
+  });
+});
+
+describe('plotTimeSeriesGraph', () => {
+  test('builds series in implementation order and divides read10 values by 10', () => {
+    const series: TimeSeriesType = {
+      [TimeSeriesKey.H]: { '2000': 3, '2001': 4 },
+      [TimeSeriesKey.G]: { '2000': 5 },
+      [TimeSeriesKey.READ10]: { '2000': 40, '2001': 15 },
+    };
+
+    expect(plotTimeSeriesGraph(series)).toEqual({
+      data: [
+        {
+          id: 'h-index',
+          data: [
+            { x: '2000', y: 3 },
+            { x: '2001', y: 4 },
+          ],
+        },
+        {
+          id: 'g-index',
+          data: [{ x: '2000', y: 5 }],
+        },
+        {
+          id: 'read10-index',
+          data: [
+            { x: '2000', y: 4 },
+            { x: '2001', y: 1.5 },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('returns an empty data array when no series are defined', () => {
+    expect(plotTimeSeriesGraph({})).toEqual({ data: [] });
+  });
+});
+
+describe('table transformers', () => {
+  test('getCitationTableData rounds decimal values to one place and preserves zeroes', () => {
+    const input = {
+      total: {
+        [CitationsStatsKey.NCP]: 12.34,
+        [CitationsStatsKey.TNC]: 20.04,
+        [CitationsStatsKey.NSC]: 0,
+        [CitationsStatsKey.ANC]: 1.04,
+        [CitationsStatsKey.MNC]: 2,
+        [CitationsStatsKey.NNC]: 3.99,
+        [CitationsStatsKey.TNRC]: 4.44,
+        [CitationsStatsKey.ANRC]: 5.05,
+        [CitationsStatsKey.MNRC]: 6.66,
+        [CitationsStatsKey.NNRC]: 7.01,
+        'self-citations': [],
+      },
+      refereed: {
+        [CitationsStatsKey.NCP]: 10.55,
+        [CitationsStatsKey.TNC]: 11.01,
+        [CitationsStatsKey.NSC]: 0,
+        [CitationsStatsKey.ANC]: 1,
+        [CitationsStatsKey.MNC]: 2.01,
+        [CitationsStatsKey.NNC]: 3.44,
+        [CitationsStatsKey.TNRC]: 4,
+        [CitationsStatsKey.ANRC]: 5.94,
+        [CitationsStatsKey.MNRC]: 6,
+        [CitationsStatsKey.NNRC]: 7.49,
+      },
+    };
+
+    expect(getCitationTableData(input)).toEqual({
+      numberOfCitingPapers: [12.3, 10.6],
+      totalCitations: [20, 11],
+      numberOfSelfCitations: [0, 0],
+      averageCitations: [1, 1],
+      medianCitations: [2, 2],
+      normalizedCitations: [4, 3.4],
+      refereedCitations: [4.4, 4],
+      averageRefereedCitations: [5, 5.9],
+      medianRefereedCitations: [6.7, 6],
+      normalizedRefereedCitations: [7, 7.5],
+    });
+  });
+
+  test('getReadsTableData rounds values and uses the total median downloads value for both entries', () => {
+    const input = {
+      total: {
+        [BasicStatsKey.TNR]: 100.04,
+        [BasicStatsKey.ANR]: 3.49,
+        [BasicStatsKey.MNR]: 2.01,
+        [BasicStatsKey.TND]: 80.66,
+        [BasicStatsKey.AND]: 4.44,
+        [BasicStatsKey.MND]: 7.77,
+        [BasicStatsKey.NP]: 0,
+        [BasicStatsKey.NPC]: 0,
+        [BasicStatsKey.RND]: 0,
+        [BasicStatsKey.RNR]: 0,
+      },
+      refereed: {
+        [BasicStatsKey.TNR]: 50.55,
+        [BasicStatsKey.ANR]: 2.04,
+        [BasicStatsKey.MNR]: 1.94,
+        [BasicStatsKey.TND]: 40.01,
+        [BasicStatsKey.AND]: 2.05,
+        [BasicStatsKey.MND]: 9.99,
+        [BasicStatsKey.NP]: 0,
+        [BasicStatsKey.NPC]: 0,
+        [BasicStatsKey.RND]: 0,
+        [BasicStatsKey.RNR]: 0,
+      },
+    };
+
+    expect(getReadsTableData(input)).toEqual({
+      totalNumberOfReads: [100, 50.5],
+      averageNumberOfReads: [3.5, 2],
+      medianNumberOfReads: [2, 1.9],
+      totalNumberOfDownloads: [80.7, 40],
+      averageNumberOfDownloads: [4.4, 2],
+      medianNumberOfDownloads: [7.8, 7.8],
+    });
+  });
+
+  test('getPapersTableData and getIndicesTableData return rounded output shapes', () => {
+    const papersInput = {
+      total: {
+        [BasicStatsKey.NP]: 10.09,
+        [BasicStatsKey.NPC]: 4.44,
+        [BasicStatsKey.AND]: 0,
+        [BasicStatsKey.ANR]: 0,
+        [BasicStatsKey.MND]: 0,
+        [BasicStatsKey.MNR]: 0,
+        [BasicStatsKey.RND]: 0,
+        [BasicStatsKey.RNR]: 0,
+        [BasicStatsKey.TND]: 0,
+        [BasicStatsKey.TNR]: 0,
+      },
+      refereed: {
+        [BasicStatsKey.NP]: 8.94,
+        [BasicStatsKey.NPC]: 3,
+        [BasicStatsKey.AND]: 0,
+        [BasicStatsKey.ANR]: 0,
+        [BasicStatsKey.MND]: 0,
+        [BasicStatsKey.MNR]: 0,
+        [BasicStatsKey.RND]: 0,
+        [BasicStatsKey.RNR]: 0,
+        [BasicStatsKey.TND]: 0,
+        [BasicStatsKey.TNR]: 0,
+      },
+    };
+    const indicesInput = {
+      total: {
+        [TimeSeriesKey.H]: 1.04,
+        [TimeSeriesKey.M]: 2,
+        [TimeSeriesKey.G]: 3.95,
+        [TimeSeriesKey.I10]: undefined,
+        [TimeSeriesKey.I100]: 0,
+        [TimeSeriesKey.TORI]: 5.55,
+        [TimeSeriesKey.RIQ]: 6.01,
+        [TimeSeriesKey.READ10]: 7.77,
+      },
+      refereed: {
+        [TimeSeriesKey.H]: 1.95,
+        [TimeSeriesKey.M]: 2.04,
+        [TimeSeriesKey.G]: 3,
+        [TimeSeriesKey.I10]: 4.44,
+        [TimeSeriesKey.I100]: undefined,
+        [TimeSeriesKey.TORI]: 5,
+        [TimeSeriesKey.RIQ]: 6.66,
+        [TimeSeriesKey.READ10]: 0,
+      },
+    };
+
+    expect(getPapersTableData(papersInput)).toEqual({
+      totalNumberOfPapers: [10.1, 8.9],
+      totalNormalizedPaperCount: [4.4, 3],
+    });
+    expect(getIndicesTableData(indicesInput)).toEqual({
+      hIndex: [1, 1.9],
+      mIndex: [2, 2],
+      gIndex: [4, 3],
+      i10Index: [undefined, 4.4],
+      i100Index: [0, undefined],
+      toriIndex: [5.5, 5],
+      riqIndex: [6, 6.7],
+      read10Index: [7.8, 0],
+    });
+  });
+});
+
+describe('getYearsGraph', () => {
+  test('builds year buckets, fills gaps, and ignores unrelated property groups', () => {
+    const input = {
+      facet_queries: {},
+      facet_fields: {} as IFacetCountsFields['facet_fields'],
+      facet_ranges: {},
+      facet_intervals: {},
+      facet_heatmaps: {},
+      facet_pivot: {
+        'property,year': [
+          {
+            count: 2,
+            field: 'property',
+            value: 'refereed',
+            pivot: [
+              { field: 'year', value: '2000', count: 2 },
+              { field: 'year', value: '2002', count: 3 },
+            ],
+          },
+          {
+            count: 1,
+            field: 'property',
+            value: 'notrefereed',
+            pivot: [{ field: 'year', value: '2001', count: 4 }],
+          },
+          {
+            count: 1,
+            field: 'property',
+            value: 'other',
+            pivot: [{ field: 'year', value: '1999', count: 99 }],
+          },
+        ],
+      },
+    } as IFacetCountsFields;
+
+    expect(getYearsGraph(input)).toEqual({
+      data: [
+        { year: 2000, refereed: 2, notrefereed: 0 },
+        { year: 2001, refereed: 0, notrefereed: 4 },
+        { year: 2002, refereed: 3, notrefereed: 0 },
+      ],
+      keys: ['refereed', 'notrefereed'],
+      indexBy: 'year',
+    });
+  });
+});
+
+describe('getHIndexGraphData', () => {
+  test('expands bucket counts into one point per paper and caps the result length', () => {
+    const counts: IBucket[] = [
+      { val: 9, count: 2 },
+      { val: 5, count: 3 },
+      { val: 1, count: 10 },
+    ];
+
+    expect(getHIndexGraphData(counts, 4)).toEqual([
+      { x: 1, y: 9 },
+      { x: 2, y: 9 },
+      { x: 3, y: 5 },
+      { x: 4, y: 5 },
+    ]);
+  });
+
+  test.each([
+    { name: 'empty counts', counts: [] as IBucket[], maxDataPoints: 5 },
+    { name: 'zero max data points', counts: [{ val: 3, count: 2 }] as IBucket[], maxDataPoints: 0 },
+  ])('returns an empty array for $name', ({ counts, maxDataPoints }) => {
+    expect(getHIndexGraphData(counts, maxDataPoints)).toEqual([]);
+  });
+});
+
+describe('getResultsGraph', () => {
+  test('normalizes result nodes, defaults missing fields, and groups less common journals as other', () => {
+    const docs = [
+      { bibcode: '2024ApJ..0001A', pubdate: '2024-00-00', title: ['Alpha'], read_count: 5, citation_count: 7 },
+      { bibcode: '2024ApJ..0002B', pubdate: '2024-02-00', title: ['Beta'] },
+      { bibcode: '2024MNRAS003C', pubdate: '2024-03-15', title: ['Gamma'], read_count: 1, citation_count: 2 },
+      { bibcode: '2024AJ...004D', pubdate: '2024-04-20', title: ['Delta'], read_count: 2, citation_count: 1 },
+      { bibcode: '2024A&A..005E', pubdate: '2024-05-00', title: ['Epsilon'], read_count: 3, citation_count: 4 },
+      { bibcode: '2024Nat..006F', pubdate: '2024-06-30', title: ['Zeta'], read_count: 4, citation_count: 5 },
+      { bibcode: '2024Sci..007G', pubdate: '2024-07-00', title: ['Eta'], read_count: 6, citation_count: 8 },
+      { bibcode: '2024PASP.008H', pubdate: '2024-08-12', title: ['Theta'], read_count: 7, citation_count: 9 },
+    ] as IDocsEntity[];
+
+    const result = getResultsGraph(docs);
+
+    expect(result.groups).toEqual(['ApJ', 'PASP', 'Sci', 'Nat', 'A&A', 'other']);
+    expect(result.data).toHaveLength(8);
+    expect(result.data[0]).toMatchObject({
+      bibcode: '2024ApJ..0001A',
+      pubdate: '2024-01-01',
+      title: 'Alpha',
+      read_count: 5,
+      citation_count: 7,
+      year: 2024,
+      pub: 'ApJ',
+    });
+    expect(result.data[0].date.toISOString()).toBe(new Date('2024-01-01').toISOString());
+    expect(result.data[1]).toMatchObject({
+      bibcode: '2024ApJ..0002B',
+      pubdate: '2024-02-01',
+      title: 'Beta',
+      read_count: 0,
+      citation_count: 0,
+      pub: 'ApJ',
+    });
+    expect(result.data[2].pub).toBe('other');
+    expect(result.data[3].pub).toBe('other');
+    expect(result.data[6].pub).toBe('Sci');
+  });
+
+  test('returns no groups and rewrites all pubs to other when the top five journals are less than 25 percent of results', () => {
+    const docs = Array.from({ length: 24 }, (_, index) => {
+      const pub = `J${index.toString().padStart(4, '0')}`;
+      return {
+        bibcode: `2024${pub}X`,
+        pubdate: '2024-01-15',
+        title: [`Paper ${index + 1}`],
+      };
+    }) as IDocsEntity[];
+
+    const result = getResultsGraph(docs);
+
+    expect(result.groups).toEqual([]);
+    expect(result.data.every((item) => item.pub === 'other')).toBe(true);
+  });
+});

--- a/src/components/Visualizations/utils/utils.test.ts
+++ b/src/components/Visualizations/utils/utils.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'vitest';
+import type { Serie } from '@nivo/line';
+import type { YearDatum } from '../types';
+import { getLineGraphXTicks, getQueryWithCondition, getYearGraphTicks, groupBarDatumByYear } from './utils';
+
+const makeYearDatum = (year: number, refereed: number, notrefereed: number): YearDatum => ({
+  year,
+  refereed,
+  notrefereed,
+});
+
+describe('getLineGraphXTicks', () => {
+  test('returns evenly spaced ticks across the full x range from mixed series', () => {
+    const data: Serie[] = [
+      {
+        id: 'first',
+        data: [
+          { x: 2001, y: 1 },
+          { x: 2003, y: 2 },
+        ],
+      },
+      {
+        id: 'second',
+        data: [
+          { x: '2002', y: 3 },
+          { x: '2006', y: 4 },
+        ],
+      },
+    ];
+
+    expect(getLineGraphXTicks(data, 3)).toEqual([2001, 2003, 2005]);
+  });
+
+  test('returns a single tick when all x values are the same', () => {
+    const data: Serie[] = [
+      {
+        id: 'only',
+        data: [
+          { x: 1999, y: 1 },
+          { x: '1999', y: 2 },
+        ],
+      },
+    ];
+
+    expect(getLineGraphXTicks(data, 4)).toEqual([1999]);
+  });
+
+  test('returns an empty array for empty input', () => {
+    expect(getLineGraphXTicks([], 5)).toEqual([]);
+  });
+});
+
+describe('groupBarDatumByYear', () => {
+  test('groups year data into summed ranges based on max x ticks', () => {
+    const yearData: YearDatum[] = [
+      makeYearDatum(2000, 1, 10),
+      makeYearDatum(2001, 2, 20),
+      makeYearDatum(2002, 3, 30),
+      makeYearDatum(2003, 4, 40),
+      makeYearDatum(2004, 5, 50),
+    ];
+
+    expect(groupBarDatumByYear(yearData, 2, 0, yearData.length)).toEqual([
+      { year: '2000 - 2002', refereed: 6, notrefereed: 60 },
+      { year: '2003 - 2004', refereed: 9, notrefereed: 90 },
+    ]);
+  });
+
+  test('returns a single-year label when grouping a single item', () => {
+    const yearData: YearDatum[] = [makeYearDatum(2010, 7, 11)];
+
+    expect(groupBarDatumByYear(yearData, 3, 0, 1)).toEqual([{ year: '2010 - 2010', refereed: 7, notrefereed: 11 }]);
+  });
+
+  test('returns an empty array when the requested range is empty', () => {
+    const yearData: YearDatum[] = [makeYearDatum(2010, 7, 11)];
+
+    expect(groupBarDatumByYear(yearData, 3, 0, 0)).toEqual([]);
+  });
+});
+
+describe('getQueryWithCondition', () => {
+  test('wraps an unparenthesized query before appending the condition', () => {
+    expect(getQueryWithCondition('author:einstein', 'year', '[2000 TO 2005]')).toBe(
+      '(author:einstein) AND year:[2000 TO 2005]',
+    );
+  });
+
+  test('preserves an already parenthesized query', () => {
+    expect(getQueryWithCondition('(author:einstein OR author:curie)', 'read_count', '[10 TO *]')).toBe(
+      '(author:einstein OR author:curie) AND read_count:[10 TO *]',
+    );
+  });
+
+  test('handles an empty query string using the current implementation behavior', () => {
+    expect(getQueryWithCondition('', 'citation_count', '[1 TO 5]')).toBe('() AND citation_count:[1 TO 5]');
+  });
+});
+
+describe('getYearGraphTicks', () => {
+  test('returns every nth year based on the provided maxTicks step', () => {
+    const data: YearDatum[] = [
+      makeYearDatum(2000, 1, 1),
+      makeYearDatum(2001, 1, 1),
+      makeYearDatum(2002, 1, 1),
+      makeYearDatum(2003, 1, 1),
+      makeYearDatum(2004, 1, 1),
+    ];
+
+    expect(getYearGraphTicks(data, 2)).toEqual([2000, 2002, 2004]);
+  });
+
+  test('returns the only year for a single-item input', () => {
+    expect(getYearGraphTicks([makeYearDatum(1995, 1, 1)], 3)).toEqual([1995]);
+  });
+
+  test('returns an empty array for empty input', () => {
+    expect(getYearGraphTicks([], 2)).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/performance.test.ts
+++ b/src/lib/__tests__/performance.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import * as Sentry from '@sentry/nextjs';
 
 // Mock Sentry
@@ -14,7 +14,7 @@ describe('performance utilities', () => {
   });
 
   describe('trackUserFlow', () => {
-    it('should create a span with the correct name and call the callback', async () => {
+    test('should create a span with the correct name and call the callback', async () => {
       const { trackUserFlow } = await import('../performance');
       const mockFn = vi.fn().mockResolvedValue('result');
 
@@ -30,7 +30,7 @@ describe('performance utilities', () => {
       expect(result).toBe('result');
     });
 
-    it('should pass additional tags to the span', async () => {
+    test('should pass additional tags to the span', async () => {
       const { trackUserFlow } = await import('../performance');
       const mockFn = vi.fn().mockResolvedValue('result');
 
@@ -51,7 +51,7 @@ describe('performance utilities', () => {
       );
     });
 
-    it('should handle errors and still end the span', async () => {
+    test('should handle errors and still end the span', async () => {
       const { trackUserFlow } = await import('../performance');
       const error = new Error('Test error');
       const mockFn = vi.fn().mockRejectedValue(error);
@@ -61,7 +61,7 @@ describe('performance utilities', () => {
   });
 
   describe('startRenderSpan', () => {
-    it('should start an inactive span and return end function', async () => {
+    test('should start an inactive span and return end function', async () => {
       const { startRenderSpan } = await import('../performance');
       const mockEnd = vi.fn();
       vi.mocked(Sentry.startInactiveSpan).mockReturnValue({
@@ -83,7 +83,7 @@ describe('performance utilities', () => {
   });
 
   describe('getResultCountBucket', () => {
-    it('should return correct buckets', async () => {
+    test('should return correct buckets', async () => {
       const { getResultCountBucket } = await import('../performance');
 
       expect(getResultCountBucket(0)).toBe('0');
@@ -97,14 +97,14 @@ describe('performance utilities', () => {
   });
 
   describe('getQueryType', () => {
-    it('should detect simple queries', async () => {
+    test('should detect simple queries', async () => {
       const { getQueryType } = await import('../performance');
 
       expect(getQueryType('black holes')).toBe('simple');
       expect(getQueryType('exoplanet')).toBe('simple');
     });
 
-    it('should detect fielded queries', async () => {
+    test('should detect fielded queries', async () => {
       const { getQueryType } = await import('../performance');
 
       expect(getQueryType('author:Einstein')).toBe('fielded');
@@ -112,7 +112,7 @@ describe('performance utilities', () => {
       expect(getQueryType('bibcode:2020ApJ')).toBe('fielded');
     });
 
-    it('should detect boolean queries', async () => {
+    test('should detect boolean queries', async () => {
       const { getQueryType } = await import('../performance');
 
       expect(getQueryType('black holes AND exoplanets')).toBe('boolean');

--- a/src/lib/orcid/helpers.test.ts
+++ b/src/lib/orcid/helpers.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'vitest';
+import type { IOrcidProfile } from '@/api/orcid/types';
+import type { IDocsEntity } from '@/api/search/types';
+import { convertDocType, findWorkInProfile, mergeOrcidMissingRecords } from './helpers';
+
+const createProfileEntry = (identifier: string) => ({
+  identifier,
+  status: 'verified' as const,
+  title: `Title for ${identifier}`,
+  pubyear: '2024',
+  pubmonth: '06',
+  updated: '2024-06-03',
+  putcode: `putcode-${identifier}`,
+  source: ['ADS'],
+});
+
+const createDoc = (overrides: Partial<IDocsEntity>): IDocsEntity =>
+  ({
+    identifier: ['bibcode:default'],
+    pubdate: '2024-06-03',
+    title: ['Default title'],
+    ...overrides,
+  } as IDocsEntity);
+
+describe('convertDocType', () => {
+  test.each([
+    ['article', 'JOURNAL_ARTICLE'],
+    ['inproceedings', 'CONFERENCE_PAPER'],
+    ['abstract', 'CONFERENCE_ABSTRACT'],
+    ['eprint', 'WORKING_PAPER'],
+    ['phdthesis', 'DISSERTATION'],
+    ['techreport', 'RESEARCH_TECHNIQUE'],
+    ['inbook', 'BOOK_CHAPTER'],
+    ['circular', 'RESEARCH_TOOL'],
+    ['book', 'BOOK'],
+    ['proceedings', 'BOOK'],
+    ['bookreview', 'BOOK_REVIEW'],
+    ['erratum', 'JOURNAL_ARTICLE'],
+    ['newsletter', 'NEWSLETTER_ARTICLE'],
+    ['catalog', 'DATA-SET'],
+    ['intechreport', 'RESEARCH_TECHNIQUE'],
+    ['mastersthesis', 'DISSERTATION'],
+    ['software', 'RESEARCH_TECHNIQUE'],
+    ['talk', 'LECTURE_SPEECH'],
+    ['dataset', 'DATA-SET'],
+    ['instrument', 'PHYSICAL-OBJECT'],
+    ['service', 'DATA-SET'],
+    ['obituary', 'OTHER'],
+    ['pressrelease', 'OTHER'],
+    ['proposal', 'OTHER'],
+    ['editorial', 'OTHER'],
+    ['misc', 'OTHER'],
+    ['unknown-doc-type', 'OTHER'],
+  ])('maps %s to %s', (docType, expected) => {
+    expect(convertDocType(docType)).toBe(expected);
+  });
+});
+
+describe('findWorkInProfile', () => {
+  const profile: IOrcidProfile = {
+    alpha: createProfileEntry('alpha'),
+    beta: createProfileEntry('beta'),
+  };
+
+  test.each([
+    [null, profile],
+    ['', profile],
+    [[], profile],
+    ['alpha', null],
+    ['alpha', {}],
+  ])('returns null for nil or empty inputs: %j', (identifier, currentProfile) => {
+    expect(findWorkInProfile(identifier as string | string[], currentProfile as IOrcidProfile)).toBeNull();
+  });
+
+  test('returns the matching profile entry for a string identifier', () => {
+    expect(findWorkInProfile('alpha', profile)).toBe(profile.alpha);
+  });
+
+  test('returns null when a string identifier is not in the profile', () => {
+    expect(findWorkInProfile('missing', profile)).toBeNull();
+  });
+
+  test('returns the first matching entry when given an identifier array', () => {
+    expect(findWorkInProfile(['missing', 'beta', 'alpha'], profile)).toBe(profile.beta);
+  });
+
+  test('returns null when no identifiers in the array match the profile', () => {
+    expect(findWorkInProfile(['missing', 'also-missing'], profile)).toBeNull();
+  });
+});
+
+describe('mergeOrcidMissingRecords', () => {
+  test('adds only docs whose identifiers are not already present in the profile', () => {
+    const existingEntry = createProfileEntry('existing:bibcode');
+    const profile: IOrcidProfile = {
+      'existing:bibcode': existingEntry,
+    };
+    const missing: IDocsEntity[] = [
+      createDoc({
+        identifier: ['existing:bibcode', 'alt:existing'],
+        pubdate: '2024-01-15',
+        title: ['Existing title should be ignored'],
+      }),
+      createDoc({
+        identifier: ['new:bibcode', 'alt:new'],
+        pubdate: '2024-02-20',
+        title: ['New title'],
+      }),
+    ];
+
+    const merged = mergeOrcidMissingRecords(missing, profile);
+
+    expect(merged).toStrictEqual({
+      'existing:bibcode': existingEntry,
+      'new:bibcode': {
+        identifier: 'new:bibcode',
+        pubyear: '2024',
+        pubmonth: '02',
+        putcode: null,
+        source: [],
+        status: null,
+        title: 'New title',
+        updated: null,
+      },
+    });
+    expect(merged['existing:bibcode']).toBe(existingEntry);
+  });
+
+  test('preserves the original profile entries unchanged when every missing doc already exists', () => {
+    const existingEntry = createProfileEntry('existing:bibcode');
+    const profile: IOrcidProfile = {
+      'existing:bibcode': existingEntry,
+    };
+    const missing: IDocsEntity[] = [
+      createDoc({
+        identifier: ['other:id', 'existing:bibcode'],
+        pubdate: '2023-12',
+        title: ['Should not be merged'],
+      }),
+    ];
+
+    const merged = mergeOrcidMissingRecords(missing, profile);
+
+    expect(merged).toStrictEqual(profile);
+    expect(merged['existing:bibcode']).toBe(existingEntry);
+  });
+
+  test('uses the first identifier and first title when creating a new profile entry', () => {
+    const merged = mergeOrcidMissingRecords(
+      [
+        createDoc({
+          identifier: ['primary:id', 'secondary:id'],
+          pubdate: '2023-12',
+          title: ['Primary title', 'Secondary title'],
+        }),
+      ],
+      {},
+    );
+
+    expect(merged).toStrictEqual({
+      'primary:id': {
+        identifier: 'primary:id',
+        pubyear: '2023',
+        pubmonth: '12',
+        putcode: null,
+        source: [],
+        status: null,
+        title: 'Primary title',
+        updated: null,
+      },
+    });
+  });
+});

--- a/src/lib/orcid/useRemoveWorks.test.ts
+++ b/src/lib/orcid/useRemoveWorks.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest';
+import { IOrcidProfile } from '@/api/orcid/types';
+import { findPutcodeInProfile, getFulfilled, getRejected } from './useRemoveWorks';
+
+const createProfileEntry = (putcode: string | number) => ({
+  identifier: `id-${putcode}`,
+  status: 'verified' as const,
+  title: `Title ${putcode}`,
+  pubyear: '2024',
+  pubmonth: '06',
+  updated: '2024-06-03',
+  putcode,
+  source: ['ADS'],
+});
+
+describe('getFulfilled', () => {
+  test('returns keys for fulfilled entries when results are mixed', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'fulfilled', value: undefined },
+      beta: { status: 'rejected', reason: new Error('failed') },
+      gamma: { status: 'fulfilled', value: undefined },
+    };
+
+    expect(getFulfilled(entries)).toStrictEqual(['alpha', 'gamma']);
+  });
+
+  test('returns all keys when every entry is fulfilled', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'fulfilled', value: undefined },
+      beta: { status: 'fulfilled', value: undefined },
+    };
+
+    expect(getFulfilled(entries)).toStrictEqual(['alpha', 'beta']);
+  });
+
+  test('returns an empty array when every entry is rejected', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'rejected', reason: new Error('failed') },
+      beta: { status: 'rejected', reason: new Error('failed again') },
+    };
+
+    expect(getFulfilled(entries)).toStrictEqual([]);
+  });
+
+  test('returns an empty array for an empty object', () => {
+    expect(getFulfilled({})).toStrictEqual([]);
+  });
+});
+
+describe('getRejected', () => {
+  test('returns keys for rejected entries when results are mixed', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'fulfilled', value: undefined },
+      beta: { status: 'rejected', reason: new Error('failed') },
+      gamma: { status: 'rejected', reason: new Error('failed again') },
+    };
+
+    expect(getRejected(entries)).toStrictEqual(['beta', 'gamma']);
+  });
+
+  test('returns an empty array when every entry is fulfilled', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'fulfilled', value: undefined },
+      beta: { status: 'fulfilled', value: undefined },
+    };
+
+    expect(getRejected(entries)).toStrictEqual([]);
+  });
+
+  test('returns all keys when every entry is rejected', () => {
+    const entries: Record<string, PromiseSettledResult<void>> = {
+      alpha: { status: 'rejected', reason: new Error('failed') },
+      beta: { status: 'rejected', reason: new Error('failed again') },
+    };
+
+    expect(getRejected(entries)).toStrictEqual(['alpha', 'beta']);
+  });
+
+  test('returns an empty array for an empty object', () => {
+    expect(getRejected({})).toStrictEqual([]);
+  });
+});
+
+describe('findPutcodeInProfile', () => {
+  test('finds a matching entry using numeric comparison across string and number putcodes', () => {
+    const profile: IOrcidProfile = {
+      first: createProfileEntry(101),
+      second: createProfileEntry('202'),
+    };
+
+    expect(findPutcodeInProfile('101', profile)).toBe('first');
+    expect(findPutcodeInProfile('202', profile)).toBe('second');
+  });
+
+  test('returns undefined when no entry matches the putcode', () => {
+    const profile: IOrcidProfile = {
+      first: createProfileEntry('101'),
+      second: createProfileEntry(202),
+    };
+
+    expect(findPutcodeInProfile('999', profile)).toBeUndefined();
+  });
+
+  test('returns the first matching entry key when multiple entries share the same numeric putcode', () => {
+    const profile: IOrcidProfile = {
+      first: createProfileEntry('101'),
+      second: createProfileEntry(101),
+      third: createProfileEntry('303'),
+    };
+
+    expect(findPutcodeInProfile('101', profile)).toBe('first');
+  });
+});

--- a/src/lib/serverside/__tests__/bootstrap.test.ts
+++ b/src/lib/serverside/__tests__/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import { bootstrap } from '../bootstrap';
 import { getIronSession } from 'iron-session/edge';
 
@@ -38,7 +38,7 @@ describe('bootstrap', () => {
     fetchSpy.mockRestore();
   });
 
-  it('forwards tracing headers to the bootstrap API', async () => {
+  test('forwards tracing headers to the bootstrap API', async () => {
     const req = {
       headers: {
         cookie: 'ads_session=abc',
@@ -60,7 +60,7 @@ describe('bootstrap', () => {
     expect(headers.get('X-Forwarded-For')).toBe('10.0.0.1');
   });
 
-  it('makes fetch call without tracing headers when none present', async () => {
+  test('makes fetch call without tracing headers when none present', async () => {
     const req = {
       headers: {
         cookie: 'ads_session=abc',

--- a/src/lib/useBackToSearchResults.test.ts
+++ b/src/lib/useBackToSearchResults.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { useBackToSearchResults } from './useBackToSearchResults';
 
 const router = {
@@ -10,7 +10,7 @@ vi.mock('next/router', () => ({
 }));
 
 describe('useBackToSearchResults', () => {
-  it('handleBack calls router.back()', () => {
+  test('handleBack calls router.back()', () => {
     const { result } = renderHook(() => useBackToSearchResults());
     result.current.handleBack();
     expect(router.back).toHaveBeenCalledOnce();

--- a/src/lib/useNivoDarkTheme.test.ts
+++ b/src/lib/useNivoDarkTheme.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+
+import { useNivoDarkTheme } from './useNivoDarkTheme';
+
+describe('useNivoDarkTheme', () => {
+  test('returns the expected dark theme shape', () => {
+    const theme = useNivoDarkTheme();
+
+    expect(theme).toEqual(
+      expect.objectContaining({
+        background: expect.any(String),
+        text: expect.objectContaining({
+          fill: expect.any(String),
+        }),
+        axis: expect.objectContaining({
+          ticks: expect.objectContaining({
+            text: expect.objectContaining({
+              fill: expect.any(String),
+            }),
+          }),
+        }),
+        tooltip: expect.objectContaining({
+          container: expect.objectContaining({
+            background: expect.any(String),
+          }),
+        }),
+        legends: expect.objectContaining({
+          text: expect.objectContaining({
+            fill: expect.any(String),
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('returns the expected dark theme colors', () => {
+    const theme = useNivoDarkTheme();
+
+    expect(theme.background).toBe('#1C1C1C');
+    expect(theme.text.fill).toBe('#000000');
+    expect(theme.axis.ticks.text.fill).toBe('#ffffff');
+    expect(theme.tooltip.container.background).toBe('#000000');
+    expect(theme.legends.text.fill).toBe('#ffffff');
+  });
+});

--- a/src/middlewares/__tests__/botCheck.test.ts
+++ b/src/middlewares/__tests__/botCheck.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { botCheck } from '@/middlewares/botCheck';
 import { getIronSession } from 'iron-session/edge';
@@ -60,7 +60,7 @@ describe('botCheck', () => {
       }) as unknown as Response,
     );
 
-  it('marks verified bot with bot token and clears apiCookieHash', async () => {
+  test('marks verified bot with bot token and clears apiCookieHash', async () => {
     mockCrawlerResponse(0); // BOT
     const session = await getIronSessionMock();
     const req = makeReq('1.1.1.1', 'TestUA');
@@ -73,7 +73,7 @@ describe('botCheck', () => {
     expect(session.save).toHaveBeenCalled();
   });
 
-  it('marks unverifiable bot with dedicated token', async () => {
+  test('marks unverifiable bot with dedicated token', async () => {
     mockCrawlerResponse(3); // UNVERIFIABLE
     const session = await getIronSessionMock();
     await botCheck(makeReq(), NextResponse.next());
@@ -82,7 +82,7 @@ describe('botCheck', () => {
     expect(session.bot).toBe(true);
   });
 
-  it('marks malicious bot with dedicated token', async () => {
+  test('marks malicious bot with dedicated token', async () => {
     mockCrawlerResponse(2); // POTENTIAL_MALICIOUS_BOT
     const session = await getIronSessionMock();
     await botCheck(makeReq(), NextResponse.next());
@@ -91,7 +91,7 @@ describe('botCheck', () => {
     expect(session.bot).toBe(true);
   });
 
-  it('does nothing for human responses', async () => {
+  test('does nothing for human responses', async () => {
     mockCrawlerResponse(1); // HUMAN
     const session = await getIronSessionMock();
     await botCheck(makeReq(), NextResponse.next());
@@ -101,7 +101,7 @@ describe('botCheck', () => {
     expect(session.save).not.toHaveBeenCalled();
   });
 
-  it('treats fetch failure as human to avoid blocking users', async () => {
+  test('treats fetch failure as human to avoid blocking users', async () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
     const session = await getIronSessionMock();
     await botCheck(makeReq(), NextResponse.next());

--- a/src/middlewares/__tests__/initSession.contract.test.ts
+++ b/src/middlewares/__tests__/initSession.contract.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { rest } from 'msw';
 import { webcrypto } from 'crypto';
@@ -56,7 +56,7 @@ describe('initSession msw contracts', () => {
     vi.clearAllMocks();
   });
 
-  it('hydrates from the bootstrap API and rewrites cookie attributes', async () => {
+  test('hydrates from the bootstrap API and rewrites cookie attributes', async () => {
     const bootstrapCookie = `${cookieName}=rotated; Domain=.example.com; SameSite=None; HttpOnly; Secure; Path=/; Max-Age=3600`;
     const expiresAt = `${Math.floor(Date.now() / 1000) + 600}`;
     let receivedCookie: string | null = null;
@@ -104,7 +104,7 @@ describe('initSession msw contracts', () => {
     expect(session.apiCookieHash).toBe(await hash('rotated'));
   });
 
-  it('avoids setting Set-Cookie when the API returns the same cookie value', async () => {
+  test('avoids setting Set-Cookie when the API returns the same cookie value', async () => {
     const expiresAt = `${Math.floor(Date.now() / 1000) + 600}`;
     server.use(
       rest.get('https://api.example.com/accounts/bootstrap', (_req, res, ctx) =>

--- a/src/middlewares/__tests__/initSession.integration.test.ts
+++ b/src/middlewares/__tests__/initSession.integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi, afterEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { webcrypto } from 'crypto';
 import { initSession, isValidToken, hash } from '@/middlewares/initSession';
@@ -75,7 +75,7 @@ describe('initSession integration', () => {
       },
     });
 
-  it('uses fast path when token is valid and hash matches', async () => {
+  test('uses fast path when token is valid and hash matches', async () => {
     const cookieValue = 'abc123';
     const cookieHash = await hash(cookieValue);
     const session = createSession({
@@ -107,7 +107,7 @@ describe('initSession integration', () => {
     expect(session.apiCookieHash).toBe(cookieHash);
   });
 
-  it('hydrates session on slow path and rewrites session cookie', async () => {
+  test('hydrates session on slow path and rewrites session cookie', async () => {
     process.env.NEXT_PUBLIC_API_MOCKING = 'enabled';
     const session = createSession({
       token: {
@@ -141,7 +141,7 @@ describe('initSession integration', () => {
     expect(session.apiCookieHash).toBe(await hash('mocked'));
   });
 
-  it('leaves session untouched when bootstrap fails', async () => {
+  test('leaves session untouched when bootstrap fails', async () => {
     process.env.NEXT_PUBLIC_API_MOCKING = '';
     const session = createSession({
       token: {
@@ -172,7 +172,7 @@ describe('initSession integration', () => {
     expect(session.apiCookieHash).toBe('stale');
   });
 
-  it('forces slow path when refresh header present even with valid token', async () => {
+  test('forces slow path when refresh header present even with valid token', async () => {
     const cookieValue = 'abc123';
     const session = createSession({
       token: {
@@ -210,7 +210,7 @@ describe('initSession integration', () => {
     expect(setCookie?.path).toBe('/');
   });
 
-  it('does not set response cookie when API cookie value is unchanged', async () => {
+  test('does not set response cookie when API cookie value is unchanged', async () => {
     const cookieValue = 'unchanged';
     const session = createSession({
       token: {
@@ -239,7 +239,7 @@ describe('initSession integration', () => {
     expect(session.apiCookieHash).toBe(await hash(cookieValue));
   });
 
-  it('forwards tracing headers to bootstrap call', async () => {
+  test('forwards tracing headers to bootstrap call', async () => {
     const cookieValue = 'test-cookie';
     const session = createSession({
       token: {

--- a/src/middlewares/__tests__/middleware.routes.integration.test.ts
+++ b/src/middlewares/__tests__/middleware.routes.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { MockedRequest, rest } from 'msw';
 import { NextRequest, NextResponse } from 'next/server';
 import { middleware } from '@/middleware';
@@ -76,7 +76,7 @@ describe('middleware route integration', () => {
 
   const makeReq = (url: string, init?: RequestInit) => new NextRequest(url, init);
 
-  it('hydrates root path without redirect', async () => {
+  test('hydrates root path without redirect', async () => {
     const session = { save: vi.fn(), destroy: vi.fn(), updateConfig: vi.fn() };
     getIronSessionMock.mockResolvedValue(session);
     const req = makeReq('https://example.com/');
@@ -85,7 +85,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
-  it('redirects unauthenticated protected routes to login with next param', async () => {
+  test('redirects unauthenticated protected routes to login with next param', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: false,
       token: { access_token: 'token' },
@@ -102,7 +102,7 @@ describe('middleware route integration', () => {
     expect(location).toContain('next=%252Fuser%252Flibraries');
   });
 
-  it('allows authenticated protected routes to continue', async () => {
+  test('allows authenticated protected routes to continue', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -115,20 +115,20 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
-  it('routes verify endpoints through verifyMiddleware', async () => {
+  test('routes verify endpoints through verifyMiddleware', async () => {
     const req = makeReq('https://example.com/user/account/verify/change-email/token123');
     await middleware(req);
     expect(verifyMiddlewareMock).toHaveBeenCalled();
   });
 
-  it('redirects legacy search URLs via legacySearchURLMiddleware', async () => {
+  test('redirects legacy search URLs via legacySearchURLMiddleware', async () => {
     isLegacySearchURLMock.mockReturnValue(true);
     const req = makeReq('https://example.com/search/q=foo');
     await middleware(req);
     expect(legacySearchMiddlewareMock).toHaveBeenCalled();
   });
 
-  it('skips auth middleware for Next.js data prefetch routes', async () => {
+  test('skips auth middleware for Next.js data prefetch routes', async () => {
     const req = {
       method: 'GET',
       nextUrl: {
@@ -145,7 +145,7 @@ describe('middleware route integration', () => {
     expect(rateLimitMock).not.toHaveBeenCalled();
   });
 
-  it('redirects to / when session token is missing after initSession', async () => {
+  test('redirects to / when session token is missing after initSession', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: false,
       token: undefined,
@@ -159,7 +159,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toContain('/?notify=api-connect-failed');
   });
 
-  it('login route: redirects authenticated users to decoded relative next param', async () => {
+  test('login route: redirects authenticated users to decoded relative next param', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -173,7 +173,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBe('https://example.com/user/settings?notify=account-login-success');
   });
 
-  it('login route: redirects authenticated users to / when next param is external', async () => {
+  test('login route: redirects authenticated users to / when next param is external', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -187,7 +187,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBe('https://example.com/?notify=account-login-success');
   });
 
-  it('login route: redirects authenticated users to / when next param is missing', async () => {
+  test('login route: redirects authenticated users to / when next param is missing', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -201,7 +201,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBe('https://example.com/');
   });
 
-  it('login route: allows unauthenticated users to continue', async () => {
+  test('login route: allows unauthenticated users to continue', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: false,
       token: { access_token: 'token' },
@@ -214,7 +214,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
-  it('register route: redirects authenticated users to /', async () => {
+  test('register route: redirects authenticated users to /', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -228,7 +228,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBe('https://example.com/');
   });
 
-  it('register route: allows unauthenticated users to continue', async () => {
+  test('register route: allows unauthenticated users to continue', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: false,
       token: { access_token: 'token' },
@@ -241,7 +241,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
-  it('forgot password route: redirects authenticated users to /', async () => {
+  test('forgot password route: redirects authenticated users to /', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: true,
       token: { access_token: 'token' },
@@ -255,7 +255,7 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBe('https://example.com/');
   });
 
-  it('forgot password route: allows unauthenticated users to continue', async () => {
+  test('forgot password route: allows unauthenticated users to continue', async () => {
     getIronSessionMock.mockResolvedValue({
       isAuthenticated: false,
       token: { access_token: 'token' },
@@ -268,13 +268,13 @@ describe('middleware route integration', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
-  it('rewrites abs identifiers to canonical form', async () => {
+  test('rewrites abs identifiers to canonical form', async () => {
     const req = makeReq('https://example.com/abs/123/456');
     const res = await middleware(req);
     expect(res.headers.get('x-middleware-rewrite')).toContain('/abs/123%2F456/abstract');
   });
 
-  it('emits analytics for abs paths when BASE_URL is set', async () => {
+  test('emits analytics for abs paths when BASE_URL is set', async () => {
     process.env.BASE_URL = 'https://base.example.com';
     const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 200 }) as Response);
     const req = makeReq('https://example.com/abs/123%2F456/abstract');
@@ -286,7 +286,7 @@ describe('middleware route integration', () => {
     fetchSpy.mockRestore();
   });
 
-  it('routes analytics calls through msw when BASE_URL is configured', async () => {
+  test('routes analytics calls through msw when BASE_URL is configured', async () => {
     process.env.BASE_URL = 'https://base.example.com';
     const requests: string[] = [];
     server.use(
@@ -317,14 +317,14 @@ describe('middleware route integration', () => {
     expect(requests[0]).toBe('https://base.example.com/link_gateway/789/abstract');
   });
 
-  it('honors rate limiting and short-circuits', async () => {
+  test('honors rate limiting and short-circuits', async () => {
     rateLimitMock.mockReturnValue(false);
     const req = makeReq('https://example.com/search');
     const res = (await middleware(req)) as NextResponse;
     expect(res.headers.get('location')).toContain('notify=rate-limit-exceeded');
   });
 
-  it('handles requests with tracing headers', async () => {
+  test('handles requests with tracing headers', async () => {
     const req = makeReq('https://example.com/search', {
       headers: {
         'X-Original-Uri': '/original/path',

--- a/src/middlewares/__tests__/verifyMiddleware.integration.test.ts
+++ b/src/middlewares/__tests__/verifyMiddleware.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { rest } from 'msw';
 import { verifyMiddleware } from '@/middlewares/verifyMiddleware';
@@ -46,7 +46,7 @@ describe('verifyMiddleware', () => {
       .spyOn(global, 'fetch')
       .mockResolvedValue(new Response(JSON.stringify(body), { status, headers }) as unknown as Response);
 
-  it('redirects to login with success notify when verification succeeds', async () => {
+  test('redirects to login with success notify when verification succeeds', async () => {
     const session = makeSession();
     const fetchSpy = mockFetch({ message: 'success' }, 200, { 'set-cookie': `${cookieName}=new-value` });
     const res = await verifyMiddleware(makeReq('/user/account/verify/change-email/abc'), NextResponse.next(), session);
@@ -56,13 +56,13 @@ describe('verifyMiddleware', () => {
     expect(location).toContain('notify=verify-account-success');
   });
 
-  it('redirects with failure when access token is missing', async () => {
+  test('redirects with failure when access token is missing', async () => {
     const session = makeSession(false);
     const res = await verifyMiddleware(makeReq('/user/account/verify/change-email/abc'), NextResponse.next(), session);
     expect((res as NextResponse).headers.get('location')).toContain('notify=verify-account-failed');
   });
 
-  it('handles unknown verification token error', async () => {
+  test('handles unknown verification token error', async () => {
     const session = makeSession();
     mockFetch({ error: 'unknown verification token' });
     const res = await verifyMiddleware(
@@ -73,7 +73,7 @@ describe('verifyMiddleware', () => {
     expect((res as NextResponse).headers.get('location')).toContain('notify=verify-account-failed');
   });
 
-  it('handles already validated token error', async () => {
+  test('handles already validated token error', async () => {
     const session = makeSession();
     mockFetch({ error: 'already been validated' });
     const res = await verifyMiddleware(
@@ -84,21 +84,21 @@ describe('verifyMiddleware', () => {
     expect((res as NextResponse).headers.get('location')).toContain('notify=verify-account-was-valid');
   });
 
-  it('redirects with failure on non-200 responses', async () => {
+  test('redirects with failure on non-200 responses', async () => {
     const session = makeSession();
     mockFetch({ error: 'server error' }, 500);
     const res = await verifyMiddleware(makeReq('/user/account/verify/change-email/abc'), NextResponse.next(), session);
     expect((res as NextResponse).headers.get('location')).toContain('notify=verify-account-failed');
   });
 
-  it('redirects with failure when fetch throws', async () => {
+  test('redirects with failure when fetch throws', async () => {
     const session = makeSession();
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
     const res = await verifyMiddleware(makeReq('/user/account/verify/change-email/abc'), NextResponse.next(), session);
     expect((res as NextResponse).headers.get('location')).toContain('notify=verify-account-failed');
   });
 
-  it('forwards tracing headers to the verify API', async () => {
+  test('forwards tracing headers to the verify API', async () => {
     const session = makeSession();
     const fetchSpy = mockFetch({ message: 'success' });
     const req = new NextRequest('https://example.com/user/account/verify/change-email/tok', {
@@ -118,7 +118,7 @@ describe('verifyMiddleware', () => {
   });
 
   describe('msw contract coverage', () => {
-    it('calls the verify API with bearer and session cookie and forwards Set-Cookie', async () => {
+    test('calls the verify API with bearer and session cookie and forwards Set-Cookie', async () => {
       const setCookieValue = `${cookieName}=verified; Domain=example.com; Secure; Path=/; SameSite=None; HttpOnly`;
       let authHeader: string | null = null;
       let cookieHeader: string | null = null;
@@ -146,7 +146,7 @@ describe('verifyMiddleware', () => {
       expect(location).toContain('notify=verify-account-success');
     });
 
-    it('maps API error payloads from msw', async () => {
+    test('maps API error payloads from msw', async () => {
       server.use(
         rest.get('https://api.example.com/accounts/verify/:token', (_req, res, ctx) =>
           res(ctx.status(200), ctx.json({ error: 'already been validated' })),

--- a/src/store/slices/notification.test.ts
+++ b/src/store/slices/notification.test.ts
@@ -1,39 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { getNotification, NOTIFICATIONS } from './notification';
 
 describe('notification store', () => {
   describe('getNotification', () => {
-    it('returns null for unknown notification id', () => {
+    test('returns null for unknown notification id', () => {
       // @ts-expect-error - testing with invalid id
       expect(getNotification('unknown-id')).toBeNull();
     });
 
-    it('returns correct notification for valid id', () => {
-      expect(getNotification('account-login-success')).toEqual(
-        NOTIFICATIONS['account-login-success'],
-      );
+    test('returns correct notification for valid id', () => {
+      expect(getNotification('account-login-success')).toEqual(NOTIFICATIONS['account-login-success']);
     });
   });
 
   describe('orcid-session-expired notification', () => {
-    it('exists in NOTIFICATIONS', () => {
+    test('exists in NOTIFICATIONS', () => {
       expect(NOTIFICATIONS['orcid-session-expired']).toBeDefined();
     });
 
-    it('has warning status', () => {
+    test('has warning status', () => {
       expect(NOTIFICATIONS['orcid-session-expired'].status).toBe('warning');
     });
 
-    it('has correct id', () => {
+    test('has correct id', () => {
       expect(NOTIFICATIONS['orcid-session-expired'].id).toBe('orcid-session-expired');
     });
 
-    it('has informative message', () => {
+    test('has informative message', () => {
       expect(NOTIFICATIONS['orcid-session-expired'].message).toContain('ORCiD session');
       expect(NOTIFICATIONS['orcid-session-expired'].message).toContain('log in again');
     });
 
-    it('is retrievable via getNotification', () => {
+    test('is retrievable via getNotification', () => {
       const notification = getNotification('orcid-session-expired');
       expect(notification).toEqual(NOTIFICATIONS['orcid-session-expired']);
     });

--- a/src/utils/__tests__/appMode.test.ts
+++ b/src/utils/__tests__/appMode.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { AppMode } from '@/types';
 import { getAppModeLabel, mapDisciplineParamToAppMode, mapPathToDisciplineParam } from '../appMode';
 
 describe('mapDisciplineParamToAppMode', () => {
-  it('maps supported disciplines', () => {
+  test('maps supported disciplines', () => {
     expect(mapDisciplineParamToAppMode('general')).toBe(AppMode.GENERAL);
     expect(mapDisciplineParamToAppMode('astrophysics')).toBe(AppMode.ASTROPHYSICS);
     expect(mapDisciplineParamToAppMode('heliophysics')).toBe(AppMode.HELIOPHYSICS);
@@ -13,12 +13,12 @@ describe('mapDisciplineParamToAppMode', () => {
     expect(mapDisciplineParamToAppMode('biophysical')).toBe(AppMode.BIO_PHYSICAL);
   });
 
-  it('handles arrays and trimming', () => {
+  test('handles arrays and trimming', () => {
     expect(mapDisciplineParamToAppMode(['planetary'])).toBe(AppMode.PLANET_SCIENCE);
     expect(mapDisciplineParamToAppMode('  earthscience ')).toBe(AppMode.EARTH_SCIENCE);
   });
 
-  it('returns null for unsupported values', () => {
+  test('returns null for unsupported values', () => {
     expect(mapDisciplineParamToAppMode('chemistry')).toBeNull();
     expect(mapDisciplineParamToAppMode('')).toBeNull();
     expect(mapDisciplineParamToAppMode(undefined)).toBeNull();
@@ -26,7 +26,7 @@ describe('mapDisciplineParamToAppMode', () => {
 });
 
 describe('getAppModeLabel', () => {
-  it('returns readable labels', () => {
+  test('returns readable labels', () => {
     expect(getAppModeLabel(AppMode.GENERAL)).toBe('No preferred discipline');
     expect(getAppModeLabel(AppMode.ASTROPHYSICS)).toBe('Astrophysics');
     expect(getAppModeLabel(AppMode.HELIOPHYSICS)).toBe('Heliophysics');
@@ -37,7 +37,7 @@ describe('getAppModeLabel', () => {
 });
 
 describe('mapPathToDisciplineParam', () => {
-  it('returns discipline param for valid paths', () => {
+  test('returns discipline param for valid paths', () => {
     expect(mapPathToDisciplineParam('/astrophysics')).toBe('astrophysics');
     expect(mapPathToDisciplineParam('/heliophysics')).toBe('heliophysics');
     expect(mapPathToDisciplineParam('/planetary')).toBe('planetary');
@@ -46,14 +46,14 @@ describe('mapPathToDisciplineParam', () => {
     expect(mapPathToDisciplineParam('/general')).toBe('general');
   });
 
-  it('returns null for invalid paths', () => {
+  test('returns null for invalid paths', () => {
     expect(mapPathToDisciplineParam('/search')).toBeNull();
     expect(mapPathToDisciplineParam('/abs/foobar')).toBeNull();
     expect(mapPathToDisciplineParam('/')).toBeNull();
     expect(mapPathToDisciplineParam('/invalid')).toBeNull();
   });
 
-  it('is case-insensitive', () => {
+  test('is case-insensitive', () => {
     expect(mapPathToDisciplineParam('/ASTROPHYSICS')).toBe('astrophysics');
     expect(mapPathToDisciplineParam('/Heliophysics')).toBe('heliophysics');
   });

--- a/src/utils/__tests__/tracing.edge.test.ts
+++ b/src/utils/__tests__/tracing.edge.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { pickTracingHeadersEdge } from '@/utils/tracing.edge';
 
 describe('pickTracingHeadersEdge', () => {
-  it('extracts tracing headers from a Request-like headers object', () => {
+  test('extracts tracing headers from a Request-like headers object', () => {
     const headers = new Headers({
       'X-Amzn-Trace-Id': 'Root=1-abc-def',
       'X-Forwarded-For': '10.0.0.1',
@@ -17,12 +17,12 @@ describe('pickTracingHeadersEdge', () => {
     });
   });
 
-  it('handles missing headers gracefully', () => {
+  test('handles missing headers gracefully', () => {
     const result = pickTracingHeadersEdge(new Headers());
     expect(result).toEqual({});
   });
 
-  it('sanitizes control characters from header values', () => {
+  test('sanitizes control characters from header values', () => {
     // jsdom Headers rejects control characters per Fetch spec, but real
     // edge runtimes can receive them from upstream proxies. Stub .get()
     // to simulate a value containing control characters.

--- a/src/utils/abstract/escape-math-html.test.ts
+++ b/src/utils/abstract/escape-math-html.test.ts
@@ -1,32 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { escapeMathHtml } from './escape-math-html';
 
 describe('escapeMathHtml', () => {
-  it('escapes < and > inside inline math delimiters', () => {
+  test('escapes < and > inside inline math delimiters', () => {
     const input = 'Text $10<z<12$ more text';
     const result = escapeMathHtml(input);
     expect(result).toBe('Text $10&lt;z&lt;12$ more text');
   });
 
-  it('escapes < and > inside display math delimiters', () => {
+  test('escapes < and > inside display math delimiters', () => {
     const input = 'Text $$a<b>c$$ more';
     const result = escapeMathHtml(input);
     expect(result).toBe('Text $$a&lt;b&gt;c$$ more');
   });
 
-  it('leaves text outside math delimiters unchanged', () => {
+  test('leaves text outside math delimiters unchanged', () => {
     const input = '<p>Normal HTML</p> with $x<y$ math';
     const result = escapeMathHtml(input);
     expect(result).toBe('<p>Normal HTML</p> with $x&lt;y$ math');
   });
 
-  it('handles multiple math expressions', () => {
+  test('handles multiple math expressions', () => {
     const input = 'First $a<b$ then $c>d$';
     const result = escapeMathHtml(input);
     expect(result).toBe('First $a&lt;b$ then $c&gt;d$');
   });
 
-  it('handles ambiguous dollar signs by matching left-to-right', () => {
+  test('handles ambiguous dollar signs by matching left-to-right', () => {
     // When $ appears without math context, it pairs with the next $
     // This is expected behavior - abstracts don't typically mix currency with math
     const input = 'Price is $5, but $x<y$ is math';
@@ -36,17 +36,17 @@ describe('escapeMathHtml', () => {
     expect(result).toBe('Price is $5, but $x<y$ is math');
   });
 
-  it('handles empty input', () => {
+  test('handles empty input', () => {
     expect(escapeMathHtml('')).toBe('');
     expect(escapeMathHtml(undefined as unknown as string)).toBe('');
   });
 
-  it('handles input with no math', () => {
+  test('handles input with no math', () => {
     const input = '<p>Just HTML</p>';
     expect(escapeMathHtml(input)).toBe('<p>Just HTML</p>');
   });
 
-  it('handles the real-world problematic abstract', () => {
+  test('handles the real-world problematic abstract', () => {
     const input = 'rate at $10<z_\\mathrm{phot}<12$ in the';
     const result = escapeMathHtml(input);
     expect(result).toBe('rate at $10&lt;z_\\mathrm{phot}&lt;12$ in the');


### PR DESCRIPTION
Overall test coverage was at 62.57%. This adds 156 new tests across 11 files targeting the lowest-coverage areas with deterministic, pure-function behavior.

- graphUtils, visualization utils, ORCID models, EmailNotifications/Utils, useNivoDarkTheme
- KeywordsForm, CitationForm, orcid API key helpers, useBubblePlot
- ArxivForm category toggle/submit collapsing, useRemoveWorks pure helpers
- ORCID helpers (convertDocType, findWorkInProfile, mergeOrcidMissingRecords), QueryForm state machine

- change `it` to `test` to try to normalize the naming scheme were using