### PR TITLE
SCIX-876 Change UAT facet to use uat field instead of uat_facet_hier

### DIFF
--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -123,6 +123,7 @@ export type FacetField =
   | 'nedtype_object_facet_hier'
   | 'simbad_object_facet_hier'
   | 'planetary_feature_facet_hier_3level'
+  | 'uat'
   | 'uat_facet_hier';
 
 export interface IFacetCountsFields {

--- a/src/components/AbstractSources/__tests__/createUrlByType.test.ts
+++ b/src/components/AbstractSources/__tests__/createUrlByType.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createUrlByType } from '@/components/AbstractSources/linkGenerator';
+
+describe('createUrlByType', () => {
+  it('encodes # in a DOI identifier', () => {
+    const url = createUrlByType(
+      '1999AN....320..163M',
+      'doi',
+      '10.1002/1521-3994(199908)320:4/5<163::AID-ASNA163>3.0.CO;2-#',
+    );
+    expect(url).not.toContain('#');
+    expect(url).toContain('%23');
+  });
+
+  it('encodes < and > in a DOI identifier', () => {
+    const url = createUrlByType('test', 'doi', '10.1000/foo<bar>');
+    expect(url).toContain('%3C');
+    expect(url).toContain('%3E');
+    expect(url).not.toContain('<');
+    expect(url).not.toContain('>');
+  });
+
+  it('preserves / in DOI identifiers', () => {
+    const url = createUrlByType('test', 'doi', '10.48550/arXiv.2507.19320');
+    expect(url).toContain('10.48550/arXiv.2507.19320');
+  });
+
+  it('returns empty string for non-string arguments', () => {
+    expect(createUrlByType(null as unknown as string, 'doi', '10.1000/x')).toBe('');
+    expect(createUrlByType('bib', null as unknown as string, '10.1000/x')).toBe('');
+    expect(createUrlByType('bib', 'doi', null as unknown as string)).toBe('');
+  });
+});

--- a/src/components/AbstractSources/__tests__/linkGenerator.test.ts
+++ b/src/components/AbstractSources/__tests__/linkGenerator.test.ts
@@ -108,7 +108,7 @@ describe('processLinkData', () => {
             rawType: 'INSTITUTION',
             shortName: 'My Institution',
             type: 'INSTITUTION',
-            url: 'http://my-link-server.com/?url_ver=Z39.88-2004&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rfr_id=info:sid/ADS&sid=ADS&id=doi:foo&genre=article&rft_id=info:doi/foo&rft.degree=false&rft.genre=article',
+            url: 'http://my-link-server.com/?url_ver=Z39.88-2004&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Aarticle&rfr_id=info%3Asid%2FADS&sid=ADS&id=doi%3Afoo&genre=article&rft_id=info%3Adoi%2Ffoo&rft.degree=false&rft.genre=article',
           },
         ],
         dataProducts: [],
