### PR TITLE
SCIX-889 fix(search): sort operator queries by score instead of user preference

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ import { useSettings } from '@/lib/useSettings';
 import { NotificationId } from '@/store/slices';
 import { SearchBar } from '@/components/SearchBar';
 import { SimpleLink } from '@/components/SimpleLink';
-import { makeSearchParams, normalizeSolrSort } from '@/utils/common/search';
+import { getDefaultSortForQuery, makeSearchParams, normalizeSolrSort } from '@/utils/common/search';
 import { SolrSort } from '@/api/models';
 import { SearchExamples } from '@/components/SearchExamples/SearchExamples';
 import { Pager } from '@/components/Pager/Pager';
@@ -142,7 +142,8 @@ const HomePage: NextPage = () => {
       if (query && query.trim().length > 0) {
         setIsLoading(true);
         submitQuery();
-        const defaultedQuery = applyDefaultFilters({ q: query, sort, p: 1 }) as IADSApiSearchParams;
+        const querySortOverride = getDefaultSortForQuery(query, sort);
+        const defaultedQuery = applyDefaultFilters({ q: query, sort: querySortOverride, p: 1 }) as IADSApiSearchParams;
         void router
           .push({
             pathname: '/search',

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -52,7 +52,7 @@ import { XMarkIcon } from '@heroicons/react/20/solid';
 import { CustomInfoMessage } from '@/components/Feedbacks';
 import { CheckCircleIcon } from '@chakra-ui/icons';
 import { SimpleLink } from '@/components/SimpleLink';
-import { makeSearchParams, normalizeSolrSort, parseQueryFromUrl } from '@/utils/common/search';
+import { getDefaultSortForQuery, makeSearchParams, normalizeSolrSort, parseQueryFromUrl } from '@/utils/common/search';
 import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
 import { sendGTMEvent } from '@next/third-parties/google';
@@ -258,7 +258,8 @@ const SearchPage: NextPage = () => {
     clearSelectedDocs();
 
     // generate a URL search string and trigger a page transition, and update store
-    const search = makeSearchParams({ ...params, ...query, q, p: 1 });
+    const overriddenSort = getDefaultSortForQuery(q, params.sort);
+    const search = makeSearchParams({ ...params, ...query, q, sort: overriddenSort, p: 1 });
     void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
   };
 

--- a/src/utils/common/__tests__/search.test.ts
+++ b/src/utils/common/__tests__/search.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { getDefaultSortForQuery } from '@/utils/common/search';
+import { SolrSort } from '@/api/models';
+
+const PREF_SORT: SolrSort[] = ['date desc', 'score desc'];
+
+describe('getDefaultSortForQuery', () => {
+  describe('second-order operator queries — returns score desc', () => {
+    test.each([
+      ['trending(collection:astronomy)', 'trending'],
+      ['reviews(author:kurtz)', 'reviews'],
+      ['useful(author:kurtz)', 'useful'],
+      ['similar(bibcode:2020ApJ)', 'similar'],
+      ['TRENDING(collection:astronomy)', 'trending upper-case'],
+      ['trending (collection:astronomy)', 'trending with space before paren'],
+    ])('%s', (q) => {
+      const result = getDefaultSortForQuery(q, PREF_SORT);
+      expect(result[0]).toBe('score desc');
+    });
+  });
+
+  describe('regular queries — returns fallback', () => {
+    test.each([['star formation'], ['author:kurtz'], ['trending_topic:foo'], [''], ['reviews_count > 5']])(
+      '%s',
+      (q) => {
+        expect(getDefaultSortForQuery(q, PREF_SORT)).toBe(PREF_SORT);
+      },
+    );
+  });
+});

--- a/src/utils/common/__tests__/search.test.ts
+++ b/src/utils/common/__tests__/search.test.ts
@@ -20,11 +20,16 @@ describe('getDefaultSortForQuery', () => {
   });
 
   describe('regular queries — returns fallback', () => {
-    test.each([['star formation'], ['author:kurtz'], ['trending_topic:foo'], [''], ['reviews_count > 5']])(
-      '%s',
-      (q) => {
-        expect(getDefaultSortForQuery(q, PREF_SORT)).toBe(PREF_SORT);
-      },
-    );
+    test.each([
+      ['star formation'],
+      ['author:kurtz'],
+      ['trending_topic:foo'],
+      [''],
+      ['reviews_count > 5'],
+      ['title:trending(foo)'],
+      ['"trending("'],
+    ])('%s', (q) => {
+      expect(getDefaultSortForQuery(q, PREF_SORT)).toBe(PREF_SORT);
+    });
   });
 });

--- a/src/utils/common/search.ts
+++ b/src/utils/common/search.ts
@@ -175,7 +175,7 @@ export const normalizeSolrSort = (rawSolrSort: unknown, postfixSort?: SolrSort):
 };
 
 // Matches second-order operator queries that should default to relevance sort.
-const SECOND_ORDER_OPERATOR_RE = /\b(trending|reviews|useful|similar)\s*\(/i;
+const SECOND_ORDER_OPERATOR_RE = /^\s*[+-]?(trending|reviews|useful|similar)\s*\(/i;
 
 /**
  * Returns the appropriate default sort for a query. Second-order operator queries

--- a/src/utils/common/search.ts
+++ b/src/utils/common/search.ts
@@ -174,6 +174,17 @@ export const normalizeSolrSort = (rawSolrSort: unknown, postfixSort?: SolrSort):
   return uniq(validSort.concat(tieBreaker));
 };
 
+// Matches second-order operator queries that should default to relevance sort.
+const SECOND_ORDER_OPERATOR_RE = /\b(trending|reviews|useful|similar)\s*\(/i;
+
+/**
+ * Returns the appropriate default sort for a query. Second-order operator queries
+ * (trending, reviews, useful, similar) sort by relevance score; all others use
+ * the provided fallback (typically the user's saved preference).
+ */
+export const getDefaultSortForQuery = (q: string, fallback: SolrSort[]): SolrSort[] =>
+  SECOND_ORDER_OPERATOR_RE.test(q) ? normalizeSolrSort(['score desc']) : fallback;
+
 /**
  * Splits a string by a given delimiter or returns the array if the input is already an array.
  *


### PR DESCRIPTION
Manually typing a second-order operator query (trending, reviews, useful, similar) used the user's saved default sort instead of score desc. The Explore menu path already injected the correct sort; only the manual submit handlers were affected.

- Adds getDefaultSortForQuery() to the search utils — returns score desc for operator queries, fallback sort for everything else
- Applies at both submit handlers: home page and search page
- Adds unit tests for operator detection and regular query passthrough