### PR TITLE
SCIX-891 feat(api): add X-Ui-Tag header to all outbound API calls

### DIFF
--- a/src/api/__tests__/api.test.ts
+++ b/src/api/__tests__/api.test.ts
@@ -162,9 +162,7 @@ test('Fallback to bootstrapping directly if the /api/user endpoint continuously 
 
   // the refresh header was added to force a new session
   expect(onReq.mock.calls[1][0].headers.get('x-refresh-token')).toMatchInlineSnapshot('"1"');
-  expect(onReq.mock.calls[3][0].headers.get('authorization')).toMatchInlineSnapshot(
-    '"Bearer mocked-anonymous-token"',
-  );
+  expect(onReq.mock.calls[3][0].headers.get('authorization')).toMatchInlineSnapshot('"Bearer mocked-anonymous-token"');
 });
 
 test('passing token initially skips bootstrap', async ({ server }: TestContext) => {
@@ -296,6 +294,17 @@ test('request rejects if the refreshed user data is not valid', async ({ server 
   expect(onReq).toBeCalledTimes(3);
   expect(urls(onReq)).toStrictEqual(['/test', API_USER, ApiTargets.BOOTSTRAP]);
   expect(onReq.mock.calls[1][0].headers.get('x-refresh-token')).toEqual('1');
+});
+
+test('request interceptor sets X-Ui-Tag header from ui_tag', async ({ server }: TestContext) => {
+  const { onRequest: onReq } = createServerListenerMocks(server);
+  server.use(testHandlerWith200);
+  api.setUserData(mockUserData);
+
+  await api.request({ method: 'GET', url: '/test', ui_tag: 'search/primary' } as ApiRequestConfig);
+
+  expect(onReq).toHaveBeenCalledOnce();
+  expect(onReq.mock.calls[0][0].headers.get('x-ui-tag')).toEqual('search/primary');
 });
 
 test('duplicate requests are provided the same promise', async ({ server }: TestContext) => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -109,6 +109,14 @@ class Api {
   }
 
   private async init() {
+    this.service.interceptors.request.use((config) => {
+      if ((config as ApiRequestConfig).ui_tag) {
+        config.headers['X-Ui-Tag'] = (config as ApiRequestConfig).ui_tag;
+        delete (config as ApiRequestConfig).ui_tag;
+      }
+      return config;
+    });
+
     this.service.interceptors.response.use(identity, (error: AxiosError & { canRefresh: boolean }) => {
       // Use global error handler (skip Sentry as React Query will handle it)
       handleAPIError(error, error.config?.url, {

--- a/src/api/author-affiliation/author-affiliation.ts
+++ b/src/api/author-affiliation/author-affiliation.ts
@@ -10,8 +10,11 @@ export const authorAffiliationsKeys = {
   export: (params: IAuthorAffiliationExportPayload) => ['authoraffiliation/export', params] as const,
 };
 
-type SearchQuery = ADSQuery<Parameters<typeof authorAffiliationsKeys['search']>[0], IAuthorAffiliationResponse['data']>;
-type ExportQuery = ADSQuery<Parameters<typeof authorAffiliationsKeys['export']>[0], string>;
+type SearchQuery = ADSQuery<
+  Parameters<(typeof authorAffiliationsKeys)['search']>[0],
+  IAuthorAffiliationResponse['data']
+>;
+type ExportQuery = ADSQuery<Parameters<(typeof authorAffiliationsKeys)['export']>[0], string>;
 
 export const useAuthorAffiliationSearch: SearchQuery = (params, options) => {
   const searchParams = getAuthorAffiliationSearchParams(params);
@@ -39,6 +42,7 @@ export const fetchAuthorAffiliationSearch: QueryFunction<IAuthorAffiliationRespo
     method: 'POST',
     url: ApiTargets.AUTHOR_AFFILIATION_SEARCH,
     data: params,
+    ui_tag: 'author-affiliation/search',
   };
 
   const { data } = await api.request<IAuthorAffiliationResponse>(config);
@@ -53,6 +57,7 @@ export const fetchAuthorAffiliationExport: QueryFunction<string> = async ({ meta
     method: 'POST',
     url: ApiTargets.AUTHOR_AFFILIATION_EXPORT,
     data: params,
+    ui_tag: 'author-affiliation/export',
   };
 
   const { data } = await api.request<string>(config);

--- a/src/api/biblib/libraries.ts
+++ b/src/api/biblib/libraries.ts
@@ -95,6 +95,7 @@ export const fetchLibraries: QueryFunction<IADSApiLibraryResponse> = async ({ me
     method: 'GET',
     url: ApiTargets.LIBRARIES,
     params,
+    ui_tag: 'library/libraries',
   };
 
   return trackUserFlow(PERF_SPANS.LIBRARY_LIST_LOAD, async () => {
@@ -119,6 +120,7 @@ export const addLibrary: MutationFunction<IADSApiLibraryAddResponse, IADSApiLibr
     method: 'POST',
     url: `${ApiTargets.LIBRARIES}`,
     data: params,
+    ui_tag: 'library/add',
   };
 
   return trackUserFlow(PERF_SPANS.LIBRARY_CREATE_TOTAL, async () => {
@@ -145,6 +147,7 @@ export const fetchLibraryEntity: QueryFunction<IADSApiLibraryEntityResponse> = a
     method: 'GET',
     url: `${ApiTargets.LIBRARIES}/${params.id}`,
     params: omit(['id'], params),
+    ui_tag: 'library/library',
   };
 
   const { data } = await api.request<IADSApiLibraryEntityResponse>(config);
@@ -170,6 +173,7 @@ export const deleteLibrary: MutationFunction<IADSApiLibraryDeleteResponse, IADSA
   const config: ApiRequestConfig = {
     method: 'DELETE',
     url: `${ApiTargets.DOCUMENTS}/${id}`,
+    ui_tag: 'library/delete',
   };
 
   const { data } = await api.request<IADSApiLibraryDeleteResponse>(config);
@@ -195,6 +199,7 @@ export const editLibraryMeta: MutationFunction<IADSApiLibraryEditMetaResponse, I
     method: 'PUT',
     url: `${ApiTargets.DOCUMENTS}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/edit',
   };
 
   const { data } = await api.request<IADSApiLibraryEditMetaResponse>(config);
@@ -221,6 +226,7 @@ export const editLibraryDocuments: MutationFunction<
     method: 'POST',
     url: `${ApiTargets.DOCUMENTS}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/document',
   };
 
   return trackUserFlow(PERF_SPANS.LIBRARY_ADD_TOTAL, async () => {
@@ -250,6 +256,7 @@ export const operation: MutationFunction<IADSApiLibraryOperationResponse, IADSAp
     method: 'POST',
     url: `${ApiTargets.LIBRARY_OPERATION}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/operation',
   };
 
   const { data } = await api.request<IADSApiLibraryOperationResponse>(config);
@@ -276,6 +283,7 @@ export const addDocumentsByQuery: MutationFunction<IADSApiLibraryQueryResponse, 
     method: 'POST',
     url: `${ApiTargets.LIBRARY_QUERY}/${params.id}`,
     data: params,
+    ui_tag: 'library/query',
   };
 
   const { data } = await api.request<IADSApiLibraryQueryResponse>(config);
@@ -302,6 +310,7 @@ export const updateDocumentsByQuery: MutationFunction<
     method: 'POST',
     url: `${ApiTargets.LIBRARY_QUERY}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/query-update',
   };
 
   const { data } = await api.request<IADSApiLibraryQueryUpdateResponse>(config);
@@ -327,6 +336,7 @@ export const getPermission: QueryFunction<IADSApiLibraryPermissionResponse> = as
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.PERMISSIONS}/${params.id}`,
+    ui_tag: 'library/permission',
   };
 
   const { data } = await api.request<IADSApiLibraryPermissionResponse>(config);
@@ -353,6 +363,7 @@ export const modifyPermission: MutationFunction<
     method: 'POST',
     url: `${ApiTargets.PERMISSIONS}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/permission-update',
   };
 
   const { data } = await api.request<IADSApiLibraryPermissionUpdateResponse>(config);
@@ -379,6 +390,7 @@ export const transfer: MutationFunction<IADSApiLibraryTransferResponse, IADSApiL
     method: 'POST',
     url: `${ApiTargets.LIBRARY_TRANSFER}/${params.id}`,
     data: omit(['id'], params),
+    ui_tag: 'library/transfer',
   };
 
   const { data } = await api.request<IADSApiLibraryTransferResponse>(config);
@@ -407,6 +419,7 @@ export const fetchAnnotation: QueryFunction<IADSApiLibraryGetAnnotationResponse>
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.LIBRARY_NOTES}/${params.library}/${params.bibcode}`,
+    ui_tag: 'library/get-annotation',
   };
 
   const { data } = await api.request<IADSApiLibraryGetAnnotationResponse>(config);
@@ -435,6 +448,7 @@ export const addAnnotation: MutationFunction<
     method: 'POST',
     url: `${ApiTargets.LIBRARY_NOTES}/${params.library}/${params.bibcode}`,
     data: { content: params.content },
+    ui_tag: 'library/add-annotation',
   };
 
   const { data } = await api.request<IADSApiLibraryAddAnnotationResponse>(config);
@@ -463,6 +477,7 @@ export const updateAnnotation: MutationFunction<
     method: 'PUT',
     url: `${ApiTargets.LIBRARY_NOTES}/${params.library}/${params.bibcode}`,
     data: { content: params.content },
+    ui_tag: 'library/update-annotation',
   };
 
   const { data } = await api.request<IADSApiLibraryAddAnnotationResponse>(config);
@@ -490,6 +505,7 @@ export const deleteAnnotation: MutationFunction<
   const config: ApiRequestConfig = {
     method: 'DELETE',
     url: `${ApiTargets.LIBRARY_NOTES}/${params.library}/${params.bibcode}`,
+    ui_tag: 'library/delete-annotation',
   };
 
   const { data } = await api.request<IADSApiLibraryDeleteAnnotationResponse>(config);

--- a/src/api/citation_helper/citation_helper.ts
+++ b/src/api/citation_helper/citation_helper.ts
@@ -24,6 +24,7 @@ export const fetchCitationHelper: QueryFunction<ICitationHelperResponse> = async
     method: 'POST',
     url: ApiTargets.SERVICE_CITATION_HELPER,
     data: params,
+    ui_tag: 'citation-helper/primary',
   };
 
   const { data } = await api.request<ICitationHelperResponse>(config);

--- a/src/api/export/export.ts
+++ b/src/api/export/export.ts
@@ -36,6 +36,7 @@ export const fetchExportFormats: QueryFunction<ExportFormatsApiResponse> = async
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.EXPORT_MANIFEST,
+    ui_tag: 'export/manifest',
   };
 
   const { data } = await api.request<ExportFormatsApiResponse>(config);
@@ -58,6 +59,7 @@ export const fetchExportCitation: QueryFunction<IExportApiResponse> = async ({ m
       ...params,
       ...(format === ExportApiFormatKey.custom ? { format: customFormat } : {}),
     },
+    ui_tag: 'export/citation',
   };
 
   return trackUserFlow(PERF_SPANS.EXPORT_API_REQUEST, async () => {

--- a/src/api/feedback/feedback.ts
+++ b/src/api/feedback/feedback.ts
@@ -21,6 +21,7 @@ const feedbackQueryFn: MutationFunction<IADSApiFeedbackResponse, Partial<IFeedba
     method: 'POST',
     url: ApiTargets.FEEDBACK,
     data: params,
+    ui_tag: 'feedback/primary',
   };
 
   const { data } = await api.request<IADSApiFeedbackResponse>(config);

--- a/src/api/graphics/graphics.ts
+++ b/src/api/graphics/graphics.ts
@@ -65,6 +65,7 @@ export const fetchGraphics: QueryFunction<IADSApiGraphicsResponse> = async ({ me
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.GRAPHICS}/${params.bibcode}`,
+    ui_tag: 'graphics/primary',
   };
 
   const { data: graphics } = await api.request<IADSApiGraphicsResponse>(config);

--- a/src/api/journals/journals.ts
+++ b/src/api/journals/journals.ts
@@ -48,6 +48,7 @@ export const fetchJournal: QueryFunction<IADSApiJournalsJournalResponse> = async
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.JOURNAL}/${params.term}`,
+    ui_tag: 'journals/journal',
   };
 
   const { data } = await api.request<IADSApiJournalsJournalResponse>(config);
@@ -71,6 +72,7 @@ export const fetchSummary: QueryFunction<IADSApiJournalsSummaryResponse> = async
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.JOURNAL_SUMMARY}/${params.bibstem}`,
+    ui_tag: 'journals/summary',
   };
 
   const { data } = await api.request<IADSApiJournalsSummaryResponse>(config);
@@ -91,6 +93,7 @@ export const fetchISSN: QueryFunction<IADSApiJournalsISSNResponse> = async ({ me
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.JOURNAL_ISSN}/${params.issn}`,
+    ui_tag: 'journals/issn',
   };
 
   const { data } = await api.request<IADSApiJournalsISSNResponse>(config);

--- a/src/api/metrics/metrics.ts
+++ b/src/api/metrics/metrics.ts
@@ -35,7 +35,7 @@ export const useHasMetrics: ADSQuery<Bibcode, IADSApiMetricsResponse, null, bool
     queryKey: metricsKeys.primary([bibcode]),
     queryFn: fetchMetrics,
     retry: retryFn,
-    meta: { params, skipGlobalErrorHandler: true },
+    meta: { params, skipGlobalErrorHandler: true, ui_tag: 'metrics/primary' },
     ...options,
   });
 
@@ -67,7 +67,7 @@ export const useGetMetrics: ADSQuery<Bibcode | Bibcode[], IADSApiMetricsResponse
     queryKey: metricsKeys.primary(bibcodes),
     queryFn: fetchMetrics,
     retry: retryFn,
-    meta: { params },
+    meta: { params, ui_tag: 'metrics/primary' },
     ...options,
   });
 };
@@ -82,18 +82,19 @@ export const useGetMetricsTimeSeries: ADSQuery<Bibcode[], IADSApiMetricsResponse
     queryKey: metricsKeys.timeSeries(bibcodes),
     queryFn: fetchMetrics,
     retry: retryFn,
-    meta: { params },
+    meta: { params, ui_tag: 'metrics/time-series' },
     ...options,
   });
 };
 
 export const fetchMetrics: QueryFunction<IADSApiMetricsResponse> = async ({ meta }) => {
-  const { params } = meta as { params: IADSApiMetricsParams };
+  const { params, ui_tag } = meta as { params: IADSApiMetricsParams; ui_tag?: string };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_METRICS,
     data: params,
+    ui_tag,
   };
 
   const metrics = await trackUserFlow(PERF_SPANS.ABSTRACT_METRICS_REQUEST, async () => {

--- a/src/api/objects/objects.ts
+++ b/src/api/objects/objects.ts
@@ -50,6 +50,7 @@ export const resolveObjectQuery = async (params: IObjectsQueryApiParams) => {
     url: ApiTargets.SERVICE_OBJECTS_QUERY,
     method: 'POST',
     data: { query: [query] },
+    ui_tag: 'objects/primary',
   };
 
   const { data } = await api.request<ObjectService['response']>(config);
@@ -86,6 +87,7 @@ export const resolveObjectQuerySSR = async (params: IObjectsQueryApiParams, ctx:
       ...defaultRequestConfig.headers,
       ...pickTracingHeaders(ctx.req.headers),
       Authorization: `Bearer ${token}`,
+      'X-Ui-Tag': 'objects/primary',
     },
   };
 
@@ -114,6 +116,7 @@ export const resolveObjects = async (params: IObjectsApiParams) => {
     url: ApiTargets.SERVICE_OBJECTS,
     method: 'POST',
     data: { identifiers },
+    ui_tag: 'objects/primary',
   };
 
   const { data } = await api.request<IObjectsApiResponse>(config);

--- a/src/api/orcid/orcid.ts
+++ b/src/api/orcid/orcid.ts
@@ -145,6 +145,7 @@ const fetchExchangeToken: QueryFunction<IOrcidUser> = async ({ meta }) => {
     method: 'GET',
     url: ApiTargets.ORCID_EXCHANGE_TOKEN,
     params,
+    ui_tag: 'orcid/exchange-token',
   };
 
   return trackUserFlow(PERF_SPANS.ORCID_OAUTH_TOTAL, async () => {
@@ -166,6 +167,7 @@ const getPreferences: QueryFunction<IOrcidResponse['getPreferences']> = async ({
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
+    ui_tag: 'orcid/get-preferences',
   };
 
   const { data } = await api.request<IOrcidResponse['getPreferences']>(config);
@@ -187,6 +189,7 @@ export const fetchProfile: QueryFunction<IOrcidResponse['profile']> = async ({ m
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
+    ui_tag: 'orcid/profile',
   };
 
   return trackUserFlow(PERF_SPANS.ORCID_PROFILE_LOAD, async () => {
@@ -212,6 +215,7 @@ const removeWorks: MutationFunction<IOrcidResponse['removeWorks'], IOrcidMutatio
     headers: {
       'orcid-authorization': `Bearer ${user.access_token}`,
     },
+    ui_tag: 'orcid/remove-works',
   };
 
   const makeRequest = async (putcode: IOrcidWork['put-code']) => {
@@ -260,6 +264,7 @@ const addWorks: MutationFunction<IOrcidResponse['addWorks'], IOrcidMutationParam
     headers: {
       'orcid-authorization': `Bearer ${user.access_token}`,
     },
+    ui_tag: 'orcid/add-works',
   };
 
   const data = await trackUserFlow(PERF_SPANS.ORCID_CLAIM_TOTAL, () =>
@@ -296,6 +301,7 @@ const updateWork: MutationFunction<IOrcidResponse['updateWork'], IOrcidMutationP
       'orcid-authorization': `Bearer ${user.access_token}`,
     },
     data: work,
+    ui_tag: 'orcid/update-work',
   };
 
   return trackUserFlow(PERF_SPANS.ORCID_SYNC_TOTAL, async () => {
@@ -316,6 +322,7 @@ const getName: QueryFunction<IOrcidResponse['name']> = async ({ meta }) => {
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
+    ui_tag: 'orcid/name',
   };
 
   const { data } = await api.request<null>(config);
@@ -335,6 +342,7 @@ const getWork: QueryFunction<IOrcidResponse['getWork']> = async ({ meta }) => {
     headers: {
       'orcid-authorization': `Bearer ${params.user.access_token}`,
     },
+    ui_tag: 'orcid/get-work',
   };
 
   const { data } = await api.request<null>(config);
@@ -359,6 +367,7 @@ const setPreferences: MutationFunction<
     headers: {
       'orcid-authorization': `Bearer ${user.access_token}`,
     },
+    ui_tag: 'orcid/set-preferences',
   };
 
   const { data } = await api.request<IOrcidResponse['setPreferences']>(config);

--- a/src/api/reference/reference.ts
+++ b/src/api/reference/reference.ts
@@ -12,7 +12,7 @@ export const referenceKeys = {
   [ReferenceKeysEnum.TEXT]: (text: string) => [ReferenceKeysEnum.TEXT, { text }] as const,
 };
 
-type ReferenceQuery = ADSQuery<Parameters<typeof referenceKeys[ReferenceKeysEnum.TEXT]>[0], IADSApiReferenceResponse>;
+type ReferenceQuery = ADSQuery<Parameters<(typeof referenceKeys)[ReferenceKeysEnum.TEXT]>[0], IADSApiReferenceResponse>;
 
 /**
  * Generic reference search, will accept raw text and make request for reference string
@@ -32,6 +32,7 @@ export const fetchReferenceText: QueryFunction<IADSApiReferenceResponse> = async
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.REFERENCE}/${params.text}`,
+    ui_tag: 'reference/primary',
   };
 
   const { data } = await api.request<IADSApiReferenceResponse>(config);

--- a/src/api/resolver/resolver.ts
+++ b/src/api/resolver/resolver.ts
@@ -28,6 +28,7 @@ export const fetchLinks: QueryFunction<IADSApiResolverResponse> = async ({ meta 
     method: 'GET',
     url: `${ApiTargets.RESOLVER}/${params.bibcode}/${params.link_type}`,
     validateStatus: (status) => status === 200 || status === 404,
+    ui_tag: 'resolver/primary',
   };
 
   const { data } = await api.request<IADSApiResolverResponse>(config);

--- a/src/api/search/search.ts
+++ b/src/api/search/search.ts
@@ -119,7 +119,7 @@ export function useSearch<TData = IADSApiSearchResponse['response']>(
     queryKey: searchKeys.primary(cleanParams),
     queryHash: JSON.stringify(searchKeys.primary(cleanParams)),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/primary' },
     select,
     retry: (failCount, error) => failCount < 1 && axios.isAxiosError(error) && error.response?.status !== 400,
     ...(options as Omit<UseQueryOptions<IADSApiSearchResponse, ErrorType, TData>, 'queryKey' | 'queryFn' | 'select'>),
@@ -143,7 +143,7 @@ export const useGetHighlights: SearchADSQuery<
   return useQuery({
     queryKey: searchKeys.highlight(omitParams(highlightParams)),
     queryFn: fetchSearch,
-    meta: { params: highlightParams },
+    meta: { params: highlightParams, ui_tag: 'search/highlight' },
     select: highlightingSelector,
     ...options,
   });
@@ -157,7 +157,7 @@ export const useGetCitations: SubPageQuery = ({ bibcode, start = 0, rows = APP_D
   return useQuery({
     queryKey: searchKeys.citations({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/citations' },
     select: responseSelector,
     ...options,
   });
@@ -174,7 +174,7 @@ export const useGetReferences: SubPageQuery = (
   return useQuery({
     queryKey: searchKeys.references({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/references' },
     select: responseSelector,
     ...options,
   });
@@ -188,7 +188,7 @@ export const useGetCredits: SubPageQuery = ({ bibcode, start = 0, rows = APP_DEF
   return useQuery({
     queryKey: searchKeys.credits({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/credits' },
     select: responseSelector,
     ...options,
   });
@@ -202,7 +202,7 @@ export const useGetMentions: SubPageQuery = ({ bibcode, start = 0, rows = APP_DE
   return useQuery({
     queryKey: searchKeys.mentions({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/mentions' },
     select: responseSelector,
     ...options,
   });
@@ -216,7 +216,7 @@ export const useGetCoreads: SubPageQuery = ({ bibcode, start = 0, rows = APP_DEF
   return useQuery({
     queryKey: searchKeys.coreads({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/coreads' },
     select: responseSelector,
     ...options,
   });
@@ -230,7 +230,7 @@ export const useGetSimilar: SubPageQuery = ({ bibcode, start = 0, rows = APP_DEF
   return useQuery({
     queryKey: searchKeys.similar({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/similar' },
     select: responseSelector,
     ...options,
   });
@@ -244,7 +244,7 @@ export const useGetToc: SubPageQuery = ({ bibcode, start = 0, rows = APP_DEFAULT
   return useQuery({
     queryKey: searchKeys.toc({ bibcode, start, rows }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/toc' },
     select: responseSelector,
     ...options,
   });
@@ -258,7 +258,7 @@ export const useGetAbstract: SearchADSQuery<{ id: string }> = ({ id }, options) 
   return useQuery({
     queryKey: searchKeys.abstract(id),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/abstract' },
     select: responseSelector,
     ...options,
   });
@@ -272,7 +272,7 @@ export const useGetAffiliations: SearchADSQuery<{ bibcode: IDocsEntity['bibcode'
   return useQuery({
     queryKey: searchKeys.affiliations({ bibcode }),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/affiliations' },
     select: responseSelector,
     ...options,
   });
@@ -287,7 +287,7 @@ export const useGetAbstractPreview: SearchADSQuery<{ bibcode: IDocsEntity['bibco
     queryKey: searchKeys.preview(bibcode),
     queryHash: JSON.stringify(searchKeys.preview(bibcode)),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/preview' },
     select: responseSelector,
     ...options,
   });
@@ -301,7 +301,7 @@ export const useGetSingleRecord: SearchADSQuery<{ id: string }> = ({ id }, optio
   return useQuery({
     queryKey: searchKeys.record(id),
     queryFn: fetchSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'search/record' },
     select: responseSelector,
     ...options,
   });
@@ -330,7 +330,7 @@ export const useGetSearchStats: SearchADSQuery<IADSApiSearchParams, IADSApiSearc
   return useQuery({
     queryKey: searchKeys.stats(cleanParams),
     queryFn: fetchSearch,
-    meta: { params: searchParams },
+    meta: { params: searchParams, ui_tag: 'search/stats' },
     enabled: isCitationSort,
     select: statsSelector,
     ...options,
@@ -350,7 +350,7 @@ export const useGetSearchFacetCounts: SearchADSQuery<IADSApiSearchParams, IADSAp
     queryKey: searchKeys.facet(cleanParams),
     queryFn: fetchSearch,
     queryHash: JSON.stringify(cleanParams),
-    meta: { params: searchParams },
+    meta: { params: searchParams, ui_tag: 'search/facet' },
     select: facetCountSelector,
     ...options,
   });
@@ -365,7 +365,7 @@ export const useGetSearchFacet: SearchADSQuery<IADSApiSearchParams, IADSApiSearc
   return useQuery({
     queryKey: searchKeys.facet(cleanParams),
     queryFn: fetchSearch,
-    meta: { params: searchParams },
+    meta: { params: searchParams, ui_tag: 'search/facet' },
     ...options,
   });
 };
@@ -408,7 +408,7 @@ export const useGetSearchFacetJSON: SearchADSQuery<
   return useQuery({
     queryKey: searchKeys.facet(cleanParams),
     queryFn: fetchSearch,
-    meta: { params: searchParams, postTransformers: [transformData] },
+    meta: { params: searchParams, postTransformers: [transformData], ui_tag: `search/facet/${params.field}` },
     select: facetFieldSelector,
     ...options,
   });
@@ -427,7 +427,7 @@ export const useSearchInfinite: InfiniteADSQuery<IADSApiSearchParams, IADSApiSea
         ? lastPage.nextCursorMark
         : false;
     },
-    meta: { ...options?.meta, params },
+    meta: { ...options?.meta, params, ui_tag: 'search/infinite' },
     ...options,
   });
 };
@@ -456,6 +456,7 @@ export const fetchBigQuerySearch: MutationFunction<
     params: { ...params, rows: variables.rows, sort: variables.sort },
     data: `bibcode\n${variables.bibcodes.join('\n')}`,
     headers: { 'Content-Type': 'bigquery/csv' },
+    ui_tag: 'search/bigquery',
   };
 
   const { data } = await api.request<IADSApiSearchResponse>(config);
@@ -473,9 +474,10 @@ export const fetchBigQuerySearch: MutationFunction<
  * @returns {Promise<IADSApiSearchResponse>} - A promise that resolves to the search response data.
  */
 export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta }) => {
-  const { params, postTransformers } = meta as {
+  const { params, postTransformers, ui_tag } = meta as {
     params: IADSApiSearchParams;
     postTransformers?: Array<PostTransformer>;
+    ui_tag?: string;
   };
 
   const finalParams = { ...params };
@@ -491,6 +493,7 @@ export const fetchSearch: QueryFunction<IADSApiSearchResponse> = async ({ meta }
     method: 'GET',
     url: ApiTargets.SEARCH,
     params: finalParams,
+    ui_tag,
   };
 
   // Wrap API request in performance span
@@ -549,6 +552,7 @@ export const fetchSearchSSR = async (
       ...defaultRequestConfig.headers,
       Authorization: `Bearer ${token}`,
       ...pickTracingHeaders(ctx.req.headers),
+      'X-Ui-Tag': 'search/primary',
     },
   };
 
@@ -560,7 +564,7 @@ export const fetchSearchInfinite: QueryFunction<IADSApiSearchResponse & { pagePa
   meta,
   pageParam = '*',
 }: QueryFunctionContext<QueryKey, string>) => {
-  const { params } = meta as { params: IADSApiSearchParams };
+  const { params, ui_tag } = meta as { params: IADSApiSearchParams; ui_tag?: string };
 
   const finalParams = { ...params };
   if (isString(params.q) && params.q.includes('object:')) {
@@ -578,6 +582,7 @@ export const fetchSearchInfinite: QueryFunction<IADSApiSearchResponse & { pagePa
       ...finalParams,
       cursorMark: pageParam,
     } as IADSApiSearchParams,
+    ui_tag,
   };
   const { data } = await api.request<IADSApiSearchResponse>(config);
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,7 +9,7 @@ import {
   UseQueryResult,
 } from '@tanstack/react-query';
 
-export type ApiRequestConfig = AxiosRequestConfig;
+export type ApiRequestConfig = AxiosRequestConfig & { ui_tag?: string };
 
 export type ADSQuery<
   TProps,

--- a/src/api/vault/vault.ts
+++ b/src/api/vault/vault.ts
@@ -60,7 +60,7 @@ export const useVaultSearch: ADSQuery<IADSApiSearchParams, IADSApiVaultResponse>
   return useQuery({
     queryKey: vaultKeys.primary(params),
     queryFn: fetchVaultSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'vault/primary' },
     ...options,
   });
 };
@@ -73,7 +73,7 @@ export const useVaultExecuteQuery: ADSQuery<IADSVaultExecuteQueryParams, IADSApi
   return useQuery({
     queryKey: vaultKeys.executeQuery(qid),
     queryFn: fetchVaultSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'vault/execute-query' },
     ...options,
   });
 };
@@ -86,18 +86,19 @@ export const useVaultBigQuerySearch: ADSQuery<IDocsEntity['bibcode'][], IADSApiV
   return useQuery({
     queryKey: vaultKeys.bigquery(bibcodes),
     queryFn: fetchVaultSearch,
-    meta: { params },
+    meta: { params, ui_tag: 'vault/bigquery' },
     ...options,
   });
 };
 
 export const fetchVaultSearch: QueryFunction<IADSApiVaultResponse> = async ({ meta }) => {
-  const { params } = meta as { params: IADSApiSearchParams };
+  const { params, ui_tag } = meta as { params: IADSApiSearchParams; ui_tag?: string };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.MYADS_STORAGE_QUERY,
     data: params,
+    ui_tag,
   };
 
   const { data } = await api.request<IADSApiVaultResponse>(config);
@@ -110,6 +111,7 @@ export const fetchVaultExecuteQuery: QueryFunction<IADSApiSearchResponse['respon
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_STORAGE}/execute_query/${params.qid}`,
+    ui_tag: 'vault/execute-query',
   };
 
   const { data } = await api.request<IADSApiSearchResponse['response']>(config);
@@ -120,6 +122,7 @@ export const fetchLibraryLinkServers: QueryFunction<IADSApiLibraryLinkServersRes
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.LINK_SERVERS,
+    ui_tag: 'vault/library-link-servers',
   };
 
   const { data } = await api.request<IADSApiLibraryLinkServersResponse>(config);
@@ -150,6 +153,7 @@ export const fetchNotifications: QueryFunction<IADSApiNotificationsReponse> = as
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.MYADS_NOTIFICATIONS,
+    ui_tag: 'vault/notifications',
   };
 
   const { data } = await api.request<IADSApiNotificationsReponse>(config);
@@ -175,6 +179,7 @@ export const fetchNotification: QueryFunction<IADSApiNotificationReponse> = asyn
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_NOTIFICATIONS}/${params.id.toString()}`,
+    ui_tag: 'vault/notification',
   };
 
   const { data } = await api.request<IADSApiNotificationReponse>(config);
@@ -183,14 +188,17 @@ export const fetchNotification: QueryFunction<IADSApiNotificationReponse> = asyn
 
 // add notification
 
-export const useAddNotification: ADSMutation<IADSApiAddNotificationResponse, undefined, IADSApiAddNotificationParams> =
-  (_, options) => {
-    return useMutation({
-      mutationKey: vaultKeys.addNotification(),
-      mutationFn: addNotification,
-      ...options,
-    });
-  };
+export const useAddNotification: ADSMutation<
+  IADSApiAddNotificationResponse,
+  undefined,
+  IADSApiAddNotificationParams
+> = (_, options) => {
+  return useMutation({
+    mutationKey: vaultKeys.addNotification(),
+    mutationFn: addNotification,
+    ...options,
+  });
+};
 
 export const addNotification: MutationFunction<IADSApiAddNotificationResponse, IADSApiAddNotificationParams> = async (
   params,
@@ -199,6 +207,7 @@ export const addNotification: MutationFunction<IADSApiAddNotificationResponse, I
     method: 'POST',
     url: ApiTargets.MYADS_NOTIFICATIONS,
     data: params,
+    ui_tag: 'vault/add-notification',
   };
 
   const { data } = await api.request<IADSApiAddNotificationResponse>(config);
@@ -219,17 +228,20 @@ export const useEditNotification: ADSMutation<
   });
 };
 
-export const editNotification: MutationFunction<IADSApiEditNotificationResponse, IADSApiEditNotificationParams> =
-  async (params) => {
-    const config: ApiRequestConfig = {
-      method: 'PUT',
-      url: `${ApiTargets.MYADS_NOTIFICATIONS}/${params.id}`,
-      data: omit(['id'], params),
-    };
-
-    const { data } = await api.request<IADSApiEditNotificationResponse>(config);
-    return data;
+export const editNotification: MutationFunction<
+  IADSApiEditNotificationResponse,
+  IADSApiEditNotificationParams
+> = async (params) => {
+  const config: ApiRequestConfig = {
+    method: 'PUT',
+    url: `${ApiTargets.MYADS_NOTIFICATIONS}/${params.id}`,
+    data: omit(['id'], params),
+    ui_tag: 'vault/edit-notification',
   };
+
+  const { data } = await api.request<IADSApiEditNotificationResponse>(config);
+  return data;
+};
 
 export const useDelNotification: ADSMutation<
   IADSApiDeleteNotificationResponse,
@@ -243,16 +255,19 @@ export const useDelNotification: ADSMutation<
   });
 };
 
-export const deleteNotification: MutationFunction<IADSApiDeleteNotificationResponse, IADSApiDeleteNotificationParams> =
-  async ({ id }) => {
-    const config: ApiRequestConfig = {
-      method: 'DELETE',
-      url: `${ApiTargets.MYADS_NOTIFICATIONS}/${id}`,
-    };
-
-    const { data } = await api.request<IADSApiDeleteNotificationResponse>(config);
-    return data;
+export const deleteNotification: MutationFunction<
+  IADSApiDeleteNotificationResponse,
+  IADSApiDeleteNotificationParams
+> = async ({ id }) => {
+  const config: ApiRequestConfig = {
+    method: 'DELETE',
+    url: `${ApiTargets.MYADS_NOTIFICATIONS}/${id}`,
+    ui_tag: 'vault/delete-notification',
   };
+
+  const { data } = await api.request<IADSApiDeleteNotificationResponse>(config);
+  return data;
+};
 
 // get notification query
 
@@ -273,6 +288,7 @@ export const fetchNotificationQuery: QueryFunction<IADSApiNotificationQueryRespo
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.MYADS_NOTIFICATIONS_QUERY}/${params.id.toString()}`,
+    ui_tag: 'vault/notification-query',
   };
 
   const { data } = await api.request<IADSApiNotificationQueryResponse>(config);
@@ -292,6 +308,7 @@ export const fetchSiteWideMsg: QueryFunction<IADSApiSiteWideMsgResponse> = async
   const config: ApiRequestConfig = {
     method: 'GET',
     url: `${ApiTargets.SITE_SIDE_MESSAGE}`,
+    ui_tag: 'vault/site-wide-msg',
   };
 
   const { data } = await api.request<IADSApiSiteWideMsgResponse>(config);

--- a/src/api/vis/vis.ts
+++ b/src/api/vis/vis.ts
@@ -48,6 +48,7 @@ export const fetchAuthorNetwork: QueryFunction<IADSApiAuthorNetworkResponse> = a
     method: 'POST',
     url: ApiTargets.SERVICE_AUTHOR_NETWORK,
     data: params,
+    ui_tag: 'vis/author-network',
   };
 
   const { data } = await api.request<IADSApiAuthorNetworkResponse>(config);
@@ -73,6 +74,7 @@ export const fetchPaperNetwork: QueryFunction<IADSApiPaperNetworkResponse> = asy
     method: 'POST',
     url: ApiTargets.SERVICE_PAPER_NETWORK,
     data: params,
+    ui_tag: 'vis/paper-network',
   };
 
   const { data } = await api.request<IADSApiPaperNetworkResponse>(config);
@@ -98,6 +100,7 @@ export const fetchWordCloud: QueryFunction<IADSApiWordCloudResponse> = async ({ 
     method: 'POST',
     url: ApiTargets.SERVICE_WORDCLOUD,
     data: params,
+    ui_tag: 'vis/word-cloud',
   };
 
   const { data } = await api.request<IADSApiWordCloudResponse>(config);
@@ -123,6 +126,7 @@ export const fetchResultsGraph: QueryFunction<IADSApiSearchResponse> = async ({ 
     method: 'GET',
     url: ApiTargets.SEARCH,
     params,
+    ui_tag: 'vis/results-graph',
   };
 
   const { data } = await api.request<IADSApiSearchResponse>(config);


### PR DESCRIPTION
Add the X-Ui-Tag header, which identifies API call types (e.g. search/primary, search/facet/author).

- Extended ApiRequestConfig with optional ui_tag field; Axios request interceptor in Api lifts it to X-Ui-Tag before dispatch and strips it from the config object
- Annotated all fetch functions across src/api/ with taxonomy tags; for shared query functions (fetchSearch, fetchVaultSearch) the tag threads through React Query meta
- useGetSearchFacetJSON uses a dynamic tag (search/facet/<field>) so the actual field name appears in backend logs
- SSR paths that bypass the Api singleton set X-Ui-Tag directly on the axios headers config