### PR TITLE
SCIX-887 fix(app-mode): switch to Astrophysics on classic/paper forms

### DIFF
--- a/src/__tests__/paper-form.test.tsx
+++ b/src/__tests__/paper-form.test.tsx
@@ -1,10 +1,12 @@
-import { render } from '@/test-utils';
-import { beforeEach, describe, test, vi } from 'vitest';
+import { render, waitFor, within } from '@/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AppMode } from '@/types';
 import PaperForm from '../pages/paper-form';
 
 const router = {
   pathname: '/',
-  push: vi.fn(),
+  route: '/paper-form',
+  push: vi.fn().mockResolvedValue(true),
   asPath: '/',
 };
 vi.mock('next/router', () => ({
@@ -16,6 +18,20 @@ describe('Paper Form', () => {
 
   test('renders without error', () => {
     render(<PaperForm />);
+  });
+
+  // The paper form is Astrophysics-only, so submitting while viewing another
+  // discipline must produce an Astrophysics search with a discipline-stable URL.
+  test('forces an Astrophysics search on submit from a non-astro discipline', async () => {
+    const { getByLabelText, getByTestId, user } = render(<PaperForm />, {
+      initialStore: { mode: AppMode.GENERAL },
+    });
+
+    await user.type(getByLabelText('Year'), '2020');
+    await user.click(within(getByTestId('journal-query')).getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledTimes(1));
+    expect(router.push.mock.calls[0][0]).toContain('d=astrophysics');
   });
 
   test.todo('journal search works');

--- a/src/components/ClassicForm/ClassicForm.test.tsx
+++ b/src/components/ClassicForm/ClassicForm.test.tsx
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, waitFor } from '@/test-utils';
+import { AppMode } from '@/types';
+import { ClassicForm } from './ClassicForm';
+
+const router = {
+  route: '/classic-form',
+  pathname: '/classic-form',
+  asPath: '/classic-form',
+  query: {},
+  push: vi.fn().mockResolvedValue(true),
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+describe('ClassicForm', () => {
+  beforeEach(() => router.push.mockReset());
+
+  // The classic form is Astrophysics-only, so submitting while viewing another
+  // discipline must still produce an Astrophysics search (SCIX-887).
+  test('forces an Astrophysics search on submit from a non-astro discipline', async () => {
+    const { getByText, user } = render(<ClassicForm ssrError="" />, { initialStore: { mode: AppMode.GENERAL } });
+
+    await user.click(getByText('Search'));
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledTimes(1));
+    const arg = router.push.mock.calls[0][0] as { pathname: string; search: string };
+    expect(arg.pathname).toBe('/search');
+    expect(arg.search).toContain('d=astrophysics');
+    expect(arg.search).not.toContain('general');
+  });
+});

--- a/src/components/ClassicForm/ClassicForm.tsx
+++ b/src/components/ClassicForm/ClassicForm.tsx
@@ -33,6 +33,7 @@ import { Control, Controller, useForm, UseFormRegisterReturn, useWatch } from 'r
 import { getSearchQuery, getSearchQueryParams } from './helpers';
 import { IClassicFormState, IRawClassicFormState } from './types';
 import { useStore } from '@/store';
+import { AppMode } from '@/types';
 
 import { solrSortOptions } from '@/components/Sort/model';
 import { SimpleLink } from '@/components/SimpleLink';
@@ -73,6 +74,7 @@ export const ClassicForm = (props: IClassicFormProps) => {
   const router = useRouter();
   const [queryError, setQueryError] = useErrorMessage<string>(props.ssrError);
   const mode = useStore((state) => state.mode);
+  const setMode = useStore((state) => state.setMode);
 
   const { register, control, handleSubmit } = useForm<IClassicFormState>({
     defaultValues: defaultClassicFormState,
@@ -83,7 +85,12 @@ export const ClassicForm = (props: IClassicFormProps) => {
 
     void handleSubmit((params) => {
       try {
-        const search = getSearchQuery(params, { mode });
+        // The classic form is Astrophysics-only, so the search it produces must
+        // run in Astrophysics regardless of the discipline the user is viewing.
+        if (mode !== AppMode.ASTROPHYSICS) {
+          setMode(AppMode.ASTROPHYSICS);
+        }
+        const search = getSearchQuery(params, { mode: AppMode.ASTROPHYSICS });
         void router.push({ pathname: '/search', search });
       } catch (e) {
         setQueryError((e as Error)?.message);

--- a/src/components/NavBar/AppModeUrlNotice.tsx
+++ b/src/components/NavBar/AppModeUrlNotice.tsx
@@ -63,6 +63,8 @@ export const AppModeUrlNotice: FC = () => {
     shallow,
   );
   const urlModePrevious = useStore((state) => state.urlModePrevious);
+  const forcedAstroFromMode = useStore((state) => state.forcedAstroFromMode);
+  const setForcedAstroFromMode = useStore((state) => state.setForcedAstroFromMode);
   const [previousMode, setPreviousMode] = useState<AppMode | null>(null);
   const [appliedMode, setAppliedMode] = useState<AppMode | null>(null);
   const [visible, setVisible] = useState(false);
@@ -214,20 +216,40 @@ export const AppModeUrlNotice: FC = () => {
     void sync();
   }, [router, mode, urlModeOverride]);
 
-  const shouldRender = !!appliedMode && !!previousMode && (visible || modeNoticeVisible);
+  // A forced switch (from a classic/paper form route) has no URL `d` param, so
+  // the local appliedMode/previousMode are never set — fall back to the store.
+  const isForcedSwitch = forcedAstroFromMode !== null;
+  const effectiveAppliedMode = appliedMode ?? (isForcedSwitch ? AppMode.ASTROPHYSICS : null);
+  const effectivePreviousMode = previousMode ?? forcedAstroFromMode;
+  const shouldRender = !!effectiveAppliedMode && !!effectivePreviousMode && (visible || modeNoticeVisible);
   if (!shouldRender) {
     return null;
   }
 
-  const handleKeep = () => setVisible(false);
+  const handleKeep = () => {
+    setVisible(false);
+    if (isForcedSwitch) {
+      setForcedAstroFromMode(null);
+      dismissModeNotice();
+    }
+  };
 
   const handleSwitchBack = () => {
-    const targetMode = previousMode ?? urlModePrevious ?? null;
+    const targetMode = effectivePreviousMode ?? urlModePrevious ?? null;
     if (targetMode && targetMode !== mode) {
       setMode(targetMode);
     }
     setVisible(false);
     dismissModeNotice();
+
+    // Forced switches come from an Astrophysics-only form route. Reverting the
+    // discipline there would just re-trigger the switch, so navigate home.
+    if (isForcedSwitch) {
+      setForcedAstroFromMode(null);
+      void router.push('/');
+      return;
+    }
+
     setUrlModeOverride(null);
     setUrlModePrevious(targetMode);
     setUrlModeUserSelected(true);
@@ -254,7 +276,7 @@ export const AppModeUrlNotice: FC = () => {
     >
       <AlertIcon color="blue.100" />
       <Box>
-        <AlertDescription fontSize="sm">Changed to {getAppModeLabel(appliedMode)}.</AlertDescription>
+        <AlertDescription fontSize="sm">Changed to {getAppModeLabel(effectiveAppliedMode)}.</AlertDescription>
       </Box>
       <HStack spacing={2} ml={3}>
         <Button

--- a/src/components/NavBar/__tests__/AppModeUrlNotice.test.tsx
+++ b/src/components/NavBar/__tests__/AppModeUrlNotice.test.tsx
@@ -82,6 +82,25 @@ describe('AppModeUrlNotice', () => {
     expect(mockRouter.query.d).toBe('astrophysics');
   });
 
+  test('shows the notice for a route-forced Astrophysics switch and navigates home on switch back', async () => {
+    mockRouter = createMockRouter({ pathname: '/classic-form', asPath: '/classic-form' });
+
+    const { getByTestId, queryByTestId, user } = render(<NavBar />, {
+      initialStore: {
+        mode: AppMode.ASTROPHYSICS,
+        forcedAstroFromMode: AppMode.GENERAL,
+        modeNoticeVisible: true,
+      },
+    });
+
+    await waitFor(() => expect(getByTestId('app-mode-url-notice')).toBeInTheDocument());
+    expect(getByTestId('app-mode-url-notice').textContent).toContain('Astrophysics');
+
+    await user.click(getByTestId('app-mode-url-notice-switch-back'));
+    await waitFor(() => expect(queryByTestId('app-mode-url-notice')).not.toBeInTheDocument());
+    expect(mockRouter.push).toHaveBeenCalledWith('/');
+  });
+
   test('does nothing when URL param is missing', async () => {
     mockRouter = createMockRouter({ pathname: '/search' }); // No 'd' param
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -97,7 +97,9 @@ const AppModeRouter = (): ReactElement => {
     if (!isClient) {
       return;
     }
-    const onFormRoute = /^\/(classic|paper)-form.*$/.test(router.asPath);
+    // Match /classic-form and /paper-form exactly, allowing a query or hash
+    // suffix — but not lookalikes such as /classic-former.
+    const onFormRoute = /^\/(classic|paper)-form(?:[/?#]|$)/.test(router.asPath);
     const { mode, forcedAstroFromMode } = storeApi.getState();
 
     // Navigating away from the form route without acting on the notice: clear

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -82,18 +82,40 @@ const NectarApp = memo(({ Component, pageProps }: AppProps): ReactElement => {
 NectarApp.displayName = 'NectarApp';
 
 const AppModeRouter = (): ReactElement => {
-  const mode = useStore((state) => state.mode);
+  const storeApi = useStoreApi();
+  const setMode = useStore((state) => state.setMode);
+  const setForcedAstroFromMode = useStore((state) => state.setForcedAstroFromMode);
+  const showModeNotice = useStore((state) => state.showModeNotice);
+  const dismissModeNotice = useStore((state) => state.dismissModeNotice);
   const router = useRouter();
   const isClient = useIsClient();
 
   useEffect(() => {
-    // redirect to main form if path is not valid
-    if (isClient) {
-      if (mode !== AppMode.ASTROPHYSICS && /^\/(classic|paper)-form.*$/.test(router.asPath)) {
-        void router.replace('/');
-      }
+    // The classic/paper forms are Astrophysics-only. When a user in another
+    // discipline lands here, switch them to Astrophysics and surface the
+    // "Switch back?" notice instead of bouncing them to the home page.
+    if (!isClient) {
+      return;
     }
-  }, [mode, router.asPath, isClient, router]);
+    const onFormRoute = /^\/(classic|paper)-form.*$/.test(router.asPath);
+    const { mode, forcedAstroFromMode } = storeApi.getState();
+
+    // Navigating away from the form route without acting on the notice: clear
+    // the forced switch so its notice does not linger on unrelated routes.
+    if (!onFormRoute) {
+      if (forcedAstroFromMode !== null) {
+        setForcedAstroFromMode(null);
+        dismissModeNotice();
+      }
+      return;
+    }
+
+    if (mode !== AppMode.ASTROPHYSICS) {
+      setForcedAstroFromMode(mode);
+      setMode(AppMode.ASTROPHYSICS);
+      showModeNotice();
+    }
+  }, [router.asPath, isClient, storeApi, setMode, setForcedAstroFromMode, showModeNotice, dismissModeNotice]);
 
   // Clean forceMode from URL after it has been applied to the store.
   // The param is only needed for initial SSR load; keeping it in the URL

--- a/src/pages/classic-form.tsx
+++ b/src/pages/classic-form.tsx
@@ -25,6 +25,7 @@ const ClassicFormPage: NextPage<{ ssrError?: string }> = ({ ssrError }) => {
   const setUrlModePrevious = useStore((state) => state.setUrlModePrevious);
   const urlModeOverride = useStore((state) => state.urlModeOverride);
   const setUrlModeOverride = useStore((state) => state.setUrlModeOverride);
+  const forcedAstroFromMode = useStore((state) => state.forcedAstroFromMode);
   const { persistCurrentForm } = useLandingFormPreference();
 
   // Track this form as the last-used landing form
@@ -32,11 +33,20 @@ const ClassicFormPage: NextPage<{ ssrError?: string }> = ({ ssrError }) => {
     persistCurrentForm('classic');
   }, [persistCurrentForm]);
 
-  // clear search on mount
+  // Clear any in-progress search once on entry. clearQuery is recreated each
+  // render, so this is intentionally mount-only.
   useEffect(() => {
     clearSelectedDocs();
     clearQuery();
-    dismissModeNoticeSilently();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reconcile app mode on entry: drop a stale notice and restore the user's
+  // discipline, unless this route forced the switch to Astrophysics.
+  useEffect(() => {
+    if (forcedAstroFromMode === null) {
+      dismissModeNoticeSilently();
+    }
     if (urlModeOverride) {
       const fallbackMode = urlModePrevious ?? AppMode.GENERAL;
       if (mode !== fallbackMode) {
@@ -50,7 +60,7 @@ const ClassicFormPage: NextPage<{ ssrError?: string }> = ({ ssrError }) => {
       setMode(urlModePrevious);
       setUrlModePrevious(null);
     }
-  }, [router, mode, urlModePrevious, urlModeOverride]);
+  }, [router, mode, urlModePrevious, urlModeOverride, forcedAstroFromMode]);
 
   return (
     <Box as="section" aria-labelledby="form-title" my={16}>

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -89,6 +89,7 @@ const PaperForm: NextPage<{ error?: IPaperFormServerError }> = ({ error: ssrErro
   const setUrlModePrevious = useStore((state) => state.setUrlModePrevious);
   const urlModeOverride = useStore((state) => state.urlModeOverride);
   const setUrlModeOverride = useStore((state) => state.setUrlModeOverride);
+  const forcedAstroFromMode = useStore((state) => state.forcedAstroFromMode);
   const { persistCurrentForm } = useLandingFormPreference();
 
   // Track this form as the last-used landing form
@@ -96,11 +97,20 @@ const PaperForm: NextPage<{ error?: IPaperFormServerError }> = ({ error: ssrErro
     persistCurrentForm('paper');
   }, [persistCurrentForm]);
 
-  // clear search on mount
+  // Clear any in-progress search once on entry. clearQuery is recreated each
+  // render, so this is intentionally mount-only.
   useEffect(() => {
     clearSelectedDocs();
     clearQuery();
-    dismissModeNoticeSilently();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reconcile app mode on entry: drop a stale notice and restore the user's
+  // discipline, unless this route forced the switch to Astrophysics.
+  useEffect(() => {
+    if (forcedAstroFromMode === null) {
+      dismissModeNoticeSilently();
+    }
     if (urlModeOverride) {
       const fallbackMode = urlModePrevious ?? AppMode.GENERAL;
       if (mode !== fallbackMode) {
@@ -114,18 +124,23 @@ const PaperForm: NextPage<{ error?: IPaperFormServerError }> = ({ error: ssrErro
       setMode(urlModePrevious);
       setUrlModePrevious(null);
     }
-  }, [router, mode, urlModePrevious, urlModeOverride]);
+  }, [router, mode, urlModePrevious, urlModeOverride, forcedAstroFromMode]);
 
   const handleSubmit = useCallback(
     async (params: PaperFormState[PaperFormType]) => {
       try {
+        // The paper form is Astrophysics-only, so the search it produces must
+        // run in Astrophysics regardless of the discipline the user is viewing.
+        if (mode !== AppMode.ASTROPHYSICS) {
+          setMode(AppMode.ASTROPHYSICS);
+        }
         const destination = await getSearchQuery(params, queryClient);
         await router.push(destination);
       } catch (e) {
         setError({ form: params.form, message: (e as Error).message });
       }
     },
-    [queryClient, router, setError],
+    [queryClient, router, setError, mode, setMode],
   );
 
   return (

--- a/src/pages/paper-form.tsx
+++ b/src/pages/paper-form.tsx
@@ -41,7 +41,7 @@ import { fetchVaultSearch, vaultKeys } from '@/api/vault/vault';
 import { SimpleLink } from '@/components/SimpleLink';
 import { IADSApiSearchParams } from '@/api/search/types';
 import { AppMode } from '@/types';
-import { syncUrlDisciplineParam } from '@/utils/appMode';
+import { appModeToDisciplineParam, syncUrlDisciplineParam } from '@/utils/appMode';
 import { useLandingFormPreference } from '@/lib/useLandingFormPreference';
 
 const MAX_SIMPLE_QUERY_BIBCODES = 50;
@@ -135,7 +135,15 @@ const PaperForm: NextPage<{ error?: IPaperFormServerError }> = ({ error: ssrErro
           setMode(AppMode.ASTROPHYSICS);
         }
         const destination = await getSearchQuery(params, queryClient);
-        await router.push(destination);
+        // Pin the discipline in the URL so a shared/bookmarked result stays
+        // Astrophysics regardless of the recipient's mode (classic form does
+        // this via the query builder; the paper builder does not).
+        const url = new URL(destination, 'http://localhost');
+        const disciplineParam = appModeToDisciplineParam(AppMode.ASTROPHYSICS);
+        if (disciplineParam) {
+          url.searchParams.set('d', disciplineParam);
+        }
+        await router.push(`${url.pathname}${url.search}`);
       } catch (e) {
         setError({ form: params.form, message: (e as Error).message });
       }

--- a/src/store/slices/appMode.ts
+++ b/src/store/slices/appMode.ts
@@ -8,6 +8,10 @@ export interface IAppModeState {
   urlModeOverride: AppMode | null;
   urlModeUserSelected: boolean;
   urlModePendingParam: string | null;
+  // Discipline the user had before a /classic-form or /paper-form route forced
+  // ASTROPHYSICS mode; null when no such forced switch is active. Distinct from
+  // urlModeOverride/urlModePrevious, which the form pages reset on mount.
+  forcedAstroFromMode: AppMode | null;
 }
 
 export interface IAppModeAction {
@@ -19,6 +23,7 @@ export interface IAppModeAction {
   setUrlModeOverride: (mode: AppMode | null) => void;
   setUrlModeUserSelected: (selected: boolean) => void;
   setUrlModePendingParam: (param: string | null) => void;
+  setForcedAstroFromMode: (mode: AppMode | null) => void;
 }
 
 export const appModeSlice: StoreSlice<IAppModeState & IAppModeAction> = (set, get) => ({
@@ -28,6 +33,7 @@ export const appModeSlice: StoreSlice<IAppModeState & IAppModeAction> = (set, ge
   urlModeOverride: null,
   urlModeUserSelected: false,
   urlModePendingParam: null,
+  forcedAstroFromMode: null,
   setMode: (mode) => {
     set({ mode }, false, 'mode/setMode');
 
@@ -41,4 +47,5 @@ export const appModeSlice: StoreSlice<IAppModeState & IAppModeAction> = (set, ge
   setUrlModeOverride: (mode) => set({ urlModeOverride: mode }, false, 'mode/setUrlModeOverride'),
   setUrlModeUserSelected: (selected) => set({ urlModeUserSelected: selected }, false, 'mode/setUrlModeUserSelected'),
   setUrlModePendingParam: (param) => set({ urlModePendingParam: param }, false, 'mode/setUrlModePendingParam'),
+  setForcedAstroFromMode: (mode) => set({ forcedAstroFromMode: mode }, false, 'mode/setForcedAstroFromMode'),
 });


### PR DESCRIPTION
Visiting /classic-form or /paper-form in a non-Astrophysics discipline
redirected the user to the home page. The classic and paper forms are
Astrophysics-only, so the app should switch to Astrophysics and show the
existing "Switch back?" notice instead of redirecting. The discipline picker
also lets a user change mode while on the form, so submitting now forces
Astrophysics to keep the search consistent.

- Replace the AppModeRouter redirect with a mode switch plus notice, tracked
  via a new forcedAstroFromMode store field
- Clear the forced switch when navigating away from the form route
- Render the notice from the forced switch when no URL d param is present
- Force Astrophysics in the classic and paper form submit handlers
- Split the form mount effects so search-clearing runs once
