### PR TITLE
fix(vis): resolve object queries before visualization requests

### DIFF
--- a/src/api/vis/vis.test.ts
+++ b/src/api/vis/vis.test.ts
@@ -1,0 +1,66 @@
+import { QueryFunctionContext } from '@tanstack/react-query';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import api from '@/api/api';
+import { ApiTargets } from '@/api/models';
+import { resolveObjectQuery } from '@/api/objects/objects';
+import { IADSApiSearchParams } from '@/api/search/types';
+import { fetchAuthorNetwork, fetchPaperNetwork, fetchResultsGraph, fetchWordCloud } from '@/api/vis/vis';
+
+vi.mock('@/api/api', () => ({
+  default: { request: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+vi.mock('@/api/objects/objects', () => ({
+  resolveObjectQuery: vi.fn().mockResolvedValue({ query: 'abs:LMC' }),
+}));
+
+const request = vi.mocked(api.request);
+const resolve = vi.mocked(resolveObjectQuery);
+
+const ctx = (params: IADSApiSearchParams) =>
+  ({ meta: { params }, queryKey: [], signal: new AbortController().signal } as unknown as QueryFunctionContext);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe.each([
+  ['fetchAuthorNetwork', fetchAuthorNetwork, ApiTargets.SERVICE_AUTHOR_NETWORK],
+  ['fetchPaperNetwork', fetchPaperNetwork, ApiTargets.SERVICE_PAPER_NETWORK],
+  ['fetchWordCloud', fetchWordCloud, ApiTargets.SERVICE_WORDCLOUD],
+] as const)('%s', (_, fetcher, target) => {
+  test('resolves object terms before building the request', async () => {
+    await fetcher(ctx({ q: 'object:LMC', rows: 10 }));
+
+    expect(resolve).toHaveBeenCalledWith({ query: 'object:LMC' });
+    const config = request.mock.calls[0][0];
+    expect(config.url).toEqual(target);
+    expect(JSON.stringify(config.data)).toContain('abs:LMC');
+    expect(JSON.stringify(config.data)).not.toContain('object:LMC');
+  });
+
+  test('skips the object service when no object term is present', async () => {
+    await fetcher(ctx({ q: 'star', rows: 10 }));
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(JSON.stringify(request.mock.calls[0][0].data)).toContain('star');
+  });
+});
+
+describe('fetchResultsGraph', () => {
+  test('resolves object terms before querying search', async () => {
+    await fetchResultsGraph(ctx({ q: 'object:LMC' }));
+
+    expect(resolve).toHaveBeenCalledWith({ query: 'object:LMC' });
+    const config = request.mock.calls[0][0];
+    expect(config.url).toEqual(ApiTargets.SEARCH);
+    expect((config.params as IADSApiSearchParams).q).toEqual('abs:LMC');
+  });
+
+  test('skips the object service when no object term is present', async () => {
+    await fetchResultsGraph(ctx({ q: 'star' }));
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect((request.mock.calls[0][0].params as IADSApiSearchParams).q).toEqual('star');
+  });
+});

--- a/src/api/vis/vis.ts
+++ b/src/api/vis/vis.ts
@@ -11,8 +11,21 @@ import { getAuthorNetworkParams, getPaperNetworkParams, getResultsGraphParams, g
 import { ADSQuery } from '@/api/types';
 import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
 import api, { ApiRequestConfig } from '@/api/api';
+import { resolveObjectQuery } from '@/api/objects/objects';
+import { hasObjectTerm } from '@/api/objects/helpers';
+import { isString } from '@/utils/common/guards';
 
 const MAX_RETRIES = 3;
+
+// vis services forward `q` to Solr untouched, so object terms
+// must be resolved here before the request is built
+const resolveObjectTerms = async (params: IADSApiSearchParams): Promise<IADSApiSearchParams> => {
+  if (isString(params.q) && hasObjectTerm(params.q)) {
+    const { query } = await resolveObjectQuery({ query: params.q });
+    return { ...params, q: query };
+  }
+  return params;
+};
 
 export const visKeys = {
   authorNetwork: (params: IADSApiVisParams) => ['vis/authorNetwork', { ...params }] as const,
@@ -36,18 +49,18 @@ export const useGetAuthorNetwork: ADSQuery<IADSApiSearchParams, IADSApiAuthorNet
     queryKey: visKeys.authorNetwork(authorNetworkParams),
     queryFn: fetchAuthorNetwork,
     retry: retryFn,
-    meta: { params: authorNetworkParams },
+    meta: { params },
     ...options,
   });
 };
 
 export const fetchAuthorNetwork: QueryFunction<IADSApiAuthorNetworkResponse> = async ({ meta }) => {
-  const { params } = meta as { params: IADSApiVisParams };
+  const { params } = meta as { params: IADSApiSearchParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_AUTHOR_NETWORK,
-    data: params,
+    data: getAuthorNetworkParams(await resolveObjectTerms(params)),
   };
 
   const { data } = await api.request<IADSApiAuthorNetworkResponse>(config);
@@ -61,18 +74,18 @@ export const useGetPaperNetwork: ADSQuery<IADSApiSearchParams, IADSApiPaperNetwo
     queryKey: visKeys.paperNetwork(paperNetworkParams),
     queryFn: fetchPaperNetwork,
     retry: retryFn,
-    meta: { params: paperNetworkParams },
+    meta: { params },
     ...options,
   });
 };
 
 export const fetchPaperNetwork: QueryFunction<IADSApiPaperNetworkResponse> = async ({ meta }) => {
-  const { params } = meta as { params: IADSApiVisParams };
+  const { params } = meta as { params: IADSApiSearchParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_PAPER_NETWORK,
-    data: params,
+    data: getPaperNetworkParams(await resolveObjectTerms(params)),
   };
 
   const { data } = await api.request<IADSApiPaperNetworkResponse>(config);
@@ -86,18 +99,18 @@ export const useGetWordCloud: ADSQuery<IADSApiSearchParams, IADSApiWordCloudResp
     queryKey: visKeys.wordCloud(wordCloudParams),
     queryFn: fetchWordCloud,
     retry: retryFn,
-    meta: { params: wordCloudParams },
+    meta: { params },
     ...options,
   });
 };
 
 export const fetchWordCloud: QueryFunction<IADSApiWordCloudResponse> = async ({ meta }) => {
-  const { params } = meta as { params: IADSApiWordCloudParams };
+  const { params } = meta as { params: IADSApiSearchParams };
 
   const config: ApiRequestConfig = {
     method: 'POST',
     url: ApiTargets.SERVICE_WORDCLOUD,
-    data: params,
+    data: getWordCloudParams(await resolveObjectTerms(params)),
   };
 
   const { data } = await api.request<IADSApiWordCloudResponse>(config);
@@ -111,7 +124,7 @@ export const useGetResultsGraph: ADSQuery<IADSApiSearchParams, IADSApiSearchResp
     queryKey: visKeys.resultsGraph(resultsGraphParams),
     queryFn: fetchResultsGraph,
     retry: retryFn,
-    meta: { params: resultsGraphParams },
+    meta: { params },
     ...options,
   });
 };
@@ -122,7 +135,7 @@ export const fetchResultsGraph: QueryFunction<IADSApiSearchResponse> = async ({ 
   const config: ApiRequestConfig = {
     method: 'GET',
     url: ApiTargets.SEARCH,
-    params,
+    params: getResultsGraphParams(await resolveObjectTerms(params)),
   };
 
   const { data } = await api.request<IADSApiSearchResponse>(config);


### PR DESCRIPTION
Queries with object: terms fail on the author network, paper network, concept cloud, and results graph pages. The vis fetchers send the raw q to services that forward it to Solr, which does not understand object: — only the search query functions resolved object terms.

- Resolve object: terms in the four vis query functions before building each request
- Move service-param construction into the fetchers so resolution happens before the query is stringified; query keys unchanged
- Add tests covering resolution and the no-object fast path