@@ -163,7 +163,7 @@ describe('processLinkData', () => {
             rawType: 'INSTITUTION',
             shortName: 'My Institution',
             type: 'INSTITUTION',
-            url: 'http://my-link-server.com/?url_ver=Z39.88-2004&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rfr_id=info:sid/ADS&sid=ADS&id=doi:foo&genre=article&rft_id=info:doi/foo&rft_id=info:bibcode/test&rft.genre=article',
+            url: 'http://my-link-server.com/?url_ver=Z39.88-2004&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Aarticle&rfr_id=info%3Asid%2FADS&sid=ADS&id=doi%3Afoo&genre=article&rft_id=info%3Adoi%2Ffoo&rft_id=info%3Abibcode%2Ftest&rft.genre=article',
           },
           {
             description: 'Publisher PDF',

--- a/src/components/AbstractSources/__tests__/openUrlGenerator.test.ts
+++ b/src/components/AbstractSources/__tests__/openUrlGenerator.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { processLinkData } from '@/components/AbstractSources/linkGenerator';
+import { getOpenUrl } from '@/components/AbstractSources/openUrlGenerator';
 
 test('processLinkData produces correct output', () => {
   expect(
@@ -150,4 +151,16 @@ test('processLinkData can handle empty input', () => {
       'https://hollis.harvard.edu/openurl/01HVD/HVD_URL',
     ),
   ).toEqual(defaultReturn);
+});
+
+test('encodes # in DOI when building OpenURL', () => {
+  const url = getOpenUrl({
+    metadata: {
+      doi: ['10.1002/1521-3994(199908)320:4/5<163::AID-ASNA163>3.0.CO;2-#'],
+      bibcode: '1999AN....320..163M',
+    },
+    linkServer: 'https://example.com/openurl',
+  });
+  expect(url).not.toContain('#');
+  expect(url).toContain('%23');
 });

--- a/src/components/AbstractSources/linkGenerator.ts
+++ b/src/components/AbstractSources/linkGenerator.ts
@@ -4,6 +4,7 @@ import { getOpenUrl } from './openUrlGenerator';
 import { isNilOrEmpty, isNonEmptyString } from 'ramda-adjunct';
 import { IDataProductSource, IFullTextSource, ProcessLinkDataReturns } from '@/components/AbstractSources/types';
 import { Esources, IDocsEntity } from '@/api/search/types';
+import { encodeDOIPath } from '@/utils/common/encodeDOI';
 
 /**
  * Create the resolver url
@@ -139,7 +140,7 @@ export const processLinkData = (doc: IDocsEntity, linkServer?: string): ProcessL
  */
 export const createUrlByType = function (bibcode: string, type: string, identifier: string): string {
   if (typeof bibcode === 'string' && typeof type === 'string' && typeof identifier === 'string') {
-    return `${GATEWAY_BASE_URL + bibcode}/${type}:${identifier}`;
+    return `${GATEWAY_BASE_URL + bibcode}/${type}:${encodeDOIPath(identifier)}`;
   }
   return '';
 };

--- a/src/components/AbstractSources/openUrlGenerator.ts
+++ b/src/components/AbstractSources/openUrlGenerator.ts
@@ -53,10 +53,10 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
   const parsed: Record<string, string | string[]> = {
     ...STATIC_FIELDS,
     'rft.spage': isArray(page) ? page[0].split('-')[0] : undefined,
-    id: isArray(doi) ? 'doi:' + doi[0] : undefined,
+    id: isArray(doi) ? 'doi:' + encodeURIComponent(doi[0]) : undefined,
     genre: genre,
     rft_id: [
-      isArray(doi) ? 'info:doi/' + doi[0] : undefined,
+      isArray(doi) ? 'info:doi/' + encodeURIComponent(doi[0]) : undefined,
       isString(bibcode) ? 'info:bibcode/' + bibcode : undefined,
     ],
     'rft.degree': degree,
@@ -74,15 +74,15 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
   };
 
   interface IContext extends Partial<typeof parsed> {
-    spage: typeof parsed['rft.spage'];
-    volume: typeof parsed['rft.volume'];
-    title: typeof parsed['rft.jtitle'];
-    atitle: typeof parsed['rft.atitle'];
-    aulast: typeof parsed['rft.aulast'];
-    aufirst: typeof parsed['rft.aufirst'];
-    date: typeof parsed['rft.date'];
-    isbn: typeof parsed['rft.isbn'];
-    issn: typeof parsed['rft.issn'];
+    spage: (typeof parsed)['rft.spage'];
+    volume: (typeof parsed)['rft.volume'];
+    title: (typeof parsed)['rft.jtitle'];
+    atitle: (typeof parsed)['rft.atitle'];
+    aulast: (typeof parsed)['rft.aulast'];
+    aufirst: (typeof parsed)['rft.aufirst'];
+    date: (typeof parsed)['rft.date'];
+    isbn: (typeof parsed)['rft.isbn'];
+    issn: (typeof parsed)['rft.issn'];
   }
 
   // add extra fields to context object
@@ -116,5 +116,5 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
       return `${k}=${val}`;
     });
 
-  return encodeURI(openUrl + fields.join('&'));
+  return openUrl + fields.join('&');
 };

