### PR TITLE
SCIX-877 feat(metatags): gate Google Scholar tags by doctype

### DIFF
--- a/src/components/Metatags/Metatags.tsx
+++ b/src/components/Metatags/Metatags.tsx
@@ -2,6 +2,7 @@ import { Fragment, ReactElement } from 'react';
 import { getFormattedNumericPubdate, getFormattedCitationDate, stripHtml } from '@/utils/common/formatters';
 import { Esources, IDocsEntity } from '@/api/search/types';
 import { docToJsonld } from '@/components/Metatags/json-ld-abstract/docToJsonld';
+import { showsGoogleScholarTags } from '@/components/Metatags/scholarDoctypes';
 
 const baseUrl = process.env.BASE_CANONICAL_URL ?? '';
 const LINKGATEWAY_BASE_URL = `${baseUrl}/link_gateway`;
@@ -43,6 +44,11 @@ export const Metatags = (props: IMetatagsProps): ReactElement => {
 
   const authors = doc.author ? doc.author.slice(0, 50) : [];
 
+  // Google Scholar-compatible tags (Highwire/PRISM/Dublin Core) are gated
+  // by an allowed-doctype whitelist; Schema.org JSON-LD is emitted for all.
+  const normalizedDoctype = doc.doctype?.toLowerCase();
+  const showScholarTags = showsGoogleScholarTags(doc.doctype);
+
   return (
     <>
       <script
@@ -70,89 +76,101 @@ export const Metatags = (props: IMetatagsProps): ReactElement => {
 
       {doc.author && authors.map((a, i) => <meta key={`aa-${i}`} name="article:author" content={a} />)}
 
-      {doc.doctype === 'Proceedings' ? (
-        doc.bibstem &&
-        doc.bibstem.length > 0 && <meta name="citation_conference" content={doc.bibstem[0]} data-highwire="true" />
-      ) : doc.pub_raw ? (
-        <meta name="citation_journal_title" content={doc.pub_raw} data-highwire="true" />
-      ) : doc.pub ? (
-        <meta name="citation_journal_title" content={doc.pub} data-highwire="true" />
-      ) : null}
+      {showScholarTags && (
+        <>
+          {normalizedDoctype === 'proceedings' ? (
+            doc.bibstem &&
+            doc.bibstem.length > 0 && <meta name="citation_conference" content={doc.bibstem[0]} data-highwire="true" />
+          ) : doc.pub_raw ? (
+            <meta name="citation_journal_title" content={doc.pub_raw} data-highwire="true" />
+          ) : doc.pub ? (
+            <meta name="citation_journal_title" content={doc.pub} data-highwire="true" />
+          ) : null}
 
-      {doc.pubdate && <meta name="citation_date" content={citation_date} data-highwire="true" />}
+          {doc.pubdate && <meta name="citation_date" content={citation_date} data-highwire="true" />}
 
-      {doc.author &&
-        authors.map((author, i) => (
-          <Fragment key={`author-${i}`}>
-            <meta name="citation_author" content={author} data-highwire="true" />
-            {doc.aff && doc.aff[i] && (
-              <meta name="citation_author_institution" content={doc.aff[i]} data-highwire="true" />
-            )}
-          </Fragment>
-        ))}
+          {doc.author &&
+            authors.map((author, i) => (
+              <Fragment key={`author-${i}`}>
+                <meta name="citation_author" content={author} data-highwire="true" />
+                {doc.aff && doc.aff[i] && (
+                  <meta name="citation_author_institution" content={doc.aff[i]} data-highwire="true" />
+                )}
+              </Fragment>
+            ))}
 
-      {doc.title && <meta name="citation_title" content={title} data-highwire="true" />}
+          {doc.title && <meta name="citation_title" content={title} data-highwire="true" />}
 
-      {doc.volume && <meta name="citation_volume" content={doc.volume} data-highwire="true" />}
+          {doc.volume && <meta name="citation_volume" content={doc.volume} data-highwire="true" />}
 
-      {doc.issue && <meta name="citation_issue" content={doc.issue} data-highwire="true" />}
+          {doc.issue && <meta name="citation_issue" content={doc.issue} data-highwire="true" />}
 
-      {doc.page && <meta name="citation_firstpage" content={doc.page} data-highwire="true" />}
+          {doc.page && <meta name="citation_firstpage" content={doc.page} data-highwire="true" />}
 
-      {doc.doi && doc.doi.length > 0 && <meta name="citation_doi" content={doc.doi[0]} data-highwire="true" />}
+          {doc.doi && doc.doi.length > 0 && <meta name="citation_doi" content={doc.doi[0]} data-highwire="true" />}
 
-      {doc.issn && doc.issn.length > 0 && <meta name="citation_issn" content={doc.issn[0]} data-highwire="true" />}
+          {doc.issn && doc.issn.length > 0 && <meta name="citation_issn" content={doc.issn[0]} data-highwire="true" />}
 
-      {doc.isbn && doc.isbn.length > 0 && <meta name="citation_isbn" content={doc.isbn[0]} data-highwire="true" />}
+          {doc.isbn && doc.isbn.length > 0 && <meta name="citation_isbn" content={doc.isbn[0]} data-highwire="true" />}
 
-      <meta name="citation_language" content="en" data-highwire="true" />
+          <meta name="citation_language" content="en" data-highwire="true" />
 
-      {doc.keyword &&
-        doc.keyword.map((kw, i) => (
-          <meta key={`keyword-${i}`} name="citation_keywords" content={kw} data-highwire="true" />
-        ))}
+          {doc.keyword &&
+            doc.keyword.map((kw, i) => (
+              <meta key={`keyword-${i}`} name="citation_keywords" content={kw} data-highwire="true" />
+            ))}
 
-      {doc.doctype === 'PhD Thesis' && <meta name="citation_dissertation_name" content="Phd" data-highwire="true" />}
+          {normalizedDoctype === 'phdthesis' && (
+            <meta name="citation_dissertation_name" content="Phd" data-highwire="true" />
+          )}
 
-      {doc.doctype === 'Masters Thesis' && <meta name="citation_dissertation_name" content="MS" data-highwire="true" />}
+          {normalizedDoctype === 'mastersthesis' && (
+            <meta name="citation_dissertation_name" content="MS" data-highwire="true" />
+          )}
 
-      <meta name="citation_abstract_html_url" content={url} data-highwire="true" />
+          <meta name="citation_abstract_html_url" content={url} data-highwire="true" />
 
-      {doc.pubdate && <meta name="citation_publication_date" content={citation_date} data-highwire="true" />}
+          {doc.pubdate && <meta name="citation_publication_date" content={citation_date} data-highwire="true" />}
 
-      {doc.esources && doc.esources.find((e) => e === Esources.PUB_PDF) && (
-        <meta name="citation_pdf_url" content={`${LINKGATEWAY_BASE_URL}/${doc.bibcode}/PUB_PDF`} data-highwire="true" />
+          {doc.esources && doc.esources.find((e) => e === Esources.PUB_PDF) && (
+            <meta
+              name="citation_pdf_url"
+              content={`${LINKGATEWAY_BASE_URL}/${doc.bibcode}/PUB_PDF`}
+              data-highwire="true"
+            />
+          )}
+
+          {doc.page_range && <meta name="citation_lastpage" content={last_page} data-highwire="true" />}
+
+          {arXiv !== '' && <meta name="citation_arxiv_id" content={arXiv} data-highwire="true" />}
+
+          <link title="schema(PRISM)" rel="schema.prism" href="http://prismstandard.org/namespaces/1.2/basic/" />
+
+          {doc.pubdate && <meta name="prism.publicationDate" content={formatted_numeric_pubdate} />}
+
+          {doc.bibstem && doc.bibstem.length > 0 && <meta name="prism.publicationName" content={doc.bibstem[0]} />}
+
+          {doc.issn && doc.issn.length > 0 && <meta name="prism.issn" content={doc.issn[0]} />}
+
+          {doc.volume && <meta name="prism.volume" content={doc.volume} />}
+
+          {doc.page && <meta name="prism.startingPage" content={doc.page} />}
+
+          {doc.page_range && <meta name="prism.endingPage" content={last_page} />}
+
+          <link title="schema(DC)" rel="schema.dc" href="http://purl.org/dc/elements/1.1/" />
+
+          {doc.doi && doc.doi.length > 0 && <meta name="dc.identifier" content={`doi:${doc.doi[0]}`} />}
+
+          {doc.pubdate && <meta name="dc.date" content={formatted_numeric_pubdate} />}
+
+          {doc.bibstem && doc.bibstem.length > 0 && <meta name="dc.source" content={doc.bibstem[0]} />}
+
+          <meta name="dc.title" content={title} />
+
+          {doc.author && authors.map((a, i) => <meta key={`dcc-${i}`} name="dc.creator" content={a} />)}
+        </>
       )}
-
-      {doc.page_range && <meta name="citation_lastpage" content={last_page} data-highwire="true" />}
-
-      {arXiv !== '' && <meta name="citation_arxiv_id" content={arXiv} data-highwire="true" />}
-
-      <link title="schema(PRISM)" rel="schema.prism" href="http://prismstandard.org/namespaces/1.2/basic/" />
-
-      {doc.pubdate && <meta name="prism.publicationDate" content={formatted_numeric_pubdate} />}
-
-      {doc.bibstem && doc.bibstem.length > 0 && <meta name="prism.publicationName" content={doc.bibstem[0]} />}
-
-      {doc.issn && doc.issn.length > 0 && <meta name="prism.issn" content={doc.issn[0]} />}
-
-      {doc.volume && <meta name="prism.volume" content={doc.volume} />}
-
-      {doc.page && <meta name="prism.startingPage" content={doc.page} />}
-
-      {doc.page_range && <meta name="prism.endingPage" content={last_page} />}
-
-      <link title="schema(DC)" rel="schema.dc" href="http://purl.org/dc/elements/1.1/" />
-
-      {doc.doi && doc.doi.length > 0 && <meta name="dc.identifier" content={`doi:${doc.doi[0]}`} />}
-
-      {doc.pubdate && <meta name="dc.date" content={formatted_numeric_pubdate} />}
-
-      {doc.bibstem && doc.bibstem.length > 0 && <meta name="dc.source" content={doc.bibstem[0]} />}
-
-      <meta name="dc.title" content={title} />
-
-      {doc.author && authors.map((a, i) => <meta key={`dcc-${i}`} name="dc.creator" content={a} />)}
 
       <meta name="twitter:card" content="summary" data-highwire="true" />
 

--- a/src/components/Metatags/__tests__/Metatags.test.tsx
+++ b/src/components/Metatags/__tests__/Metatags.test.tsx
@@ -357,25 +357,25 @@ describe('Metatags Component', () => {
   });
 
   describe('Edge Cases', () => {
-    test('handles PhD Thesis doctype', () => {
-      const doc = createMockDoc({ doctype: 'PhD Thesis' });
+    test('handles phdthesis doctype', () => {
+      const doc = createMockDoc({ doctype: 'phdthesis' });
       const { container } = render(<Metatags doc={doc} />);
 
       const dissertationTag = container.querySelector('meta[name="citation_dissertation_name"]');
       expect(dissertationTag?.getAttribute('content')).toBe('Phd');
     });
 
-    test('handles Masters Thesis doctype', () => {
-      const doc = createMockDoc({ doctype: 'Masters Thesis' });
+    test('handles mastersthesis doctype', () => {
+      const doc = createMockDoc({ doctype: 'mastersthesis' });
       const { container } = render(<Metatags doc={doc} />);
 
       const dissertationTag = container.querySelector('meta[name="citation_dissertation_name"]');
       expect(dissertationTag?.getAttribute('content')).toBe('MS');
     });
 
-    test('handles Proceedings doctype with conference tag', () => {
+    test('handles proceedings doctype with conference tag', () => {
       const doc = createMockDoc({
-        doctype: 'Proceedings',
+        doctype: 'proceedings',
         bibstem: ['SPIE'],
         pub: undefined,
       });
@@ -461,6 +461,72 @@ describe('Metatags Component', () => {
 
       const citationTitle = container.querySelector('meta[name="citation_title"]');
       expect(citationTitle?.getAttribute('content')).toBe('Study of Drosophila melanogaster and key findings');
+    });
+  });
+
+  describe('Google Scholar Doctype Gating', () => {
+    const countScholarTags = (container: HTMLElement) => ({
+      citation: container.querySelectorAll('meta[name^="citation_"]').length,
+      prism: container.querySelectorAll('meta[name^="prism."]').length,
+      dc: container.querySelectorAll('meta[name^="dc."]').length,
+    });
+
+    test('renders citation_, prism., and dc. tags for a whitelisted doctype', () => {
+      const doc = createMockDoc({ doctype: 'article' });
+      const { container } = render(<Metatags doc={doc} />);
+
+      const counts = countScholarTags(container);
+      expect(counts.citation).toBeGreaterThan(0);
+      expect(counts.prism).toBeGreaterThan(0);
+      expect(counts.dc).toBeGreaterThan(0);
+    });
+
+    test('omits all Google Scholar tags for a removed doctype', () => {
+      const doc = createMockDoc({ doctype: 'dataset' });
+      const { container } = render(<Metatags doc={doc} />);
+
+      const counts = countScholarTags(container);
+      expect(counts.citation).toBe(0);
+      expect(counts.prism).toBe(0);
+      expect(counts.dc).toBe(0);
+    });
+
+    test('omits all Google Scholar tags for an unlisted doctype', () => {
+      const doc = createMockDoc({ doctype: 'intechreport' });
+      const { container } = render(<Metatags doc={doc} />);
+
+      const counts = countScholarTags(container);
+      expect(counts.citation).toBe(0);
+      expect(counts.prism).toBe(0);
+      expect(counts.dc).toBe(0);
+    });
+
+    test('omits all Google Scholar tags when doctype is missing', () => {
+      const doc = createMockDoc({ doctype: undefined });
+      const { container } = render(<Metatags doc={doc} />);
+
+      const counts = countScholarTags(container);
+      expect(counts.citation).toBe(0);
+      expect(counts.prism).toBe(0);
+      expect(counts.dc).toBe(0);
+    });
+
+    test('matches the whitelist case-insensitively', () => {
+      const doc = createMockDoc({ doctype: 'ARTICLE' });
+      const { container } = render(<Metatags doc={doc} />);
+
+      expect(container.querySelectorAll('meta[name^="citation_"]').length).toBeGreaterThan(0);
+    });
+
+    test('keeps JSON-LD, OpenGraph, Twitter, canonical, and description for a removed doctype', () => {
+      const doc = createMockDoc({ doctype: 'software' });
+      const { container } = render(<Metatags doc={doc} />);
+
+      expect(container.querySelector('script[type="application/ld+json"]')).toBeTruthy();
+      expect(container.querySelector('meta[property="og:title"]')).toBeTruthy();
+      expect(container.querySelector('meta[name="twitter:card"]')).toBeTruthy();
+      expect(container.querySelector('link[rel="canonical"]')).toBeTruthy();
+      expect(container.querySelector('meta[name="description"]')).toBeTruthy();
     });
   });
 });

--- a/src/components/Metatags/scholarDoctypes.ts
+++ b/src/components/Metatags/scholarDoctypes.ts
@@ -1,0 +1,39 @@
+/**
+ * Doctypes permitted to emit Google Scholar-compatible meta tags on the
+ * abstract page. "Google Scholar-compatible" covers the Highwire
+ * (citation_*), PRISM (prism.*), and Dublin Core (dc.*) tag families.
+ *
+ * Only these doctypes display the tags; any other or unknown doctype omits
+ * them. The Schema.org JSON-LD block is emitted for all records regardless
+ * and is intentionally not gated by this list.
+ */
+export const GOOGLE_SCHOLAR_DOCTYPES: ReadonlySet<string> = new Set([
+  'article',
+  'eprint',
+  'phdthesis',
+  'circular',
+  'inbook',
+  'erratum',
+  'book',
+  'mastersthesis',
+  'inproceedings',
+  'abstract',
+  'techreport',
+  'bookreview',
+  'proceedings',
+  'editorial',
+  'newsletter',
+  'obituary',
+]);
+
+/**
+ * Returns true when the given doctype should display Google
+ * Scholar-compatible meta tags. Comparison is case-insensitive to
+ * tolerate inconsistent casing in upstream data.
+ */
+export const showsGoogleScholarTags = (doctype?: string): boolean => {
+  if (!doctype) {
+    return false;
+  }
+  return GOOGLE_SCHOLAR_DOCTYPES.has(doctype.toLowerCase());
+};


### PR DESCRIPTION
Google Scholar-compatible meta tags were emitted on every abstract page regardless of doctype. Per SCIX-877 only a defined set of doctypes should expose them; non-scholarly doctypes (proposal, dataset, software, misc, pressrelease, catalog, talk, service, instrument) should not.

- Added a doctype whitelist and showsGoogleScholarTags predicate (scholarDoctypes.ts), matched case-insensitively
- Gated the Highwire (citation_*), PRISM (prism.*), and Dublin Core (dc.*) tag families behind the whitelist on the abstract page
- Left Schema.org JSON-LD, Open Graph, Twitter, canonical, and description tags emitted for all records
- Normalized doctype comparisons to lowercase (fixes prior title-case checks for proceedings, phdthesis, mastersthesis)
- Added unit tests covering whitelisted, removed, unlisted, missing, and case-insensitive doctypes