### PR TITLE
feat(observability): group /v1 API spans by domain and endpoint

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,12 +4,17 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { beforeSendApiSpan } from '@/lib/normalizeApiSpan';
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   tunnel: '/api/monitor',
   sendDefaultPii: false,
   enableLogs: true,
+
+  // Tag /v1/* API spans with normalized api.domain / api.endpoint for grouping.
+  beforeSendSpan: beforeSendApiSpan,
 
   // Add app tag for dashboard filtering
   initialScope: {

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,6 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { beforeSendApiSpan } from '@/lib/normalizeApiSpan';
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -14,6 +16,9 @@ Sentry.init({
       app: 'nectar',
     },
   },
+
+  // Tag /v1/* API spans with normalized api.domain / api.endpoint for grouping.
+  beforeSendSpan: beforeSendApiSpan,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { beforeSendApiSpan } from '@/lib/normalizeApiSpan';
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,6 +15,9 @@ Sentry.init({
       app: 'nectar',
     },
   },
+
+  // Tag /v1/* API spans with normalized api.domain / api.endpoint for grouping.
+  beforeSendSpan: beforeSendApiSpan,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,

--- a/src/components/ResultList/SimpleResultList.tsx
+++ b/src/components/ResultList/SimpleResultList.tsx
@@ -17,6 +17,9 @@ export interface ISimpleResultListProps extends HTMLAttributes<HTMLDivElement> {
   hideActions?: boolean;
   allowHighlight?: boolean;
   useNormCite?: boolean;
+  // Opt-in: this list is also used off the search page (abstract refs, library
+  // lists), which must not emit search.*.render spans.
+  measureRenderSpan?: boolean;
 }
 
 const propTypes = {
@@ -61,13 +64,14 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
     hideActions = false,
     allowHighlight = true,
     useNormCite = false,
+    measureRenderSpan = false,
     ...divProps
   } = props;
 
   const isClient = useIsClient();
   const start = indexStart + 1;
 
-  useResultsRenderSpan(docs);
+  useResultsRenderSpan(docs, measureRenderSpan);
 
   const { highlights, showHighlights, isFetchingHighlights } = useHighlights();
 

--- a/src/lib/normalizeApiSpan.test.ts
+++ b/src/lib/normalizeApiSpan.test.ts
@@ -1,0 +1,158 @@
+import { test, expect, describe } from 'vitest';
+
+import { beforeSendApiSpan, type SpanJSON } from '@/lib/normalizeApiSpan';
+
+function makeSpan(partial: Partial<SpanJSON>): SpanJSON {
+  return {
+    data: {},
+    span_id: 'span',
+    trace_id: 'trace',
+    start_timestamp: 0,
+    ...partial,
+  };
+}
+
+function tag(description: string): { domain?: unknown; endpoint?: unknown } {
+  const span = beforeSendApiSpan(makeSpan({ op: 'http.client', description }));
+  return { domain: span.data['api.domain'], endpoint: span.data['api.endpoint'] };
+}
+
+describe('beforeSendApiSpan', () => {
+  test('tags a bare endpoint (client host)', () => {
+    expect(tag('GET https://scixplorer.org/v1/accounts/bootstrap')).toEqual({
+      domain: 'accounts',
+      endpoint: '/v1/accounts/bootstrap',
+    });
+  });
+
+  test('tags an internal SSR host', () => {
+    expect(tag('GET http://api-gateway-nectar/v1/search/query')).toEqual({
+      domain: 'search',
+      endpoint: '/v1/search/query',
+    });
+  });
+
+  test('strips the query string', () => {
+    expect(tag('GET https://scixplorer.org/v1/search/query?q=star&rows=10')).toEqual({
+      domain: 'search',
+      endpoint: '/v1/search/query',
+    });
+  });
+
+  test('parameterizes a base64url library id', () => {
+    expect(tag('GET https://scixplorer.org/v1/biblib/libraries/BoDFB3aLS0epIdTMiFbxvg')).toEqual({
+      domain: 'biblib',
+      endpoint: '/v1/biblib/libraries/{id}',
+    });
+  });
+
+  test('parameterizes an ORCID id but keeps static sub-resources', () => {
+    expect(tag('GET https://scixplorer.org/v1/orcid/0000-0002-1825-0097/orcid-profile/full')).toEqual({
+      domain: 'orcid',
+      endpoint: '/v1/orcid/{id}/orcid-profile/full',
+    });
+  });
+
+  test('parameterizes a multi-id path (notes by library + bibcode)', () => {
+    expect(tag('PUT https://scixplorer.org/v1/biblib/notes/aBcDeF12/2023ApJ...123')).toEqual({
+      domain: 'biblib',
+      endpoint: '/v1/biblib/notes/{id}/{id}',
+    });
+  });
+
+  test('treats an email segment as dynamic (no PII leak)', () => {
+    const { endpoint } = tag('POST https://scixplorer.org/v1/accounts/user/reset-password/bob@example.com');
+    expect(endpoint).toBe('/v1/accounts/user/reset-password/{id}');
+  });
+
+  test('keeps a short static export format intact', () => {
+    expect(tag('POST https://scixplorer.org/v1/export/bibtex')).toEqual({
+      domain: 'export',
+      endpoint: '/v1/export/bibtex',
+    });
+  });
+
+  test('keeps a long static route word intact (site_wide_message, 17 chars)', () => {
+    expect(tag('GET https://scixplorer.org/v1/vault/configuration/site_wide_message')).toEqual({
+      domain: 'vault',
+      endpoint: '/v1/vault/configuration/site_wide_message',
+    });
+  });
+
+  test('keeps a long hyphenated/underscored static word intact (notification_query)', () => {
+    expect(tag('GET https://scixplorer.org/v1/vault/notification_query')).toEqual({
+      domain: 'vault',
+      endpoint: '/v1/vault/notification_query',
+    });
+  });
+
+  test('parameterizes a long opaque token that is not a plain route word', () => {
+    const { endpoint } = tag('GET https://scixplorer.org/v1/biblib/libraries/abc+def=ghijklmnop');
+    expect(endpoint).toBe('/v1/biblib/libraries/{id}');
+  });
+
+  test('handles a relative target with no host', () => {
+    expect(tag('GET /v1/metrics')).toEqual({
+      domain: 'metrics',
+      endpoint: '/v1/metrics',
+    });
+  });
+
+  test('strips a fragment on a relative target', () => {
+    expect(tag('GET /v1/search/query#section')).toEqual({
+      domain: 'search',
+      endpoint: '/v1/search/query',
+    });
+  });
+
+  test('clamps an unknown first segment to the `other` domain', () => {
+    expect(tag('GET https://scixplorer.org/v1/mystery/thing')).toEqual({
+      domain: 'other',
+      endpoint: '/v1/mystery/thing',
+    });
+  });
+
+  test('redacts a dynamic first segment so it cannot leak as a raw value', () => {
+    expect(tag('GET https://scixplorer.org/v1/bob@example.com/reset')).toEqual({
+      domain: 'other',
+      endpoint: '/v1/{id}/reset',
+    });
+  });
+
+  test('redacts a token-like first segment', () => {
+    expect(tag('GET https://scixplorer.org/v1/BoDFB3aLS0epIdTMiFbxvg/thing')).toEqual({
+      domain: 'other',
+      endpoint: '/v1/{id}/thing',
+    });
+  });
+
+  test('preserves pre-existing span.data', () => {
+    const span = beforeSendApiSpan(
+      makeSpan({
+        op: 'http.client',
+        description: 'GET https://scixplorer.org/v1/search/query',
+        data: { 'http.request.method': 'GET' },
+      }),
+    );
+    expect(span.data['http.request.method']).toBe('GET');
+    expect(span.data['api.domain']).toBe('search');
+  });
+
+  test('ignores non-http.client spans', () => {
+    const span = beforeSendApiSpan(makeSpan({ op: 'ui.render', description: 'GET /v1/search/query' }));
+    expect(span.data['api.domain']).toBeUndefined();
+  });
+
+  test('ignores http.client spans that are not /v1 API calls', () => {
+    const span = beforeSendApiSpan(
+      makeSpan({ op: 'http.client', description: 'GET https://www.google-analytics.com/g/collect' }),
+    );
+    expect(span.data['api.domain']).toBeUndefined();
+    expect(span.data['api.endpoint']).toBeUndefined();
+  });
+
+  test('passes through a span with no description', () => {
+    const span = beforeSendApiSpan(makeSpan({ op: 'http.client' }));
+    expect(span.data['api.domain']).toBeUndefined();
+  });
+});

--- a/src/lib/normalizeApiSpan.ts
+++ b/src/lib/normalizeApiSpan.ts
@@ -1,4 +1,4 @@
-import type { spanToJSON } from '@sentry/nextjs';
+import { spanToJSON } from '@sentry/nextjs';
 
 // @sentry/nextjs doesn't re-export SpanJSON, so derive it from spanToJSON.
 export type SpanJSON = ReturnType<typeof spanToJSON>;

--- a/src/lib/normalizeApiSpan.ts
+++ b/src/lib/normalizeApiSpan.ts
@@ -1,0 +1,111 @@
+import type { spanToJSON } from '@sentry/nextjs';
+
+// @sentry/nextjs doesn't re-export SpanJSON, so derive it from spanToJSON.
+export type SpanJSON = ReturnType<typeof spanToJSON>;
+
+// Known backend tiers (segment after /v1/). Anything else is clamped to `other`
+// so a malformed path can never emit an arbitrary value as the tier label.
+const API_DOMAINS = new Set([
+  'search',
+  'objects',
+  'accounts',
+  'vault',
+  'biblib',
+  'orcid',
+  'export',
+  'metrics',
+  'resolver',
+  'vis',
+  'journals',
+  'graphics',
+  'reference',
+  'citation_helper',
+  'author-affiliation',
+  'feedback',
+]);
+
+// A segment is dynamic (replaced with `{id}`) when it looks like an identifier
+// or could carry PII; known static route words stay intact.
+function isDynamicSegment(segment: string): boolean {
+  // digits: ids, bibcodes, ORCIDs, issns, putcodes, qids
+  if (/[0-9]/.test(segment)) {
+    return true;
+  }
+  // uppercase: base64url library ids
+  if (/[A-Z]/.test(segment)) {
+    return true;
+  }
+  // emails, dotted ids, encoded free text
+  if (/[@%.:,;]/.test(segment)) {
+    return true;
+  }
+  // Long opaque tokens are ids, but plain lowercase route words (with `-`/`_`)
+  // are static even when long — e.g. `site_wide_message`, `notification_query`.
+  if (segment.length > 16 && !/^[a-z][a-z_-]*$/.test(segment)) {
+    return true;
+  }
+  return false;
+}
+
+interface ParsedApiSpan {
+  domain: string;
+  endpoint: string;
+}
+
+function parseApiSpan(description: string): ParsedApiSpan | null {
+  // Description is usually "<METHOD> <url-or-path>".
+  const spaceIdx = description.indexOf(' ');
+  const rawTarget = spaceIdx === -1 ? description : description.slice(spaceIdx + 1);
+
+  let pathname: string;
+  try {
+    pathname = new URL(rawTarget).pathname;
+  } catch {
+    // Relative target: drop query and fragment manually.
+    pathname = rawTarget.split(/[?#]/)[0];
+  }
+
+  const v1Idx = pathname.indexOf('/v1/');
+  if (v1Idx === -1) {
+    return null;
+  }
+
+  const segments = pathname
+    .slice(v1Idx + '/v1/'.length)
+    .split('/')
+    .filter(Boolean);
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const [firstSegment] = segments;
+  // Redact every dynamic segment, including the first, so an unknown segment
+  // can't leak an id or PII. Domain still derives from the raw first segment.
+  const endpointSegments = segments.map((segment) => (isDynamicSegment(segment) ? '{id}' : segment));
+
+  return {
+    domain: API_DOMAINS.has(firstSegment) ? firstSegment : 'other',
+    endpoint: `/v1/${endpointSegments.join('/')}`,
+  };
+}
+
+// Sentry beforeSendSpan: tags /v1/* http.client spans with low-cardinality
+// api.domain / api.endpoint for grouping. Client spans only carry the full URL
+// in description (url.path/http.route are null), so we derive both here.
+export function beforeSendApiSpan(span: SpanJSON): SpanJSON {
+  if (span.op !== 'http.client' || !span.description) {
+    return span;
+  }
+
+  const parsed = parseApiSpan(span.description);
+  if (!parsed) {
+    return span;
+  }
+
+  span.data = {
+    ...span.data,
+    'api.domain': parsed.domain,
+    'api.endpoint': parsed.endpoint,
+  };
+  return span;
+}

--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -4,8 +4,8 @@ import type { IADSApiSearchParams } from '@/api/search/types';
 export type ResultCountBucket = '0' | '1-10' | '11-100' | '100+';
 export type QueryType = 'simple' | 'fielded' | 'boolean';
 
-// Span slots: opened in Telemetry while the nav transaction is live, closed after paint.
-// Each slot is a module-level singleton — client-only, one browser instance per process.
+// Span slot: opened in Telemetry when docs arrive, closed on full-text click.
+// Module-level singleton — client-only, one browser instance per process.
 function makeSpanSlot(name: string, op: string) {
   let _span: ReturnType<typeof Sentry.startInactiveSpan> | null = null;
   return {
@@ -31,14 +31,8 @@ function makeSpanSlot(name: string, op: string) {
   };
 }
 
-const resultsSlot = makeSpanSlot('search.results.render', 'ui.render');
-const facetsSlot = makeSpanSlot('search.facets.render', 'ui.render');
 const fullTextSlot = makeSpanSlot('ux.full_text_time', 'user.flow');
 
-export const openResultsRenderSpan = (): void => resultsSlot.open();
-export const closeResultsRenderSpan = (docCount: number): void => resultsSlot.close({ doc_count: docCount });
-export const openFacetsRenderSpan = (): void => facetsSlot.open();
-export const closeFacetsRenderSpan = (): void => facetsSlot.close();
 export const openFullTextTimingSpan = (): void => fullTextSlot.open();
 export const closeFullTextTimingSpan = (): void => fullTextSlot.close();
 

--- a/src/lib/useRenderSpan.ts
+++ b/src/lib/useRenderSpan.ts
@@ -1,17 +1,76 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
 
 import { IDocsEntity } from '@/api/search/types';
-import { closeFacetsRenderSpan, closeResultsRenderSpan } from '@/lib/performance';
+import { PERF_SPANS } from '@/lib/performance';
 
-// Closes both render spans (opened in Telemetry) after the results list paints.
-// Both results and facets respond to the same docs state update and render in the
-// same React commit, so SimpleResultList's useEffect is a reliable proxy for both.
-export function useResultsRenderSpan(docs: IDocsEntity[]): void {
-  useEffect(() => {
-    if (docs.length === 0) {
+// Paint timing for the search results list: open after DOM commit
+// (useLayoutEffect), close after paint (rAF). Results and facets share one
+// lifecycle — they render in the same React commit.
+//
+// Opt-in via `enabled`: SimpleResultList is shared (abstract refs, library
+// lists), and only search should emit search.* spans. The list mounts only
+// after a search completes, so a zero-result render still counts.
+export function useResultsRenderSpan(docs: IDocsEntity[], enabled = false): void {
+  const resultsSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+  const facetsSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  // Open after DOM commit, before the browser paints.
+  useLayoutEffect(() => {
+    if (!enabled) {
       return;
     }
-    closeResultsRenderSpan(docs.length);
-    closeFacetsRenderSpan();
-  }, [docs]);
+    try {
+      resultsSpanRef.current?.end();
+      facetsSpanRef.current?.end();
+      resultsSpanRef.current = Sentry.startInactiveSpan({
+        name: PERF_SPANS.SEARCH_RESULTS_RENDER,
+        op: 'ui.render',
+      });
+      facetsSpanRef.current = Sentry.startInactiveSpan({
+        name: PERF_SPANS.SEARCH_FACETS_RENDER,
+        op: 'ui.render',
+      });
+    } catch {}
+  }, [docs, enabled]);
+
+  // Close after the browser has painted.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+    }
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      try {
+        if (resultsSpanRef.current) {
+          resultsSpanRef.current.setAttributes({ doc_count: docs.length });
+          resultsSpanRef.current.setStatus({ code: 1 });
+          resultsSpanRef.current.end();
+          resultsSpanRef.current = null;
+        }
+        if (facetsSpanRef.current) {
+          facetsSpanRef.current.setStatus({ code: 1 });
+          facetsSpanRef.current.end();
+          facetsSpanRef.current = null;
+        }
+      } catch {}
+    });
+  }, [docs, enabled]);
+
+  // Cancel pending rAF and end any open spans on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      try {
+        resultsSpanRef.current?.end();
+        facetsSpanRef.current?.end();
+      } catch {}
+    };
+  }, []);
 }