--- a/src/components/AbstractSources/openUrlGenerator.ts
+++ b/src/components/AbstractSources/openUrlGenerator.ts
@@ -53,10 +53,10 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
   const parsed: Record<string, string | string[]> = {
     ...STATIC_FIELDS,
     'rft.spage': isArray(page) ? page[0].split('-')[0] : undefined,
-    id: isArray(doi) ? 'doi:' + encodeURIComponent(doi[0]) : undefined,
+    id: isArray(doi) ? 'doi:' + doi[0] : undefined,
     genre: genre,
     rft_id: [
-      isArray(doi) ? 'info:doi/' + encodeURIComponent(doi[0]) : undefined,
+      isArray(doi) ? 'info:doi/' + doi[0] : undefined,
       isString(bibcode) ? 'info:bibcode/' + bibcode : undefined,
     ],
     'rft.degree': degree,
@@ -110,10 +110,10 @@ export const getOpenUrl = (options: IGetOpenUrlOptions): string => {
       if (isArray(val)) {
         return val
           .filter((v) => v)
-          .map((v) => `${k}=${v}`)
+          .map((v) => `${k}=${encodeURIComponent(String(v))}`)
           .join('&');
       }
-      return `${k}=${val}`;
+      return `${k}=${encodeURIComponent(String(val))}`;
     });
 
   return openUrl + fields.join('&');

--- a/src/components/Metatags/json-ld-abstract/__tests__/identifier.test.ts
+++ b/src/components/Metatags/json-ld-abstract/__tests__/identifier.test.ts
@@ -73,4 +73,16 @@ describe('collectIdentifiersFromArray', () => {
     expect(sa.has('https://hdl.handle.net/1234/abc')).toBe(true);
     expect(sa.size).toBe(3);
   });
+
+  it('encodes special characters in DOI sameAs URL', () => {
+    const { sameAs } = collectIdentifiersFromArray({
+      identifier: ['10.1002/1521-3994(199908)320:4/5<163::AID-ASNA163>3.0.CO;2-#'],
+    });
+    const doiLink = sameAs.find((u) => u.startsWith('https://doi.org/'));
+    expect(doiLink).toBeDefined();
+    expect(doiLink).not.toContain('#');
+    expect(doiLink).toContain('%23');
+    expect(doiLink).not.toContain('<');
+    expect(doiLink).toContain('%3C');
+  });
 });

--- a/src/components/Metatags/json-ld-abstract/identifiers.ts
+++ b/src/components/Metatags/json-ld-abstract/identifiers.ts
@@ -1,4 +1,5 @@
 import type { PropertyValue } from 'schema-dts';
+import { encodeDOIPath } from '@/utils/common/encodeDOI';
 
 /**
  * Minimal structure containing only identifiers we parse.
@@ -68,7 +69,7 @@ function buildSameAs(pvs: PropertyValue[]) {
     const v = String(value);
     switch (propertyID) {
       case 'DOI':
-        out.add(`https://doi.org/${v}`);
+        out.add(`https://doi.org/${encodeDOIPath(v)}`);
         break;
       case 'arXiv':
         out.add(`https://arxiv.org/abs/${v}`);

--- a/src/components/SearchFacet/config.ts
+++ b/src/components/SearchFacet/config.ts
@@ -131,14 +131,11 @@ export const facetConfig: Record<SearchFacetID, Omit<ISearchFacetProps, 'onQuery
   },
   uat: {
     label: 'UAT',
-    field: 'uat_facet_hier' as FacetField,
+    field: 'uat' as FacetField,
     hasChildren: false,
-    // UAT needs hierarchical API prefixing (0/) but has no expandable children
-    forceHierarchicalPrefix: true,
-    maxDepth: 1,
     logic: defaultLogic,
     storeId: 'uat',
     noLoadMore: true,
-    isLowerCase: true,
+    isLowerCase: false,
   },
 };

--- a/src/components/SearchFacet/helpers.ts
+++ b/src/components/SearchFacet/helpers.ts
@@ -127,7 +127,7 @@ export const cleanClause = curry((fqKey: string, clause: string) => {
   const operator = getOperator(clause);
 
   // for hierarchical facets, there is more processing to make it get the fields
-  if (fqKey === 'fq_author' || fqKey === 'fq_planetary_feature' || fqKey === 'fq_uat') {
+  if (fqKey === 'fq_author' || fqKey === 'fq_planetary_feature') {
     return pipe(
       map(pipe(replace(/["\\]/g, ''), parseTitleFromKey)),
 

--- a/src/components/SearchFacet/types.ts
+++ b/src/components/SearchFacet/types.ts
@@ -50,7 +50,7 @@ export const facetFields: FacetField[] = [
   'nedtype_object_facet_hier',
   'simbad_object_facet_hier',
   'planetary_feature_facet_hier_3level',
-  'uat_facet_hier',
+  'uat',
 ];
 
 export type SearchFacetID =

--- a/src/components/__mocks__/facetCountFields.ts
+++ b/src/components/__mocks__/facetCountFields.ts
@@ -20,6 +20,7 @@ export const facetFoundFieldsData: IFacetCountsFields = {
     property: [],
     simbad_object_facet_hier: [],
     planetary_feature_facet_hier_3level: [],
+    uat: [],
     uat_facet_hier: [],
   },
   facet_ranges: {},

--- a/src/mocks/generators/facets.ts
+++ b/src/mocks/generators/facets.ts
@@ -20,8 +20,8 @@ const createVal = (prefix: string, id: FacetField) => {
     case 'ned_object_facet_hier':
     case 'planetary_feature_facet_hier_3level':
       return `${prefix}${faker.lorem.words(2)}`;
-    case 'uat_facet_hier':
-      return `${prefix}${faker.lorem.words(2)}`;
+    case 'uat':
+      return faker.lorem.words(2);
 
     default:
       return `${faker.lorem.words(3)}`;

--- a/src/utils/common/__tests__/encodeDOI.test.ts
+++ b/src/utils/common/__tests__/encodeDOI.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { encodeDOIPath } from '../encodeDOI';
+
+describe('encodeDOIPath', () => {
+  it('encodes # as %23', () => {
+    expect(encodeDOIPath('10.1002/1521-3994(199908)320:4/5<163::AID-ASNA163>3.0.CO;2-#')).toBe(
+      '10.1002/1521-3994(199908)320%3A4/5%3C163%3A%3AAID-ASNA163%3E3.0.CO%3B2-%23',
+    );
+  });
+
+  it('encodes < and > as %3C and %3E', () => {
+    expect(encodeDOIPath('10.1000/foo<bar>baz')).toBe('10.1000/foo%3Cbar%3Ebaz');
+  });
+
+  it('encodes ? as %3F', () => {
+    expect(encodeDOIPath('10.1000/foo?bar')).toBe('10.1000/foo%3Fbar');
+  });
+
+  it('encodes space as %20', () => {
+    expect(encodeDOIPath('10.1000/foo bar')).toBe('10.1000/foo%20bar');
+  });
+
+  it('preserves / as a path separator', () => {
+    expect(encodeDOIPath('10.48550/arXiv.2507.19320')).toBe('10.48550/arXiv.2507.19320');
+  });
+
+  it('does not double-encode already-encoded sequences', () => {
+    // % itself gets encoded to %25, preventing double-encoding
+    expect(encodeDOIPath('10.1000/foo%23bar')).toBe('10.1000/foo%2523bar');
+  });
+
+  it('leaves a plain DOI unchanged', () => {
+    expect(encodeDOIPath('10.1086/345794')).toBe('10.1086/345794');
+  });
+});

--- a/src/utils/common/encodeDOI.ts
+++ b/src/utils/common/encodeDOI.ts
@@ -1,0 +1,10 @@
+/**
+ * Encodes a DOI value for safe insertion into a URL path.
+ *
+ * Uses encodeURIComponent to encode all URL-unsafe characters (#, ?, <, >, [, ],
+ * spaces, etc.) then restores '/' which is a legitimate path separator in both
+ * doi.org URLs and ADS gateway URLs.
+ */
+export function encodeDOIPath(doi: string): string {
+  return encodeURIComponent(doi).replace(/%2F/gi, '/');
+}


### PR DESCRIPTION
Changes the UAT search facet to query the uat field instead of uat_facet_hier.

- Updated UAT facet config to use the flat uat field (removed hierarchical prefixing)
- Added uat to the FacetField type and facet field list
- Removed fq_uat from the hierarchical cleanClause branch
- Updated facet mocks for the uat field