--- a/src/lib/useRenderSpan.ts
+++ b/src/lib/useRenderSpan.ts
@@ -4,6 +4,10 @@ import * as Sentry from '@sentry/nextjs';
 import { IDocsEntity } from '@/api/search/types';
 import { PERF_SPANS } from '@/lib/performance';
 
+// Avoids the "useLayoutEffect does nothing on the server" SSR warning for
+// components like SimpleResultList that can be rendered server-side.
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
 // Paint timing for the search results list: open after DOM commit
 // (useLayoutEffect), close after paint (rAF). Results and facets share one
 // lifecycle — they render in the same React commit.
@@ -17,8 +21,14 @@ export function useResultsRenderSpan(docs: IDocsEntity[], enabled = false): void
   const rafRef = useRef<number | null>(null);
 
   // Open after DOM commit, before the browser paints.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!enabled) {
+      try {
+        resultsSpanRef.current?.end();
+        facetsSpanRef.current?.end();
+      } catch {}
+      resultsSpanRef.current = null;
+      facetsSpanRef.current = null;
       return;
     }
     try {
@@ -38,6 +48,10 @@ export function useResultsRenderSpan(docs: IDocsEntity[], enabled = false): void
   // Close after the browser has painted.
   useEffect(() => {
     if (!enabled) {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
       return;
     }
     if (rafRef.current !== null) {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -429,6 +429,7 @@ const SearchPage: NextPage = () => {
                             docs={data.response.docs}
                             indexStart={params.start}
                             useNormCite={sort.startsWith('citation_count_norm')}
+                            measureRenderSpan
                           />
                         </ErrorBoundary>
                       )}

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -14,8 +14,6 @@ import {
   PERF_SPANS,
   getResultCountBucket,
   getQueryType,
-  openResultsRenderSpan,
-  openFacetsRenderSpan,
   openFullTextTimingSpan,
   closeFullTextTimingSpan,
   getPageNumber,
@@ -142,10 +140,6 @@ const Telemetry: FC = () => {
         paginationSpanRef.current.end();
         paginationSpanRef.current = null;
       }
-      // Open while the nav transaction is still alive; both render spans closed
-      // together by useResultsRenderSpan in SimpleResultList after paint.
-      openResultsRenderSpan();
-      openFacetsRenderSpan();
       openFullTextTimingSpan();
     } catch (err) {
       logger.error({ err }, 'Telemetry: docs span error');


### PR DESCRIPTION
  Sentry couldn't tell our API calls apart. Client http.client spans only carry the full URL in span.description, so everything grouped on raw descriptions with query strings. The
  search.results.render / search.facets.render spans also opened from the shared result list, so they fired on non-search pages too.

  1. Tag /v1/* spans in all three runtimes via a beforeSendSpan hook: api.domain (allowlisted backend tier, else other) and api.endpoint (path only, query/fragment stripped).
  2. Redact every dynamic path segment
  3. Measure the render spans at paint time
  4. Gate those spans behind an opt-in measureRenderSpan prop so only the search page emits them, while still counting zero-result searches.
