### PR TITLE
refactor(search): refactor search page to use URL as state only

### DIFF
--- a/docs/search-page-state.md
+++ b/docs/search-page-state.md
@@ -1,0 +1,108 @@
+# Search Page State Model
+
+As-built design for the search page after the nuqs rewrite
+(`refactor/search-page-nuqs-rewrite`, 2026-07). Supersedes the 2026-03-12
+spec/plan drafts, which were never committed.
+
+## Principle
+
+The URL is the single source of truth for the submitted query. There is no
+store mirror of it: the Zustand search slice no longer holds `latestQuery`,
+`prevQuery`, or `searchStatus`, and no store↔URL sync effects exist. What the
+slice still owns is genuinely client state:
+
+- `query` + `updateQuery` / `queryAddition` / `clearQueryFlag` — the
+  SearchBar's intermediate draft input (see `useIntermediateQuery`)
+- `numPerPage` — the persisted page-size preference
+
+## Hook chain
+
+```
+URL (nuqs) → useSearchQueryParams → useSearchResults → useSearchPage → page shell
+```
+
+All three hooks live in `src/lib/search/`. They must NOT move under
+`src/pages/` — the repo does not configure `pageExtensions`, so any file
+under `src/pages/` becomes a route (this broke the production build once).
+
+### useSearchQueryParams
+
+Declares nuqs parsers for the params the page owns: `q`, `sort`, `p`, `rows`,
+`fq`, `showHighlights`. `fq` and `sort` are native arrays (repeated keys,
+`?fq=A&fq=B`). `sort` and `rows` have no static default: absence means
+"resolve from user settings" (preferred sort, persisted page size), applied
+by `canonicalSearchParams`. Dynamic facet companion params (`fq_author`, …)
+pass through from `router.query`. Writes use history push + Next-shallow +
+no scroll, matching the pre-rewrite navigation.
+
+When a `/search` URL arrives without `sort` or `rows`, the hook stamps the
+resolved values back into the URL (`history: replace`) so every history
+entry captures the full search state — otherwise a later change to the
+user's preferred sort or page size would silently change what old URLs
+mean. The stamp waits for settings when authenticated (so the preferred
+sort, not the static default, is written) and fires at most once per URL
+(arrival-time canonicalization; re-firing could race a concurrent user
+navigation with stale values).
+
+### useSearchResults
+
+Wraps `useSearch` with `keepPreviousData` and derives `searchStatus`
+(`idle | loading | success | empty | error`) from the query state — the
+replacement for the store-written field. Nuance: under `keepPreviousData` a
+new query key sets `isFetching + isPreviousData` (not `isLoading`); that
+combination counts as `loading` so facets stay gated during a genuinely new
+search, while a background refetch of the same key stays `success`. Also
+exposes `numFound`, `isPartialResults`, and the slow-search flag
+(5 s threshold). The page shell renders result skeletons whenever the
+status is `loading` (new query key) rather than showing the previous
+query's docs; `keepPreviousData` still keeps `numFound` and stats stable
+through the transition.
+
+### useSearchPage
+
+Composes params, boost application (`useApplyBoostTypeToParams`), results,
+and all page-level handlers (submit, sort, per-page, facet submission,
+highlights toggle). Effects it owns:
+
+- publishes result bibcodes to the docs slice on genuine success
+- corrects out-of-range `p` to the last valid page after the response
+  (`history: replace`)
+- fires `search_no_results` GTM events, deduped per query
+
+`start` is pure URL math (`(p − 1) × rows`); it is never clamped against a
+previous query's `numFound`. Facet submissions can add dynamic companion
+params nuqs cannot write, so they navigate through `router.push` with the
+full param set.
+
+## SearchQueryContext
+
+`src/lib/SearchQueryContext.tsx` — a read-only context distributing the
+active search's canonical query (`facetParams` = post-boost params minus
+pagination/field-list keys, via `toFacetSearchParams`) and `searchStatus`
+to widgets below the page shell: SearchFacet, YearHistogramSlider, NumFound
+stats, AddToLibraryModal, QueryForm. It is intentionally not writable.
+Outside the search page the default value (`q: ''`, `idle`) keeps consumers
+gated exactly like an idle search.
+
+## Off-page consumers of the submitted query
+
+- **Telemetry** (`src/providers.tsx`): Sentry search-submit/pagination spans
+  key on the `/search` URL (`router.asPath` when `pathname === '/search'`),
+  parsed with `parseQueryFromUrl`.
+- **Feedback** (`src/pages/feedback/general.tsx`): `current_query` comes
+  from the captured back-to-results URL (SCIX-881 session storage), absent
+  when the user has not searched.
+- Landing page and AbstractSearchForm submit purely by `router.push` with
+  `makeSearchParams`; the old `submitQuery()` store action is gone.
+
+## Invariants
+
+- `sort` stays typed as `SolrSort[]` end to end; never cast to `string[]`.
+- Telemetry reads `useRouter()` (Pages Router), not `useSearchParams`.
+- Facet gating (SCIX-871): facet requests fire only when
+  `searchStatus === 'success'`.
+- Second-order operator queries reset sort to relevance on submit (SCIX-889).
+- `numPerPage` is written only by the explicit per-page control, never as a
+  side effect of URL state.
+- Every `/search` history entry is self-describing: missing `sort`/`rows`
+  are stamped into the URL on arrival (see useSearchQueryParams).

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "next": "16.2.6",
     "next-build-id": "^3.0.0",
     "nprogress": "^0.2.0",
+    "nuqs": "^2.9.0",
     "pino": "^8.16.2",
     "pino-pretty": "^10.2.3",
     "prop-types": "^15.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       nprogress:
         specifier: ^0.2.0
         version: 0.2.0
+      nuqs:
+        specifier: ^2.9.0
+        version: 2.9.0(next@16.2.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       pino:
         specifier: ^8.16.2
         version: 8.21.0
@@ -1098,105 +1101,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1347,28 +1334,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -1816,133 +1799,111 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.50.1':
     resolution: {integrity: sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.1':
     resolution: {integrity: sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.1':
     resolution: {integrity: sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.50.1':
     resolution: {integrity: sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
     resolution: {integrity: sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.1':
     resolution: {integrity: sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.1':
     resolution: {integrity: sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.1':
     resolution: {integrity: sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.1':
     resolution: {integrity: sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.1':
     resolution: {integrity: sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.50.1':
     resolution: {integrity: sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.1':
     resolution: {integrity: sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==}
@@ -2122,6 +2083,9 @@ packages:
 
   '@sinclair/typebox@0.34.38':
     resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2669,49 +2633,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5043,6 +4999,27 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nuqs@2.9.0:
+    resolution: {integrity: sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7 || ^8
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
@@ -8342,6 +8319,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.38': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -10352,7 +10331,7 @@ snapshots:
       eslint: 9.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0)
       eslint-plugin-react: 7.37.5(eslint@9.32.0)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.32.0)
@@ -10385,7 +10364,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10400,7 +10379,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11718,6 +11697,13 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuqs@2.9.0(next@16.2.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 18.3.1
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   nwsapi@2.2.20: {}
 

--- a/src/components/AbstractSearchForm/AbstractSearchForm.tsx
+++ b/src/components/AbstractSearchForm/AbstractSearchForm.tsx
@@ -11,7 +11,6 @@ import { SolrSort } from '@/api/models';
 
 export const AbstractSearchForm = () => {
   const { settings } = useSettings();
-  const submitQuery = useStore((state) => state.submitQuery);
   const sort = [`${settings.preferredSearchSort} desc` as SolrSort];
   const query = useStore((state) => state.query.q);
 
@@ -60,7 +59,6 @@ export const AbstractSearchForm = () => {
       const query = new FormData(e.currentTarget).get('q') as string;
 
       if (query && query.trim().length > 0) {
-        submitQuery();
         const defaultedQuery = applyDefaultFilters({ q: query, sort, p: 1 }) as IADSApiSearchParams;
         void router.push({
           pathname: '/search',
@@ -68,7 +66,7 @@ export const AbstractSearchForm = () => {
         });
       }
     },
-    [applyDefaultFilters, sort, submitQuery],
+    [applyDefaultFilters, sort],
   );
 
   return (

--- a/src/components/EmailNotifications/Forms/QueryForm.test.tsx
+++ b/src/components/EmailNotifications/Forms/QueryForm.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SearchQueryProvider } from '@/lib/SearchQueryContext';
 import { QueryForm } from './QueryForm';
 
 const mocks = vi.hoisted(() => ({
@@ -73,12 +74,15 @@ describe('QueryForm', () => {
     }));
   });
 
-  const renderForm = () =>
-    render(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />, {
-      initialStore: {
-        query,
-      },
-    });
+  // QueryForm reads the active search from SearchQueryContext (was the store).
+  // A fresh element per call so rerender() doesn't bail out on identical elements.
+  const formInContext = () => (
+    <SearchQueryProvider value={{ facetParams: query, searchStatus: 'success' }}>
+      <QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />
+    </SearchQueryProvider>
+  );
+
+  const renderForm = () => render(formInContext());
 
   test('renders with the current query and keeps submit disabled when name is empty', () => {
     renderForm();
@@ -134,7 +138,7 @@ describe('QueryForm', () => {
     mocks.searchState.isFetching = false;
     mocks.searchState.data = { qid: 'Q123' };
 
-    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+    rerender(formInContext());
 
     await waitFor(() => {
       expect(mocks.addNotification).toHaveBeenCalledWith(
@@ -171,7 +175,7 @@ describe('QueryForm', () => {
     mocks.searchState.isFetching = false;
     mocks.searchState.error = new Error('Search failed');
 
-    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+    rerender(formInContext());
 
     await waitFor(() => {
       expect(mocks.toast).toHaveBeenCalledWith({
@@ -202,7 +206,7 @@ describe('QueryForm', () => {
     mocks.searchState.isFetching = false;
     mocks.searchState.data = { qid: 'Q999' };
 
-    rerender(<QueryForm onClose={vi.fn()} onUpdated={vi.fn()} />);
+    rerender(formInContext());
 
     await waitFor(() => {
       expect(mocks.addNotification).toHaveBeenCalledWith(

--- a/src/components/EmailNotifications/Forms/QueryForm.tsx
+++ b/src/components/EmailNotifications/Forms/QueryForm.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, FormControl, FormLabel, HStack, Input, useToast } from '@chakra-ui/react';
 
-import { useStore } from '@/store';
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import { Select, SelectOption } from '@/components/Select';
 import { noop } from '@/utils/common/noop';
@@ -24,7 +24,8 @@ const frequencyOptions: SelectOption<NotificationFrequency>[] = [
 export const QueryForm = ({ onClose, onUpdated = noop }: { onClose: () => void; onUpdated?: () => void }) => {
   const toast = useToast();
 
-  const query = useStore((state) => state.query);
+  // canonical query of the active search (URL-derived via SearchQueryContext)
+  const { facetParams: query } = useSearchQuery();
 
   const [frequencyOption, setFrequencyOption] = useState<SelectOption<NotificationFrequency>>(frequencyOptions[0]);
 

--- a/src/components/Libraries/AddToLibraryModal.tsx
+++ b/src/components/Libraries/AddToLibraryModal.tsx
@@ -28,6 +28,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 
 import { useStore } from '@/store';
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { LibraryIdentifier } from '@/api/biblib/types';
@@ -54,7 +55,9 @@ export const AddToLibraryModal = ({
 }) => {
   const selectedDocs = useStore((state) => state.docs.selected);
 
-  const query = useStore((state) => state.query);
+  // canonical query of the active search (URL-derived); off the search page
+  // this is empty, but there the bibcodes/selection path is always used
+  const { facetParams: query } = useSearchQuery();
 
   const clearSelections = useStore((state) => state.clearSelected);
 

--- a/src/components/NumFound/NumFound.tsx
+++ b/src/components/NumFound/NumFound.tsx
@@ -1,6 +1,7 @@
 import { Box, SkeletonText, Text } from '@chakra-ui/react';
-import { useStore } from '@/store';
 import { ReactElement } from 'react';
+
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 
 import { truncateDecimal } from '@/utils/common/formatters';
 import { useGetSearchStats } from '@/api/search/search';
@@ -17,7 +18,7 @@ const sanitizeNum = (num: number): string => {
 
 export const NumFound = (props: INumFoundProps): ReactElement => {
   const { count = 0, isLoading } = props;
-  const searchStatus = useStore((state) => state.searchStatus);
+  const { searchStatus } = useSearchQuery();
 
   if (isLoading) {
     return (
@@ -43,8 +44,8 @@ export const NumFound = (props: INumFoundProps): ReactElement => {
 };
 
 const SortStats = () => {
-  const latestQuery = useStore((state) => state.latestQuery);
-  const { data, isSuccess } = useGetSearchStats(latestQuery);
+  const { facetParams } = useSearchQuery();
+  const { data, isSuccess } = useGetSearchStats(facetParams);
 
   if (isSuccess && 'citation_count' in data.stats_fields) {
     const count = sanitizeNum(data.stats_fields.citation_count.sum);

--- a/src/components/ResultList/ListActions.tsx
+++ b/src/components/ResultList/ListActions.tsx
@@ -52,6 +52,7 @@ import { useColorModeColors } from '@/lib/useColorModeColors';
 import { makeSearchParams, parseQueryFromUrl } from '@/utils/common/search';
 import { noop } from '@/utils/common/noop';
 import { SolrSort, SolrSortField } from '@/api/models';
+import { APP_DEFAULTS } from '@/config';
 import { useVaultBigQuerySearch } from '@/api/vault/vault';
 import { Bibcode } from '@/api/search/types';
 import { ExportApiFormatKey } from '@/api/export/types';
@@ -63,12 +64,16 @@ export interface IListActionsProps {
   onSortChange?: ISortProps<SolrSort, SolrSortField>['onChange'];
   onOpenAddToLibrary: () => void;
   isLoading: boolean;
+  // URL-driven sort and highlights, passed from the page (replaces store reads)
+  currentSort?: SolrSort;
+  showHighlights?: boolean;
+  onToggleHighlights?: () => void;
 }
 
 type Operator = 'trending' | 'reviews' | 'useful' | 'similar';
 
 export const ListActions = (props: IListActionsProps): ReactElement => {
-  const { onSortChange = noop, onOpenAddToLibrary, isLoading } = props;
+  const { onSortChange = noop, onOpenAddToLibrary, isLoading, currentSort, showHighlights, onToggleHighlights } = props;
   const selected = useStore((state) => state.docs.selected ?? []);
   const clearSelected = useStore((state) => state.clearSelected);
   const isClient = useIsClient();
@@ -183,11 +188,11 @@ export const ListActions = (props: IListActionsProps): ReactElement => {
           Result Actions
         </VisuallyHidden>
         <Flex justifyContent="space-between" width="full" gap={1}>
-          <SortWrapper onChange={onSortChange} />
+          <SortWrapper onChange={onSortChange} currentSort={currentSort} />
           {isClient && (
             <Flex gap={1}>
               <NotificationBellButton isAuthenticated={isAuthenticated} onOpenNotification={onCreateNotificationOpen} />
-              <HighlightsToggle />
+              <HighlightsToggle showHighlights={showHighlights} onToggle={onToggleHighlights} />
             </Flex>
           )}
         </Flex>
@@ -306,23 +311,30 @@ export const ListActions = (props: IListActionsProps): ReactElement => {
   );
 };
 
-const sortSelector: [
-  (state: AppState) => AppState['query'],
-  (prev: AppState['query'], next: AppState['query']) => boolean,
-] = [(state) => state.query, (prev, curr) => prev.sort === curr.sort];
-
-const SortWrapper = ({ onChange }: { onChange: ISortProps<SolrSort, SolrSortField>['onChange'] }) => {
-  const query = useStore(...sortSelector);
-
+const SortWrapper = ({
+  onChange,
+  currentSort,
+}: {
+  onChange: ISortProps<SolrSort, SolrSortField>['onChange'];
+  currentSort?: SolrSort;
+}) => {
   return (
-    <Sort<SolrSort, SolrSortField> sort={query.sort[0]} onChange={onChange} options={solrSortOptions} id="sort-order" />
+    <Sort<SolrSort, SolrSortField>
+      sort={currentSort ?? APP_DEFAULTS.SORT[0]}
+      onChange={onChange}
+      options={solrSortOptions}
+      id="sort-order"
+    />
   );
 };
 
-const HighlightsToggle = () => {
-  const showHighlights = useStore((state) => state.showHighlights);
-  const toggleShowHighlights = useStore((state) => state.toggleShowHighlights);
-
+const HighlightsToggle = ({
+  showHighlights = false,
+  onToggle,
+}: {
+  showHighlights?: boolean;
+  onToggle?: () => void;
+}) => {
   return (
     <Tooltip label={`${showHighlights ? 'Hide' : 'Show'} keyword highlights in the results.`}>
       <IconButton
@@ -330,7 +342,7 @@ const HighlightsToggle = () => {
         icon={<FontAwesomeIcon icon={faHighlighter} />}
         aria-label={`${showHighlights ? 'Hide' : 'Show'} keyword highlights in the results.`}
         variant={showHighlights ? 'solid' : 'outline'}
-        onClick={toggleShowHighlights}
+        onClick={onToggle}
       />
     </Tooltip>
   );

--- a/src/components/ResultList/SimpleResultList.tsx
+++ b/src/components/ResultList/SimpleResultList.tsx
@@ -5,7 +5,7 @@ import { HTMLAttributes, ReactElement } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { Item, IItemProps } from './Item';
 import { useHighlights } from './useHighlights';
-import { IDocsEntity } from '@/api/search/types';
+import { IADSApiSearchParams, IDocsEntity } from '@/api/search/types';
 import { handleBoundaryError } from '@/lib/errorHandler';
 import { useResultsRenderSpan } from '@/lib/useRenderSpan';
 
@@ -16,6 +16,9 @@ export interface ISimpleResultListProps extends HTMLAttributes<HTMLDivElement> {
   showOrcidAction?: boolean;
   hideActions?: boolean;
   allowHighlight?: boolean;
+  // params of the query that produced `docs` — highlights zip with docs by index
+  highlightsQuery?: IADSApiSearchParams;
+  showHighlights?: boolean;
   useNormCite?: boolean;
   // Opt-in: this list is also used off the search page (abstract refs, library
   // lists), which must not emit search.*.render spans.
@@ -63,6 +66,8 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
     indexStart = 0,
     hideActions = false,
     allowHighlight = true,
+    highlightsQuery,
+    showHighlights: showHighlightsProp = false,
     useNormCite = false,
     measureRenderSpan = false,
     ...divProps
@@ -73,7 +78,10 @@ export const SimpleResultList = (props: ISimpleResultListProps): ReactElement =>
 
   useResultsRenderSpan(docs, measureRenderSpan);
 
-  const { highlights, showHighlights, isFetchingHighlights } = useHighlights();
+  const { highlights, showHighlights, isFetchingHighlights } = useHighlights(
+    highlightsQuery,
+    allowHighlight && showHighlightsProp,
+  );
 
   return (
     <Flex

--- a/src/components/ResultList/useHighlights.ts
+++ b/src/components/ResultList/useHighlights.ts
@@ -1,24 +1,16 @@
-import { AppState, useStore } from '@/store';
 import { useGetHighlights } from '@/api/search/search';
+import { IADSApiSearchParams } from '@/api/search/types';
 
-const selectors = {
-  latestQuery: (state: AppState) => state.latestQuery,
-  showHighlights: (state: AppState) => state.showHighlights,
-};
+const DISABLED_PARAMS: IADSApiSearchParams = { q: '' };
 
-/**
- * Hook to get highlight data
- *
- * This will fetch highlights based on the latest query in the global store.
- * It also watches the global switch for `showHighlights`, so no fetching will happen unless that is set
- */
-export const useHighlights = () => {
-  const latestQuery = useStore(selectors.latestQuery);
-  const showHighlights = useStore(selectors.showHighlights);
+// Fetches highlights for the given search params, which must match the params
+// of the visible results (including start/rows) so highlights zip with docs by
+// index. No fetching happens unless showHighlights is on and params are given.
+export const useHighlights = (params: IADSApiSearchParams | undefined, showHighlights: boolean) => {
+  const enabled = showHighlights && typeof params !== 'undefined';
 
-  const { isFetching, data } = useGetHighlights(latestQuery, {
-    // will not trigger unless the toggle has been set
-    enabled: showHighlights,
+  const { isFetching, data } = useGetHighlights(params ?? DISABLED_PARAMS, {
+    enabled,
     notifyOnChangeProps: ['data', 'isFetching'],
   });
 

--- a/src/components/SearchFacet/SearchFacet.tsx
+++ b/src/components/SearchFacet/SearchFacet.tsx
@@ -31,7 +31,8 @@ import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } 
 import { CSS } from '@dnd-kit/utilities';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/20/solid';
 import { ExclamationCircleIcon } from '@heroicons/react/24/solid';
-import { AppState, useStore, useStoreApi } from '@/store';
+import { AppState, useStore } from '@/store';
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 import { append, uniq, without } from 'ramda';
 import {
   CSSProperties,
@@ -78,7 +79,7 @@ export interface ISearchFacetProps extends AccordionItemProps {
 }
 
 export const SearchFacet = (props: ISearchFacetProps): ReactElement => {
-  const store = useStoreApi();
+  const { facetParams } = useSearchQuery();
   const setFacetState = useStore((state) => state.setSearchFacetState);
   const hideFacet = useStore((state) => state.hideSearchFacet);
   const showFacet = useStore((state) => state.showSearchFacet);
@@ -113,8 +114,7 @@ export const SearchFacet = (props: ISearchFacetProps): ReactElement => {
   const [hasError, setHasError] = useState(false);
 
   const handleOnFilter = (filterArgs: OnFilterArgs) => {
-    const query = store.getState().latestQuery;
-    onQueryUpdate(applyFiltersToQuery({ ...filterArgs, query }));
+    onQueryUpdate(applyFiltersToQuery({ ...filterArgs, query: facetParams }));
     sendGTMEvent({
       event: 'facet_applied',
       facet_field: filterArgs.field,

--- a/src/components/SearchFacet/YearHistogramSlider.tsx
+++ b/src/components/SearchFacet/YearHistogramSlider.tsx
@@ -2,7 +2,7 @@ import { Box, Center, CircularProgress, Flex, Heading, Icon, IconButton, Text, V
 
 import { getYearsGraph } from '@/components/Visualizations/utils';
 import { getFQValue, removeFQ, setFQ } from '@/query-utils';
-import { useStore } from '@/store';
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 import { memo, useMemo } from 'react';
 import { withErrorBoundary } from '@/hocs/withErrorBoundary';
 import { ArrowsOutIcon } from '@/components/icons/ArrowsOut';
@@ -24,8 +24,7 @@ export interface IYearHistogramSliderProps {
 }
 
 const Component = ({ onQueryUpdate, width, height, onExpand, expanded }: IYearHistogramSliderProps) => {
-  const query = useStore((state) => state.latestQuery);
-  const searchStatus = useStore((state) => state.searchStatus);
+  const { facetParams: query, searchStatus } = useSearchQuery();
 
   // query without the year range filter, to show all years on the histogram
   const cleanedQuery = useMemo(() => {

--- a/src/components/SearchFacet/useGetFacetData.test.ts
+++ b/src/components/SearchFacet/useGetFacetData.test.ts
@@ -1,117 +1,61 @@
 import { describe, test, expect, vi, TestContext } from 'vitest';
-import { renderHook, waitFor, act, createServerListenerMocks, urls } from '@/test-utils';
-import { useStore } from '@/store';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, ReactNode } from 'react';
+import { act, createServerListenerMocks, DefaultProviders, urls } from '@/test-utils';
 import { IUseGetFacetDataProps } from './useGetFacetData';
 import { useGetFacetData } from './useGetFacetData';
-import { defaultQueryParams } from '@/store/slices/search';
-import { FacetField } from '@/api/search/types';
+import { SearchQueryProvider } from '@/lib/SearchQueryContext';
+import { APP_DEFAULTS } from '@/config';
+import { FacetField, IADSApiSearchParams } from '@/api/search/types';
+import { SearchStatus } from '@/types';
 
 vi.mock('@/components/SearchFacet/store/FacetStore', () => ({
   useFacetStore: () => vi.fn(),
 }));
 
-const defaultProps = {
+const defaultProps: IUseGetFacetDataProps = {
   field: 'author_facet_hier' as FacetField,
   prefix: '0/',
   level: 'root' as const,
 };
 
-const useCompound = (props: IUseGetFacetDataProps) => ({
-  setSearchStatus: useStore((state) => state.setSearchStatus),
-  facet: useGetFacetData(props),
-});
+const facetParams: IADSApiSearchParams = { q: 'star', sort: APP_DEFAULTS.SORT };
 
-describe('useGetFacetData', () => {
-  test('does not fire a request when searchStatus is idle', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
-    renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { searchStatus: 'idle', latestQuery: { ...defaultQueryParams, q: 'star' } },
-    });
-
-    await new Promise((r) => setTimeout(r, 200));
-    const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
-    expect(searchRequests).toHaveLength(0);
-  });
-
-  test('does not fire a request when searchStatus is not success (empty)', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
-    renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { searchStatus: 'empty', latestQuery: { ...defaultQueryParams, q: 'star' } },
-    });
-
-    await new Promise((r) => setTimeout(r, 200));
-    const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
-    expect(searchRequests).toHaveLength(0);
-  });
-
-  test('fires a request when latestQuery.q is non-empty', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
-    renderHook(() => useGetFacetData(defaultProps), {
-      initialStore: { searchStatus: 'success', latestQuery: { ...defaultQueryParams, q: 'star' } },
-    });
-
-    await waitFor(() => {
-      const searchRequests = urls(onRequest).filter((u) => u === '/search/query');
-      expect(searchRequests.length).toBeGreaterThan(0);
-    });
-  });
-});
+// SCIX-871 gating now flows through SearchQueryContext (was the store's
+// searchStatus + latestQuery). The wrapper reads status from a closure so
+// transitions are driven by mutating it and calling rerender().
+const renderFacetHook = (initialStatus: SearchStatus) => {
+  const statusRef = { current: initialStatus };
+  const wrapper = ({ children }: { children?: ReactNode }) =>
+    createElement(
+      SearchQueryProvider,
+      { value: { facetParams, searchStatus: statusRef.current } },
+      createElement(DefaultProviders, { options: {} }, children),
+    );
+  const rendered = renderHook(() => useGetFacetData(defaultProps), { wrapper });
+  const setStatus = (status: SearchStatus) => {
+    statusRef.current = status;
+    act(() => rendered.rerender());
+  };
+  return { ...rendered, setStatus };
+};
 
 describe('useGetFacetData — searchStatus gating', () => {
-  test('does not fire when searchStatus is loading', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
+  for (const status of ['idle', 'loading', 'empty', 'error'] as SearchStatus[]) {
+    test(`does not fire a request when searchStatus is ${status}`, async ({ server }: TestContext) => {
+      const { onRequest } = createServerListenerMocks(server);
+      renderFacetHook(status);
 
-    renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'loading',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
+      await new Promise((r) => setTimeout(r, 200));
+      const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
+      expect(facetRequests).toHaveLength(0);
     });
-
-    await new Promise((r) => setTimeout(r, 200));
-    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
-    expect(facetRequests).toHaveLength(0);
-  });
-
-  test('does not fire when searchStatus is empty', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
-
-    renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'empty',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
-    });
-
-    await new Promise((r) => setTimeout(r, 200));
-    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
-    expect(facetRequests).toHaveLength(0);
-  });
-
-  test('does not fire when searchStatus is error', async ({ server }: TestContext) => {
-    const { onRequest } = createServerListenerMocks(server);
-
-    renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'error',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
-    });
-
-    await new Promise((r) => setTimeout(r, 200));
-    const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
-    expect(facetRequests).toHaveLength(0);
-  });
+  }
 
   test('fires and returns data when searchStatus is success', async ({ server }: TestContext) => {
     const { onRequest } = createServerListenerMocks(server);
 
-    const { result } = renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'success',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
-    });
+    const { result } = renderFacetHook('success');
 
     await waitFor(() => {
       const facetRequests = urls(onRequest).filter((u) => u === '/search/query');
@@ -119,56 +63,42 @@ describe('useGetFacetData — searchStatus gating', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+      expect(result.current.treeData.length).toBeGreaterThan(0);
     });
   });
 
   test('regression: loading→success transition unblocks fetch and populates data', async ({ server }: TestContext) => {
     const { onRequest } = createServerListenerMocks(server);
 
-    const { result } = renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'loading',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
-    });
+    const { result, setStatus } = renderFacetHook('loading');
 
     await new Promise((r) => setTimeout(r, 200));
     expect(urls(onRequest).filter((u) => u === '/search/query')).toHaveLength(0);
-    expect(result.current.facet.treeData).toHaveLength(0);
+    expect(result.current.treeData).toHaveLength(0);
 
-    act(() => {
-      result.current.setSearchStatus('success');
-    });
+    setStatus('success');
 
     await waitFor(() => {
       expect(urls(onRequest).filter((u) => u === '/search/query').length).toBeGreaterThan(0);
     });
 
     await waitFor(() => {
-      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+      expect(result.current.treeData.length).toBeGreaterThan(0);
     });
   });
 
   test('success→loading transition clears treeData synchronously', async ({ server }: TestContext) => {
     createServerListenerMocks(server);
 
-    const { result } = renderHook(() => useCompound(defaultProps), {
-      initialStore: {
-        searchStatus: 'success',
-        latestQuery: { ...defaultQueryParams, q: 'star' },
-      },
-    });
+    const { result, setStatus } = renderFacetHook('success');
 
     await waitFor(() => {
-      expect(result.current.facet.treeData.length).toBeGreaterThan(0);
+      expect(result.current.treeData.length).toBeGreaterThan(0);
     });
 
-    act(() => {
-      result.current.setSearchStatus('loading');
-    });
+    setStatus('loading');
 
-    expect(result.current.facet.treeData).toHaveLength(0);
-    expect(result.current.facet.totalResults).toBe(0);
+    expect(result.current.treeData).toHaveLength(0);
+    expect(result.current.totalResults).toBe(0);
   });
 });

--- a/src/components/SearchFacet/useGetFacetData.ts
+++ b/src/components/SearchFacet/useGetFacetData.ts
@@ -2,12 +2,12 @@ import { calculatePagination } from '@/components/ResultList/Pagination/usePagin
 import { getLevelFromKey, getPrevKey } from '@/components/SearchFacet/helpers';
 import { useFacetStore } from '@/components/SearchFacet/store/FacetStore';
 import { FacetItem } from '@/components/SearchFacet/types';
-import { AppState, useStore } from '@/store';
+import { useSearchQuery } from '@/lib/SearchQueryContext';
 import { sanitize } from 'isomorphic-dompurify';
-import { isEmpty, omit } from 'ramda';
+import { isEmpty } from 'ramda';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isNonEmptyString } from 'ramda-adjunct';
-import { FacetField, IADSApiSearchParams, IBucket } from '@/api/search/types';
+import { FacetField, IBucket } from '@/api/search/types';
 import { useGetSearchFacetJSON } from '@/api/search/search';
 import { useObjects } from '@/api/objects/objects';
 
@@ -32,11 +32,9 @@ export interface IUseGetFacetDataProps {
 export const FACET_DEFAULT_LIMIT = 10;
 export const FACET_DEFAULT_PREFIX = '0/';
 
-const querySelector = (state: AppState) => omit(['fl', 'start', 'rows'], state.latestQuery) as IADSApiSearchParams;
-
 export const useGetFacetData = (props: IUseGetFacetDataProps) => {
-  const searchQuery = useStore(querySelector);
-  const searchStatus = useStore((state: AppState) => state.searchStatus);
+  // canonical facet-shaped params + status of the active search (SCIX-871 gating)
+  const { facetParams: searchQuery, searchStatus } = useSearchQuery();
   const {
     field,
     query = '',

--- a/src/components/SearchPage/NoResultsMsg.tsx
+++ b/src/components/SearchPage/NoResultsMsg.tsx
@@ -1,0 +1,38 @@
+import { Flex, List, ListIcon, ListItem } from '@chakra-ui/react';
+import { CheckCircleIcon } from '@chakra-ui/icons';
+
+import { CustomInfoMessage } from '@/components/Feedbacks';
+import { SimpleLink } from '@/components/SimpleLink';
+
+export const NoResultsMsg = () => (
+  <CustomInfoMessage
+    status="info"
+    alertTitle={<>Sorry no results were found</>}
+    description={
+      <List w="100%">
+        <ListItem>
+          <ListIcon as={CheckCircleIcon} color="green.500" />
+          Try broadening your search
+        </ListItem>
+        <ListItem>
+          <ListIcon as={CheckCircleIcon} color="green.500" />
+          Disable any filters that may be applied
+        </ListItem>
+        <ListItem>
+          <Flex direction="row" alignItems="center">
+            <ListIcon as={CheckCircleIcon} color="green.500" />
+            <SimpleLink href="/">Check out some examples</SimpleLink>
+          </Flex>
+        </ListItem>
+        <ListItem>
+          <Flex direction="row" alignItems="center">
+            <ListIcon as={CheckCircleIcon} color="green.500" />
+            <SimpleLink href="/help/search/search-syntax" newTab={true}>
+              Read our help pages
+            </SimpleLink>
+          </Flex>
+        </ListItem>
+      </List>
+    }
+  />
+);

--- a/src/components/SearchPage/PartialResultsWarning.tsx
+++ b/src/components/SearchPage/PartialResultsWarning.tsx
@@ -1,0 +1,18 @@
+import { Alert, AlertIcon, Text } from '@chakra-ui/react';
+
+// warns that results may be incomplete when the response flags partialResults
+export const PartialResultsWarning = ({ isPartialResults }: { isPartialResults?: boolean }) => {
+  if (!isPartialResults) {
+    return null;
+  }
+
+  return (
+    <Alert status="warning" mb={1} borderRadius="md">
+      <AlertIcon />
+      <Text>
+        The search took too long, so some results may be missing. Try refining your query to make it faster and see
+        everything.
+      </Text>
+    </Alert>
+  );
+};

--- a/src/components/SearchPage/SearchErrorFallback.tsx
+++ b/src/components/SearchPage/SearchErrorFallback.tsx
@@ -1,0 +1,15 @@
+import { Alert, AlertIcon, Box, Button, Text } from '@chakra-ui/react';
+import { FallbackProps } from 'react-error-boundary';
+
+// error fallback for the search page's error boundaries
+export const SearchErrorFallback = ({ label, resetErrorBoundary }: FallbackProps & { label: string }) => (
+  <Alert status="error" my={2} borderRadius="md">
+    <AlertIcon />
+    <Box flex="1">
+      <Text>{label}</Text>
+    </Box>
+    <Button size="sm" colorScheme="blue" onClick={resetErrorBoundary}>
+      Try Again
+    </Button>
+  </Alert>
+);

--- a/src/components/SearchPage/SearchFacetFilters.tsx
+++ b/src/components/SearchPage/SearchFacetFilters.tsx
@@ -1,0 +1,194 @@
+import dynamic from 'next/dynamic';
+import { RefObject, useState } from 'react';
+
+import {
+  Box,
+  Button,
+  Center,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerOverlay,
+  Flex,
+  Heading,
+  Icon,
+  IconButton,
+  Portal,
+  Tooltip,
+  useBreakpointValue,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { ArrowPathIcon } from '@heroicons/react/24/solid';
+import { XMarkIcon } from '@heroicons/react/20/solid';
+
+import { IADSApiSearchParams } from '@/api/search/types';
+import { ISearchFacetsProps } from '@/components/SearchFacet';
+import { IYearHistogramSliderProps } from '@/components/SearchFacet/YearHistogramSlider';
+import { AppState, useStore } from '@/store';
+
+const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
+  () =>
+    import('@/components/SearchFacet/YearHistogramSlider').then((mod) => ({
+      default: mod.YearHistogramSlider,
+    })),
+  { ssr: false },
+);
+
+const SearchFacets = dynamic<ISearchFacetsProps>(
+  () =>
+    import('@/components/SearchFacet').then((mod) => ({
+      default: mod.SearchFacets,
+    })),
+  { ssr: false },
+);
+
+const selectors = {
+  showFilters: (state: AppState) => state.settings.searchFacets.open,
+  toggleSearchFacetsOpen: (state: AppState) => state.toggleSearchFacetsOpen,
+  resetSearchFacets: (state: AppState) => state.resetSearchFacets,
+};
+
+export interface ISearchFacetFiltersProps {
+  histogramContainerRef?: RefObject<HTMLDivElement>;
+  onSearchFacetSubmission: (queryUpdates: Partial<IADSApiSearchParams>) => void;
+}
+
+export const SearchFacetFilters = (props: ISearchFacetFiltersProps) => {
+  const { onSearchFacetSubmission, histogramContainerRef } = props;
+  const showFilters = useStore(selectors.showFilters);
+  const handleToggleFilters = useStore(selectors.toggleSearchFacetsOpen);
+  const handleResetFilters = useStore(selectors.resetSearchFacets);
+  const [histogramExpanded, setHistogramExpanded] = useState(false);
+
+  const isMobile = useBreakpointValue({ base: true, lg: false });
+  const { isOpen: isFacetOpen, onClose: onCloseFacet, onOpen: onOpenFacet } = useDisclosure();
+
+  if (isMobile) {
+    return (
+      <>
+        <Box as="aside" aria-labelledby="search-facets">
+          <Portal appendToParentPortal>
+            <Button
+              position="fixed"
+              transform="rotate(90deg)"
+              transformOrigin="bottom left"
+              borderBottomRadius="none"
+              size="xs"
+              type="button"
+              onClick={onOpenFacet}
+              top="240px"
+              left="0"
+              id="tour-search-facets"
+            >
+              Show Filters
+            </Button>
+          </Portal>
+        </Box>
+        <Drawer placement="left" onClose={onCloseFacet} isOpen={isFacetOpen}>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerBody>
+              <SearchFacets onQueryUpdate={onSearchFacetSubmission} />
+            </DrawerBody>
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
+  if (showFilters) {
+    return (
+      <Flex as="aside" aria-labelledby="search-facets" minWidth="250px" direction="column" id="tour-search-facets">
+        <a className="skip-link" href="#results">
+          Skip to search results
+        </a>
+        <Flex mb={5}>
+          <Heading as="h2" id="search-facets" fontSize="normal" flex="1">
+            Filters
+          </Heading>
+          <Tooltip label="Reset filters">
+            <IconButton
+              variant="unstyled"
+              icon={
+                <Center>
+                  <Icon as={ArrowPathIcon} />
+                </Center>
+              }
+              size="xs"
+              fontSize="xl"
+              aria-label="reset filters"
+              type="button"
+              onClick={handleResetFilters}
+              _hover={{
+                backgroundColor: 'blue.50',
+                border: 'solid 1px gray.400',
+              }}
+            />
+          </Tooltip>
+          <Tooltip label="Hide filters">
+            <IconButton
+              variant="unstyled"
+              icon={
+                <Center>
+                  <Icon as={XMarkIcon} />
+                </Center>
+              }
+              size="xs"
+              fontSize="2xl"
+              aria-label="hide filters"
+              type="button"
+              onClick={handleToggleFilters}
+              fontWeight="normal"
+              _hover={{
+                backgroundColor: 'blue.50',
+                border: 'solid 1px gray.400',
+              }}
+            />
+          </Tooltip>
+        </Flex>
+        {histogramExpanded ? (
+          <Portal containerRef={histogramContainerRef}>
+            <Box mt={10}>
+              <YearHistogramSlider
+                onQueryUpdate={onSearchFacetSubmission}
+                onExpand={() => setHistogramExpanded((state) => !state)}
+                expanded={true}
+                width={props.histogramContainerRef?.current?.offsetWidth || 200}
+                height={125}
+              />
+            </Box>
+          </Portal>
+        ) : (
+          <YearHistogramSlider
+            onQueryUpdate={onSearchFacetSubmission}
+            onExpand={() => setHistogramExpanded((state) => !state)}
+            expanded={false}
+            width={200}
+            height={125}
+          />
+        )}
+        <SearchFacets onQueryUpdate={onSearchFacetSubmission} />
+      </Flex>
+    );
+  }
+  return (
+    <>
+      <Portal appendToParentPortal>
+        <Button
+          position="absolute"
+          transform="rotate(90deg)"
+          transformOrigin="bottom left"
+          borderBottomRadius="none"
+          size="xs"
+          type="button"
+          onClick={handleToggleFilters}
+          top="240px"
+          left="0"
+          id="tour-search-facets"
+        >
+          Show Filters
+        </Button>
+      </Portal>
+    </>
+  );
+};

--- a/src/components/SearchPage/index.ts
+++ b/src/components/SearchPage/index.ts
@@ -1,0 +1,5 @@
+export { SearchFacetFilters } from './SearchFacetFilters';
+export type { ISearchFacetFiltersProps } from './SearchFacetFilters';
+export { NoResultsMsg } from './NoResultsMsg';
+export { PartialResultsWarning } from './PartialResultsWarning';
+export { SearchErrorFallback } from './SearchErrorFallback';

--- a/src/lib/SearchQueryContext.tsx
+++ b/src/lib/SearchQueryContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+
+import { IADSApiSearchParams } from '@/api/search/types';
+import { SearchStatus } from '@/types';
+
+export interface ISearchQueryContextValue {
+  // Canonical params of the active search, shaped for facet/stats consumers
+  // (post-boost, no pagination or field-list keys — see toFacetSearchParams).
+  // Replaces the store's latestQuery for search-page widgets.
+  facetParams: IADSApiSearchParams;
+  // lifecycle of the active search — gates facet fetching (SCIX-871)
+  searchStatus: SearchStatus;
+}
+
+// Default mirrors "no active search": consumers rendered outside the search
+// page stay gated exactly like an idle search
+const defaultValue: ISearchQueryContextValue = {
+  facetParams: { q: '' },
+  searchStatus: 'idle',
+};
+
+const SearchQueryContext = createContext<ISearchQueryContextValue>(defaultValue);
+
+// Read-only context carrying the active search's canonical query and status
+// from the search page down to facets, histogram, and result stats. This is
+// intentionally NOT writable — the URL is the source of truth; this only
+// distributes derived values.
+export const SearchQueryProvider = SearchQueryContext.Provider;
+
+export const useSearchQuery = (): ISearchQueryContextValue => useContext(SearchQueryContext);

--- a/src/lib/search/useSearchPage.test.tsx
+++ b/src/lib/search/useSearchPage.test.tsx
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, TestContext, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { FormEvent, ReactNode } from 'react';
+import { rest } from 'msw';
+import { withNuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { DefaultProviders } from '@/test-utils';
+import { useStore } from '@/store';
+import { ApiTargets } from '@/api/models';
+import { IADSApiSearchResponse } from '@/api/search/types';
+import { apiHandlerRoute } from '@/mocks/mockHelpers';
+import { useSearchPage } from './useSearchPage';
+
+const mocks = vi.hoisted(() => ({
+  sendGTMEvent: vi.fn(),
+}));
+
+vi.mock('@next/third-parties/google', () => ({
+  sendGTMEvent: mocks.sendGTMEvent,
+  GoogleTagManager: (): null => null,
+}));
+
+const router = {
+  isReady: true,
+  pathname: '/search',
+  asPath: '/search',
+  query: {} as Record<string, string | string[]>,
+  push: vi.fn(() => Promise.resolve(true)),
+  replace: vi.fn(() => Promise.resolve(true)),
+  events: { on: vi.fn(), off: vi.fn() },
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+const makeWrapper = (searchParams: string) => {
+  router.query = {};
+  router.asPath = `/search${searchParams}`;
+  // hasMemory: URL updates persist like a real browser (the hook writes on mount)
+  const NuqsWrapper = withNuqsTestingAdapter({ searchParams, hasMemory: true });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <NuqsWrapper>
+      <DefaultProviders options={{}}>{children}</DefaultProviders>
+    </NuqsWrapper>
+  );
+  Wrapper.displayName = 'SearchPageTestWrapper';
+  return Wrapper;
+};
+
+// exercise the page hook and observe store writes through the same provider tree
+const useCompound = () => ({
+  page: useSearchPage(),
+  currentDocs: useStore((state) => state.docs.current),
+  numPerPage: useStore((state) => state.numPerPage),
+});
+
+const makeSubmitEvent = (q: string): FormEvent<HTMLFormElement> => {
+  const form = document.createElement('form');
+  const input = document.createElement('input');
+  input.name = 'q';
+  input.value = q;
+  form.appendChild(input);
+  return { preventDefault: vi.fn(), currentTarget: form } as unknown as FormEvent<HTMLFormElement>;
+};
+
+const deterministicResponse = (numFound: number, bibcodes: string[]): IADSApiSearchResponse =>
+  ({
+    response: { numFound, docs: bibcodes.map((bibcode) => ({ bibcode })) },
+  } as IADSApiSearchResponse);
+
+const overrideSearch = (server: TestContext['server'], body: IADSApiSearchResponse) => {
+  server.use(rest.get(apiHandlerRoute(ApiTargets.SEARCH), (_req, res, ctx) => res(ctx.status(200), ctx.json(body))));
+};
+
+describe('useSearchPage', () => {
+  beforeEach(() => {
+    router.push.mockClear();
+    mocks.sendGTMEvent.mockClear();
+  });
+
+  describe('handlers', () => {
+    it('onSubmit updates q, resets p, and preserves the current sort for plain queries', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&sort=citation_count+desc&p=3'),
+      });
+      await act(async () => {
+        result.current.handlers.onSubmit(makeSubmitEvent('galaxies'));
+      });
+      expect(result.current.params.q).toBe('galaxies');
+      expect(result.current.params.p).toBe(1);
+      expect(result.current.params.sort[0]).toBe('citation_count desc');
+    });
+
+    it('onSubmit forces score desc for second-order operator queries (SCIX-889)', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&sort=date+desc'),
+      });
+      await act(async () => {
+        result.current.handlers.onSubmit(makeSubmitEvent('trending(star formation)'));
+      });
+      expect(result.current.params.sort[0]).toBe('score desc');
+    });
+
+    it('onSubmit is a no-op for an empty query', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&p=2'),
+      });
+      await act(async () => {
+        result.current.handlers.onSubmit(makeSubmitEvent(''));
+      });
+      expect(result.current.params.q).toBe('stars');
+      expect(result.current.params.p).toBe(2);
+    });
+
+    it('onSortChange keeps the requested direction for the same field', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&sort=date+desc&p=4'),
+      });
+      await act(async () => {
+        result.current.handlers.onSortChange('date asc');
+      });
+      expect(result.current.params.sort).toEqual(['date asc', 'date desc']);
+      expect(result.current.params.p).toBe(1);
+    });
+
+    it('onSortChange applies the default direction when the field changes', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&sort=date+asc'),
+      });
+      await act(async () => {
+        // first_author defaults to asc even though the current direction is asc-on-date
+        result.current.handlers.onSortChange('first_author desc');
+      });
+      // field changed — the requested direction is replaced by the field default
+      expect(result.current.params.sort[0]).toBe('first_author asc');
+    });
+
+    it('onSortChange is a no-op when the URL has no q', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?sort=date+desc'),
+      });
+      await act(async () => {
+        result.current.handlers.onSortChange('score desc');
+      });
+      expect(result.current.params.sort).toEqual(['date desc']);
+    });
+
+    it('onPerPageChange writes the URL and the persisted preference, resetting p', async () => {
+      const { result } = renderHook(() => useCompound(), {
+        wrapper: makeWrapper('?q=stars&p=5'),
+      });
+      await act(async () => {
+        result.current.page.handlers.onPerPageChange(25);
+      });
+      expect(result.current.page.params.rows).toBe(25);
+      expect(result.current.page.params.p).toBe(1);
+      expect(result.current.numPerPage).toBe(25);
+    });
+
+    it('onFacetSubmission navigates through the router with merged params and p reset', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&p=3'),
+      });
+      await act(async () => {
+        result.current.handlers.onFacetSubmission({ fq: ['{!type=aqp v=$fq_author}'], fq_author: 'author:"Smith, J"' });
+      });
+      expect(router.push).toHaveBeenCalledTimes(1);
+      const [dest, , opts] = router.push.mock.calls[0] as unknown as [
+        { pathname: string; search: string },
+        unknown,
+        { scroll: boolean; shallow: boolean },
+      ];
+      expect(dest.pathname).toBe('/search');
+      expect(dest.search).toContain('fq_author=author');
+      expect(dest.search).toContain('p=1');
+      expect(opts).toEqual({ scroll: false, shallow: true });
+    });
+
+    it('onToggleHighlights flips the showHighlights param', async () => {
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars'),
+      });
+      expect(result.current.showHighlights).toBe(false);
+      await act(async () => {
+        result.current.handlers.onToggleHighlights();
+      });
+      expect(result.current.showHighlights).toBe(true);
+    });
+  });
+
+  describe('result-driven effects', () => {
+    it('publishes result bibcodes to the docs slice on success', async ({ server }: TestContext) => {
+      overrideSearch(server, deterministicResponse(2, ['bibA', 'bibB']));
+      const { result } = renderHook(() => useCompound(), {
+        wrapper: makeWrapper('?q=stars'),
+      });
+      await waitFor(() => expect(result.current.page.results.searchStatus).toBe('success'));
+      await waitFor(() => expect(result.current.currentDocs).toEqual(['bibA', 'bibB']));
+    });
+
+    it('corrects an out-of-range page to the last valid page after the response', async ({ server }: TestContext) => {
+      overrideSearch(server, deterministicResponse(35, ['bib1']));
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&p=99'),
+      });
+      // rows defaults to 10 -> last valid page is 4
+      await waitFor(() => expect(result.current.params.p).toBe(4));
+    });
+
+    it('leaves in-range deep links alone (no clamping by a previous query)', async ({ server }: TestContext) => {
+      overrideSearch(server, deterministicResponse(1000, ['bib1']));
+      const { result } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=stars&p=50'),
+      });
+      await waitFor(() => expect(result.current.results.searchStatus).toBe('success'));
+      expect(result.current.params.p).toBe(50);
+      expect(result.current.start).toBe(490);
+    });
+
+    it('fires search_no_results once per empty query', async ({ server }: TestContext) => {
+      overrideSearch(server, deterministicResponse(0, []));
+      const { result, rerender } = renderHook(() => useSearchPage(), {
+        wrapper: makeWrapper('?q=nothinghere'),
+      });
+      await waitFor(() => expect(result.current.results.searchStatus).toBe('empty'));
+      rerender();
+      rerender();
+      expect(mocks.sendGTMEvent).toHaveBeenCalledTimes(1);
+      expect(mocks.sendGTMEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'search_no_results', query: 'nothinghere' }),
+      );
+    });
+  });
+});

--- a/src/lib/search/useSearchPage.ts
+++ b/src/lib/search/useSearchPage.ts
@@ -1,0 +1,169 @@
+import { FormEventHandler, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useRouter } from 'next/router';
+import { omit } from 'ramda';
+import { sendGTMEvent } from '@next/third-parties/google';
+
+import { SolrSort, SolrSortField, solrDefaultSortDirection } from '@/api/models';
+import { defaultParams } from '@/api/search/models';
+import { IADSApiSearchParams } from '@/api/search/types';
+import { NumPerPageType } from '@/types';
+import { useStore } from '@/store';
+import shallow from 'zustand/shallow';
+import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
+import { getQueryType } from '@/lib/performance';
+import {
+  getDefaultSortForQuery,
+  makeSearchParams,
+  normalizeSolrSort,
+  toFacetSearchParams,
+} from '@/utils/common/search';
+import { useSearchQueryParams } from './useSearchQueryParams';
+import { useSearchResults } from './useSearchResults';
+
+const useDocsActions = () =>
+  useStore(
+    (state) => ({
+      setDocs: state.setDocs,
+      clearAllSelected: state.clearAllSelected,
+      setNumPerPage: state.setNumPerPage,
+    }),
+    shallow,
+  );
+
+// Composes URL state, boost params, and search results with all page-level
+// event handlers. Single import for the search page shell.
+//
+// Intentional store dependencies: appMode (via useApplyBoostTypeToParams),
+// the docs slice (result publication + selection clearing), and the persisted
+// page-size preference. Search state itself lives in the URL.
+export const useSearchPage = () => {
+  const router = useRouter();
+  const { params, setParams, showHighlights, isReady, rawQuery } = useSearchQueryParams();
+  const { setDocs, clearAllSelected: clearSelectedDocs, setNumPerPage } = useDocsActions();
+
+  // start is pure URL math — never clamped against a previous query's numFound;
+  // out-of-range pages are corrected after the response instead (below)
+  const start = (params.p - 1) * params.rows;
+
+  const { params: searchParams } = useApplyBoostTypeToParams({
+    params: useMemo(
+      () => ({ ...defaultParams, ...omit(['p'], params), start } as IADSApiSearchParams),
+      [params, start],
+    ),
+  });
+
+  const results = useSearchResults(searchParams, { enabled: isReady });
+
+  // Facet/stats consumers need the same query identity latestQuery provided:
+  // post-boost params, minus pagination and field-list keys
+  const facetParams = useMemo(() => toFacetSearchParams(searchParams), [searchParams]);
+
+  // Publish result bibcodes to the docs slice on genuine (non-previous) success —
+  // selection state and telemetry span closure depend on this write
+  useEffect(() => {
+    if (results.searchStatus === 'success') {
+      setDocs(results.docs.map((doc) => doc.bibcode));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [results.searchStatus, results.docs]);
+
+  // Correct out-of-range page numbers once the active query's numFound is known
+  useEffect(() => {
+    if (results.searchStatus !== 'success') {
+      return;
+    }
+    const lastPage = Math.max(1, Math.ceil(results.numFound / params.rows));
+    if (params.p > lastPage) {
+      void setParams({ p: lastPage }, { history: 'replace' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [results.searchStatus, results.numFound, params.p, params.rows]);
+
+  // Track the last query that fired search_no_results to prevent duplicate
+  // events when the empty state persists across re-renders
+  const lastNoResultsQuery = useRef<string | null>(null);
+  useEffect(() => {
+    if (results.searchStatus === 'empty' && searchParams.q !== lastNoResultsQuery.current) {
+      lastNoResultsQuery.current = searchParams.q ?? null;
+      sendGTMEvent({
+        event: 'search_no_results',
+        query: searchParams.q,
+        query_type: getQueryType(searchParams.q ?? ''),
+      });
+    }
+    if (results.searchStatus !== 'empty') {
+      lastNoResultsQuery.current = null;
+    }
+  }, [results.searchStatus, searchParams.q]);
+
+  const onSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+    (e) => {
+      e.preventDefault();
+      const q = (new FormData(e.currentTarget).get('q') as string) ?? '';
+      if (q.length === 0) {
+        return;
+      }
+      clearSelectedDocs();
+      // second-order operator queries sort by relevance (SCIX-889)
+      const sort = getDefaultSortForQuery(q, params.sort);
+      void setParams({ q, sort, p: 1 });
+    },
+    [clearSelectedDocs, params.sort, setParams],
+  );
+
+  const onSortChange = useCallback(
+    (sort: SolrSort) => {
+      if (rawQuery.length === 0) {
+        return;
+      }
+      // a change of sort field starts from that field's default direction
+      const currentField = params.sort[0].split(' ')[0];
+      const newField = sort.split(' ')[0] as SolrSortField;
+      const newSort = (
+        currentField === newField ? sort : `${newField} ${solrDefaultSortDirection[newField]}`
+      ) as SolrSort;
+      void setParams({ sort: normalizeSolrSort([newSort]), p: 1 });
+    },
+    [params.sort, rawQuery, setParams],
+  );
+
+  const onPerPageChange = useCallback(
+    (numPerPage: NumPerPageType) => {
+      // explicit user action — the only path that writes the persisted preference
+      setNumPerPage(numPerPage);
+      void setParams({ rows: numPerPage, p: 1 });
+    },
+    [setNumPerPage, setParams],
+  );
+
+  // Facet submissions can add dynamic companion params (fq_author, ...), which
+  // nuqs cannot write — navigate through the router with the full param set
+  const onFacetSubmission = useCallback(
+    (queryUpdates: Partial<IADSApiSearchParams>) => {
+      clearSelectedDocs();
+      const search = makeSearchParams({ ...params, ...queryUpdates, p: 1 });
+      void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
+    },
+    [clearSelectedDocs, params, router],
+  );
+
+  const onToggleHighlights = useCallback(() => {
+    void setParams({ showHighlights: !showHighlights });
+  }, [setParams, showHighlights]);
+
+  return {
+    params,
+    searchParams,
+    facetParams,
+    start,
+    showHighlights,
+    results,
+    handlers: {
+      onSubmit,
+      onSortChange,
+      onPerPageChange,
+      onFacetSubmission,
+      onToggleHighlights,
+    },
+  };
+};

--- a/src/lib/search/useSearchQueryParams.test.tsx
+++ b/src/lib/search/useSearchQueryParams.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, test, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { OnUrlUpdateFunction, withNuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { DefaultProviders } from '@/test-utils';
+import { useSearchQueryParams } from './useSearchQueryParams';
+
+// keep the next/router mock's query in sync with the nuqs adapter's searchParams
+// per test — the hook reads declared keys through nuqs and passthrough keys from
+// router.query
+const router = {
+  isReady: true,
+  pathname: '/search',
+  asPath: '/search',
+  query: {} as Record<string, string | string[]>,
+  push: vi.fn(),
+  replace: vi.fn(),
+  events: { on: vi.fn(), off: vi.fn() },
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+const makeWrapper = (
+  searchParams: string,
+  query: Record<string, string | string[]> = {},
+  options: { onUrlUpdate?: OnUrlUpdateFunction; keepMountUpdates?: boolean } = {},
+) => {
+  router.query = query;
+  router.asPath = `/search${searchParams}`;
+  // hasMemory makes the adapter apply URL updates like a real browser —
+  // required for round-trip assertions now that the hook writes on mount.
+  // keepMountUpdates disables the adapter's mount-time queue reset, which
+  // would abort the hook's own mount-time sort/rows stamp (the real pages
+  // adapter has no such reset); it stays on elsewhere for test isolation.
+  const NuqsWrapper = withNuqsTestingAdapter({
+    searchParams,
+    onUrlUpdate: options.onUrlUpdate,
+    hasMemory: true,
+    resetUrlUpdateQueueOnMount: !options.keepMountUpdates,
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <NuqsWrapper>
+      <DefaultProviders options={{}}>{children}</DefaultProviders>
+    </NuqsWrapper>
+  );
+  Wrapper.displayName = 'SearchQueryParamsTestWrapper';
+  return Wrapper;
+};
+
+describe('useSearchQueryParams', () => {
+  test('returns canonical defaults when the URL has no params', () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper(''),
+    });
+    expect(result.current.params.q).toBe('*:*');
+    expect(result.current.params.p).toBe(1);
+    expect(result.current.params.rows).toBe(10);
+    expect(result.current.params.sort).toEqual(['score desc', 'date desc']);
+    expect(result.current.params).not.toHaveProperty('fq');
+    expect(result.current.showHighlights).toBe(false);
+  });
+
+  test('parses q, p, and repeated fq/sort params from the URL', () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star+formation&p=3&fq=year%3A2020&fq=bibstem%3AApJ&sort=date+desc'),
+    });
+    expect(result.current.params.q).toBe('star formation');
+    expect(result.current.params.p).toBe(3);
+    expect(result.current.params.fq).toEqual(['year:2020', 'bibstem:ApJ']);
+    expect(result.current.params.sort).toEqual(['date desc']);
+  });
+
+  test('passes facet companion params through from router.query', () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star&fq=%7B!type%3Daqp%20v%3D%24fq_author%7D&fq_author=author%3A%22Smith%2C%20J%22', {
+        q: 'star',
+        fq: '{!type=aqp v=$fq_author}',
+        fq_author: 'author:"Smith, J"',
+      }),
+    });
+    expect(result.current.params.fq_author).toBe('author:"Smith, J"');
+  });
+
+  test('setParams round-trips values and resets are visible', async () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=stars&p=3'),
+    });
+    await act(async () => {
+      await result.current.setParams({ q: 'galaxies', p: 1 });
+    });
+    expect(result.current.params.q).toBe('galaxies');
+    expect(result.current.params.p).toBe(1);
+  });
+
+  test('setParams serializes sort and fq arrays as repeated params', async () => {
+    const onUrlUpdate = vi.fn();
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?', {}, { onUrlUpdate }),
+    });
+    await act(async () => {
+      await result.current.setParams({
+        sort: ['score desc', 'date desc'],
+        fq: ['author:"Smith, J"', 'year:2020'],
+      });
+    });
+    // the mount-time sort/rows stamp may have fired first — assert the last update
+    const call = onUrlUpdate.mock.calls.at(-1)[0] as { searchParams: URLSearchParams };
+    expect(call.searchParams.getAll('sort')).toEqual(['score desc', 'date desc']);
+    expect(call.searchParams.getAll('fq')).toEqual(['author:"Smith, J"', 'year:2020']);
+  });
+
+  test('showHighlights parses from the URL and defaults to false', () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star&showHighlights=true'),
+    });
+    expect(result.current.showHighlights).toBe(true);
+  });
+
+  test('invalid rows falls back to the store preference', () => {
+    const { result } = renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star&rows=13'),
+    });
+    // store default numPerPage is 10 (APP_DEFAULTS.RESULT_PER_PAGE)
+    expect(result.current.params.rows).toBe(10);
+  });
+
+  test('stamps resolved sort and rows into the URL when absent (history: replace)', async () => {
+    const onUrlUpdate = vi.fn();
+    renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star', {}, { onUrlUpdate, keepMountUpdates: true }),
+    });
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+    const call = onUrlUpdate.mock.calls[0][0] as {
+      searchParams: URLSearchParams;
+      options: { history: string };
+    };
+    expect(call.searchParams.getAll('sort')).toEqual(['score desc', 'date desc']);
+    expect(call.searchParams.get('rows')).toBe('10');
+    expect(call.searchParams.get('q')).toBe('star');
+    expect(call.options.history).toBe('replace');
+  });
+
+  test('does not rewrite the URL when sort and rows are already present', async () => {
+    const onUrlUpdate = vi.fn();
+    renderHook(() => useSearchQueryParams(), {
+      wrapper: makeWrapper('?q=star&sort=date+desc&rows=25', {}, { onUrlUpdate, keepMountUpdates: true }),
+    });
+    // give the stamp effect a chance to (incorrectly) fire
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(onUrlUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/search/useSearchQueryParams.ts
+++ b/src/lib/search/useSearchQueryParams.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useRouter } from 'next/router';
+import { parseAsBoolean, parseAsInteger, parseAsNativeArrayOf, parseAsString, useQueryStates } from 'nuqs';
+
+import { APP_DEFAULTS } from '@/config';
+import { SolrSortField } from '@/api/models';
+import { useStore } from '@/store';
+import { useSession } from '@/lib/useSession';
+import { useSettings } from '@/lib/useSettings';
+import { canonicalSearchParams, CanonicalSearchParams } from '@/utils/common/search';
+
+// Parsers for the search params this page owns. fq and sort use native arrays
+// (nuqs 2.7+) — the URL contract serializes both as repeated keys (?fq=A&fq=B),
+// and fq values can legitimately contain commas. sort and rows have no static
+// default on purpose: absence means "resolve from the user's settings", which
+// canonicalSearchParams applies.
+export const searchParamsParsers = {
+  q: parseAsString.withDefault(''),
+  sort: parseAsNativeArrayOf(parseAsString),
+  p: parseAsInteger.withDefault(1),
+  rows: parseAsInteger,
+  fq: parseAsNativeArrayOf(parseAsString),
+  showHighlights: parseAsBoolean.withDefault(false),
+};
+
+// history push + Next-shallow + no scroll matches the previous page's
+// router.push(..., { shallow: true, scroll: false }) navigation exactly
+const NUQS_OPTIONS = { history: 'push' as const, shallow: true, scroll: false };
+
+export type SearchQueryParamsSetter = ReturnType<typeof useQueryStates<typeof searchParamsParsers>>[1];
+
+// URL state for the search page. The URL is the single source of truth:
+// declared params are read/written through nuqs (which reads from router.query
+// and writes through the Next router, so router.asPath and route events stay
+// accurate); dynamic facet companion params (fq_author, ...) pass through from
+// router.query into the canonical params.
+export const useSearchQueryParams = () => {
+  const router = useRouter();
+  const [urlState, setParams] = useQueryStates(searchParamsParsers, NUQS_OPTIONS);
+  const { isAuthenticated } = useSession();
+  const { settings, getSettingsState } = useSettings({ suspense: false });
+  const numPerPage = useStore((state) => state.numPerPage);
+
+  const preferredSortField = (settings?.preferredSearchSort ?? APP_DEFAULTS.PREFERRED_SEARCH_SORT) as SolrSortField;
+
+  const params: CanonicalSearchParams = useMemo(
+    () => canonicalSearchParams({ ...router.query, ...urlState }, { preferredSortField, numPerPage }),
+    // router.query identity changes on every navigation; urlState is stable via nuqs
+    [router.query, urlState, preferredSortField, numPerPage],
+  );
+
+  // Stamp resolved sort/rows into the URL when they're absent so every history
+  // entry captures the full search state — otherwise a later change to the
+  // user's preferred sort or page size silently changes what old URLs mean.
+  // For authenticated users, wait for settings so the preferred sort (not the
+  // static default) is what gets written. Guarded to one stamp per URL: this
+  // is arrival-time canonicalization, and re-firing on later renders could
+  // race a concurrent user navigation with stale values.
+  const needsSort = urlState.sort === null || urlState.sort.length === 0;
+  const needsRows = urlState.rows === null;
+  const isSettingsReady = !isAuthenticated || getSettingsState.isFetched;
+  const stampedUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!router.isReady || !isSettingsReady || (!needsSort && !needsRows)) {
+      return;
+    }
+    if (stampedUrlRef.current === router.asPath) {
+      return;
+    }
+    stampedUrlRef.current = router.asPath;
+    void setParams(
+      {
+        ...(needsSort ? { sort: params.sort } : {}),
+        ...(needsRows ? { rows: params.rows } : {}),
+      },
+      { history: 'replace' },
+    );
+  }, [router.isReady, router.asPath, isSettingsReady, needsSort, needsRows, params.sort, params.rows, setParams]);
+
+  return {
+    params,
+    setParams,
+    showHighlights: urlState.showHighlights,
+    // the raw (uncanonicalized) q — empty string when the URL has no query
+    rawQuery: urlState.q,
+    isReady: router.isReady,
+  };
+};

--- a/src/lib/search/useSearchResults.test.ts
+++ b/src/lib/search/useSearchResults.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, TestContext, vi } from 'vitest';
+import { rest } from 'msw';
+import { renderHook, waitFor } from '@/test-utils';
+import { ApiTargets } from '@/api/models';
+import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
+import { apiHandlerRoute } from '@/mocks/mockHelpers';
+import { SLOW_SEARCH_THRESHOLD_MS, useSearchResults } from './useSearchResults';
+
+const params: IADSApiSearchParams = {
+  q: 'star formation',
+  sort: ['score desc', 'date desc'],
+  start: 0,
+  rows: 10,
+};
+
+type ResponseOverrides = {
+  response?: Partial<IADSApiSearchResponse['response']>;
+  responseHeader?: Partial<IADSApiSearchResponse['responseHeader']>;
+};
+
+const makeResponse = (overrides: ResponseOverrides = {}): IADSApiSearchResponse =>
+  ({
+    response: {
+      numFound: 2,
+      docs: [{ bibcode: 'bib1' }, { bibcode: 'bib2' }],
+    },
+    ...overrides,
+  } as IADSApiSearchResponse);
+
+const useSearchOverride = (server: TestContext['server'], body: IADSApiSearchResponse, status = 200) => {
+  server.use(rest.get(apiHandlerRoute(ApiTargets.SEARCH), (_req, res, ctx) => res(ctx.status(status), ctx.json(body))));
+};
+
+describe('useSearchResults', () => {
+  test('loading then success with docs and numFound', async ({ server }: TestContext) => {
+    useSearchOverride(server, makeResponse());
+    const { result } = renderHook(() => useSearchResults(params));
+    expect(result.current.searchStatus).toBe('loading');
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.searchStatus).toBe('success'));
+    expect(result.current.docs).toHaveLength(2);
+    expect(result.current.numFound).toBe(2);
+    expect(result.current.isPartialResults).toBe(false);
+  });
+
+  test('disabled query is idle and does not fetch, even with a warm cache', async ({ server }: TestContext) => {
+    const onRequest = vi.fn();
+    server.events.on('request:start', onRequest);
+    const { result } = renderHook(() => useSearchResults(params, { enabled: false }));
+    expect(result.current.searchStatus).toBe('idle');
+    expect(result.current.isSlowSearch).toBe(false);
+    // give any accidental fetch a chance to fire
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onRequest).not.toHaveBeenCalled();
+    server.events.removeListener('request:start', onRequest);
+  });
+
+  test('numFound of 0 derives empty status', async ({ server }: TestContext) => {
+    useSearchOverride(server, makeResponse({ response: { numFound: 0, docs: [] } }));
+    const { result } = renderHook(() => useSearchResults(params));
+    await waitFor(() => expect(result.current.searchStatus).toBe('empty'));
+    expect(result.current.docs).toEqual([]);
+  });
+
+  test('request failure derives error status', async ({ server }: TestContext) => {
+    useSearchOverride(server, makeResponse(), 500);
+    const { result } = renderHook(() => useSearchResults(params));
+    await waitFor(() => expect(result.current.searchStatus).toBe('error'), { timeout: 10000 });
+    expect(result.current.isError).toBe(true);
+  });
+
+  test('partialResults flag surfaces from the response header', async ({ server }: TestContext) => {
+    useSearchOverride(server, makeResponse({ responseHeader: { partialResults: true } }));
+    const { result } = renderHook(() => useSearchResults(params));
+    await waitFor(() => expect(result.current.isPartialResults).toBe(true));
+  });
+
+  test('new query key keeps previous docs but flips status to loading; resolves to success', async ({
+    server,
+  }: TestContext) => {
+    useSearchOverride(server, makeResponse());
+    const { result, rerender } = renderHook(({ p }: { p: IADSApiSearchParams }) => useSearchResults(p), undefined, {
+      initialProps: { p: params },
+    });
+    await waitFor(() => expect(result.current.searchStatus).toBe('success'));
+
+    // delay the next response so the loading window is observable
+    server.use(
+      rest.get(apiHandlerRoute(ApiTargets.SEARCH), async (_req, res, ctx) =>
+        res(ctx.delay(150), ctx.status(200), ctx.json(makeResponse())),
+      ),
+    );
+    rerender({ p: { ...params, q: 'galaxies' } });
+
+    // keepPreviousData: docs remain visible while the NEW search gates as loading
+    await waitFor(() => expect(result.current.searchStatus).toBe('loading'));
+    expect(result.current.docs).toHaveLength(2);
+    await waitFor(() => expect(result.current.searchStatus).toBe('success'));
+  });
+
+  test('q flipping to disabled overrides retained data with idle', async ({ server }: TestContext) => {
+    useSearchOverride(server, makeResponse());
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useSearchResults(params, { enabled }),
+      undefined,
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.searchStatus).toBe('success'));
+    rerender({ enabled: false });
+    expect(result.current.searchStatus).toBe('idle');
+  });
+
+  test('slow search flips after the threshold and resets when settled', async ({ server }: TestContext) => {
+    // only fake the timeout APIs — faking performance breaks GTM's performance.mark
+    vi.useFakeTimers({
+      shouldAdvanceTime: true,
+      shouldClearNativeTimers: true,
+      toFake: ['setTimeout', 'clearTimeout'],
+    });
+    server.use(
+      rest.get(apiHandlerRoute(ApiTargets.SEARCH), async (_req, res, ctx) =>
+        res(ctx.delay(SLOW_SEARCH_THRESHOLD_MS * 3), ctx.status(200), ctx.json(makeResponse())),
+      ),
+    );
+    const { result } = renderHook(() => useSearchResults(params));
+    expect(result.current.isSlowSearch).toBe(false);
+    await vi.advanceTimersByTimeAsync(SLOW_SEARCH_THRESHOLD_MS + 100);
+    await waitFor(() => expect(result.current.isSlowSearch).toBe(true));
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/search/useSearchResults.ts
+++ b/src/lib/search/useSearchResults.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+
+import { useSearch } from '@/api/search/search';
+import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
+import { SearchStatus } from '@/types';
+
+export const SLOW_SEARCH_THRESHOLD_MS = 5000;
+
+export interface IUseSearchResultsOptions {
+  // whether the search should run at all — evaluated first in the status
+  // derivation so a disabled query is always `idle`, even with retained data
+  enabled?: boolean;
+}
+
+// Wraps useSearch() for the search page. Selects the full response (numFound
+// and responseHeader.partialResults live outside the default `response`
+// selection) and derives the search lifecycle status from the query state —
+// replacing the store-written searchStatus field.
+//
+// keepPreviousData keeps prior results visible during page/sort transitions.
+// Under it, a NEW query key does not set isLoading — it sets isFetching with
+// isPreviousData — so that combination must also count as `loading` to keep
+// facets gated while a genuinely new search is in flight. A background
+// refetch of the same key (isFetching, not previous) stays `success`.
+export const useSearchResults = (params: IADSApiSearchParams, { enabled = true }: IUseSearchResultsOptions = {}) => {
+  const { data, isLoading, isFetching, isError, isSuccess, isPreviousData, error, refetch } =
+    useSearch<IADSApiSearchResponse>(params, {
+      select: (data) => data,
+      keepPreviousData: true,
+      enabled,
+    });
+
+  const numFound = data?.response?.numFound ?? 0;
+
+  const searchStatus: SearchStatus = !enabled
+    ? 'idle'
+    : isError
+    ? 'error'
+    : isLoading || (isFetching && isPreviousData)
+    ? 'loading'
+    : isSuccess && numFound === 0
+    ? 'empty'
+    : isSuccess
+    ? 'success'
+    : 'loading';
+
+  // Flag searches that exceed the threshold so the page can show a wait notice.
+  // Mirrors the pre-rewrite behavior: the timer runs for any in-flight fetch.
+  const [isSlowSearch, setIsSlowSearch] = useState(false);
+  useEffect(() => {
+    if (!enabled || !(isLoading || isFetching)) {
+      setIsSlowSearch(false);
+      return;
+    }
+    const timeoutId = setTimeout(() => setIsSlowSearch(true), SLOW_SEARCH_THRESHOLD_MS);
+    return () => clearTimeout(timeoutId);
+  }, [enabled, isLoading, isFetching]);
+
+  return {
+    docs: data?.response?.docs ?? [],
+    numFound,
+    isPartialResults: Boolean(data?.responseHeader?.partialResults),
+    searchStatus,
+    isSlowSearch,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    error,
+    refetch,
+  };
+};

--- a/src/lib/useSearchResultsTour.ts
+++ b/src/lib/useSearchResultsTour.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { useShepherd } from 'react-shepherd';
+
+import { getResultsSteps } from '@/components/NavBar';
+import { LocalSettings } from '@/types';
+
+// starts the search-results tour the first time the results list renders
+export const useSearchResultsTour = () => {
+  const Shepherd = useShepherd();
+  const [isRendered, setIsRendered] = useState(false);
+
+  // tour should not start until the first element is rendered
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const element = document.getElementById('sort-order');
+      if (element) {
+        setIsRendered(true);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (isRendered && !localStorage.getItem(LocalSettings.SEEN_RESULTS_TOUR)) {
+      const tour = new Shepherd.Tour({
+        useModalOverlay: true,
+        defaultStepOptions: {
+          scrollTo: false,
+          cancelIcon: {
+            enabled: true,
+          },
+        },
+        exitOnEsc: true,
+      });
+      tour.addSteps(getResultsSteps());
+      localStorage.setItem(LocalSettings.SEEN_RESULTS_TOUR, 'true');
+
+      const listener = (e: MouseEvent) => {
+        if ((e.target as HTMLElement).closest('.shepherd-modal-overlay-container')) {
+          tour.cancel();
+        }
+      };
+      tour.on('start', () => {
+        document.addEventListener('click', listener);
+      });
+      tour.on('cancel', () => {
+        document.removeEventListener('click', listener);
+      });
+      tour.on('complete', () => {
+        document.removeEventListener('click', listener);
+      });
+
+      setTimeout(() => {
+        tour.start();
+      }, 1000);
+    }
+  }, [isRendered, Shepherd]);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,6 +23,7 @@ import api from '@/api/api';
 import { userKeys } from '@/api/user/user';
 import { Providers } from '@/providers';
 import { isValidToken } from '@/auth-utils';
+import { NuqsAdapter } from 'nuqs/adapters/next/pages';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -62,7 +63,7 @@ const NectarApp = memo(({ Component, pageProps }: AppProps): ReactElement => {
   }, [router]);
 
   return (
-    <>
+    <NuqsAdapter>
       <Head>
         <title>{BRAND_NAME_FULL}</title>
         <DefaultMeta />
@@ -76,7 +77,7 @@ const NectarApp = memo(({ Component, pageProps }: AppProps): ReactElement => {
           <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
         </Layout>
       </Providers>
-    </>
+    </NuqsAdapter>
   );
 });
 NectarApp.displayName = 'NectarApp';

--- a/src/pages/feedback/general.tsx
+++ b/src/pages/feedback/general.tsx
@@ -15,7 +15,8 @@ import {
 import * as Sentry from '@sentry/nextjs';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useStore } from '@/store';
+import { SessionStorageKey } from '@/lib/session/sessionStore';
+import { useSessionValue } from '@/lib/session/useSessionValue';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { MouseEvent, useCallback, useState } from 'react';
@@ -38,7 +39,7 @@ import { FeedbackLayout } from '@/components/Layout';
 import { FeedbackAlert } from '@/components/FeedbackForms';
 import { RecaptchaMessage } from '@/components/RecaptchaMessage/RecaptchaMessage';
 import { useGetUserEmail } from '@/lib/useGetUserEmail';
-import { makeSearchParams } from '@/utils/common/search';
+import { makeSearchParams, parseQueryFromUrl } from '@/utils/common/search';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { useFeedback } from '@/api/feedback/feedback';
 import { logger } from '@/logger';
@@ -58,7 +59,9 @@ const validationSchema = z.object({
 
 const General: NextPage = () => {
   const userEmail = useGetUserEmail();
-  const currentQuery = useStore((state) => state.latestQuery);
+  // latest search lives in the URL now; the captured return-to-results URL
+  // (SCIX-881) is the cross-page record of the user's most recent search
+  const { value: searchUrl } = useSessionValue<string>(SessionStorageKey.SearchReturnUrl);
   const [formError, setFormError] = useState<Error | string | null>(null);
 
   const [alertDetails, setAlertDetails] = useState<{ status: AlertStatus; title: string; description?: string }>({
@@ -130,7 +133,7 @@ const General: NextPage = () => {
             platform,
             os: `${osName} ${osVersion}`,
             current_page: router.query.from ? (router.query.from as string) : undefined,
-            current_query: makeSearchParams(currentQuery),
+            current_query: searchUrl ? makeSearchParams(parseQueryFromUrl(searchUrl)) : undefined,
             url: router.asPath,
             comments,
           },
@@ -175,7 +178,7 @@ const General: NextPage = () => {
       onAlertOpen,
       reset,
       makeSearchParams,
-      currentQuery,
+      searchUrl,
       router.query.from,
       router.asPath,
       userEmail,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,6 @@ const HomePage: NextPage = () => {
   const [queryAddition, setQueryAddition] = useState('');
   const [query, setQuery] = useState<string>('');
   const sort = [`${settings.preferredSearchSort} desc` as SolrSort];
-  const submitQuery = useStore((state) => state.submitQuery);
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const clearSelectedDocs = useStore((state) => state.clearAllSelected);
@@ -141,7 +140,6 @@ const HomePage: NextPage = () => {
 
       if (query && query.trim().length > 0) {
         setIsLoading(true);
-        submitQuery();
         const querySortOverride = getDefaultSortForQuery(query, sort);
         const defaultedQuery = applyDefaultFilters({ q: query, sort: querySortOverride, p: 1 }) as IADSApiSearchParams;
         void router
@@ -154,7 +152,7 @@ const HomePage: NextPage = () => {
           });
       }
     },
-    [applyDefaultFilters, router, setIsLoading, sort, submitQuery],
+    [applyDefaultFilters, router, setIsLoading, sort],
   );
 
   const handleQueryExampleSelect = useCallback(

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,220 +1,51 @@
-import dynamic from 'next/dynamic';
-import { IYearHistogramSliderProps } from '@/components/SearchFacet/YearHistogramSlider';
-import { ISearchFacetsProps } from '@/components/SearchFacet';
-import { AppState, useStore, useStoreApi } from '@/store';
-import { last, omit } from 'ramda';
-import shallow from 'zustand/shallow';
 import { NextPage } from 'next';
-import { useRouter } from 'next/router';
-import { useQueryClient } from '@tanstack/react-query';
+import Head from 'next/head';
+import { useMemo, useRef } from 'react';
 
 import {
   Alert,
   AlertIcon,
   Box,
-  Button,
-  Center,
-  Drawer,
-  DrawerBody,
-  DrawerContent,
-  DrawerOverlay,
   Flex,
-  Heading,
-  Icon,
-  IconButton,
-  List,
-  ListIcon,
-  ListItem,
-  Portal,
   Stack,
   Text,
-  Tooltip,
-  useBreakpointValue,
   useDisclosure,
   useMediaQuery,
   VisuallyHidden,
 } from '@chakra-ui/react';
-import { calculateStartIndex } from '@/components/ResultList/Pagination/usePagination';
-import { FormEventHandler, RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { BRAND_NAME_FULL } from '@/config';
+import { HideOnPrint } from '@/components/HideOnPrint';
+import { AddToLibraryModal } from '@/components/Libraries';
+import { NumFound } from '@/components/NumFound';
+import { ItemsSkeleton, ListActions, Pagination, SimpleResultList } from '@/components/ResultList';
+import { SearchBar } from '@/components/SearchBar';
+import { FacetFilters } from '@/components/SearchFacet/FacetFilters';
+import { NoResultsMsg, PartialResultsWarning, SearchErrorFallback, SearchFacetFilters } from '@/components/SearchPage';
+import { SearchErrorAlert } from '@/components/SolrErrorAlert/SolrErrorAlert';
+import { handleBoundaryError } from '@/lib/errorHandler';
+import { SearchQueryProvider } from '@/lib/SearchQueryContext';
+import { useSearchPage } from '@/lib/search/useSearchPage';
 import { useIsClient } from '@/lib/useIsClient';
 import { useScrollRestoration } from '@/lib/useScrollRestoration';
+import { useSearchResultsTour } from '@/lib/useSearchResultsTour';
 import { useCaptureSearchReturnUrl } from '@/lib/useSearchReturnTo';
-import { LocalSettings, NumPerPageType } from '@/types';
-import Head from 'next/head';
-import { APP_DEFAULTS, BRAND_NAME_FULL } from '@/config';
-import { HideOnPrint } from '@/components/HideOnPrint';
-import { SearchBar } from '@/components/SearchBar';
-import { NumFound } from '@/components/NumFound';
-import { FacetFilters } from '@/components/SearchFacet/FacetFilters';
-import { ItemsSkeleton, ListActions, Pagination, SimpleResultList } from '@/components/ResultList';
-import { AddToLibraryModal } from '@/components/Libraries';
-import { ArrowPathIcon } from '@heroicons/react/24/solid';
-import { XMarkIcon } from '@heroicons/react/20/solid';
-import { CustomInfoMessage } from '@/components/Feedbacks';
-import { CheckCircleIcon } from '@chakra-ui/icons';
-import { SimpleLink } from '@/components/SimpleLink';
-import { getDefaultSortForQuery, makeSearchParams, normalizeSolrSort, parseQueryFromUrl } from '@/utils/common/search';
-import { IADSApiSearchParams, IADSApiSearchResponse } from '@/api/search/types';
-import { SEARCH_API_KEYS, useSearch } from '@/api/search/search';
-import { sendGTMEvent } from '@next/third-parties/google';
-import { getQueryType } from '@/lib/performance';
-import { defaultParams } from '@/api/search/models';
-import { solrDefaultSortDirection, SolrSort, SolrSortField } from '@/api/models';
-import { useApplyBoostTypeToParams } from '@/lib/useApplyBoostTypeToParams';
-import { SearchErrorAlert } from '@/components/SolrErrorAlert/SolrErrorAlert';
-import { useSettings } from '@/lib/useSettings';
-import { getResultsSteps } from '@/components/NavBar';
-import { useShepherd } from 'react-shepherd';
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
-import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { handleBoundaryError } from '@/lib/errorHandler';
-
-const YearHistogramSlider = dynamic<IYearHistogramSliderProps>(
-  () =>
-    import('@/components/SearchFacet/YearHistogramSlider').then((mod) => ({
-      default: mod.YearHistogramSlider,
-    })),
-  { ssr: false },
-);
-
-const SearchFacets = dynamic<ISearchFacetsProps>(
-  () =>
-    import('@/components/SearchFacet').then((mod) => ({
-      default: mod.SearchFacets,
-    })),
-  { ssr: false },
-);
-
-// useLayoutEffect triggers an SSR warning on server-rendered pages; use
-// useEffect on the server where layout effects are a no-op anyway.
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
-
-/**
- * Consolidated selector for search page store values
- * Using shallow comparison to prevent unnecessary re-renders
- */
-const useSearchPageStore = () =>
-  useStore(
-    (state) => ({
-      numPerPage: state.numPerPage,
-      sort: state.query.sort[0],
-      setQuery: state.setQuery,
-      updateQuery: state.updateQuery,
-      submitQuery: state.submitQuery,
-      setNumPerPage: state.setNumPerPage,
-      setDocs: state.setDocs,
-      clearAllSelected: state.clearAllSelected,
-      setSearchStatus: state.setSearchStatus,
-    }),
-    shallow,
-  );
-
-const selectors = {
-  showFilters: (state: AppState) => state.settings.searchFacets.open,
-  toggleSearchFacetsOpen: (state: AppState) => state.toggleSearchFacetsOpen,
-  resetSearchFacets: (state: AppState) => state.resetSearchFacets,
-};
-
-const omitP = omit(['p']);
-
-/**
- * Error fallback component for error boundaries
- */
-const ErrorFallback = ({ label, resetErrorBoundary }: FallbackProps & { label: string }) => (
-  <Alert status="error" my={2} borderRadius="md">
-    <AlertIcon />
-    <Box flex="1">
-      <Text>{label}</Text>
-    </Box>
-    <Button size="sm" colorScheme="blue" onClick={resetErrorBoundary}>
-      Try Again
-    </Button>
-  </Alert>
-);
 
 const SearchPage: NextPage = () => {
-  const router = useRouter();
-  const store = useStoreApi();
+  const { params, searchParams, facetParams, results, handlers, start, showHighlights } = useSearchPage();
 
-  // Consolidated store selector - reduces subscription overhead
-  const {
-    numPerPage: storeNumPerPage,
-    sort,
-    setQuery,
-    updateQuery,
-    submitQuery,
-    setNumPerPage,
-    setDocs,
-    clearAllSelected: clearSelectedDocs,
-    setSearchStatus,
-  } = useSearchPageStore();
+  // distributes the active search's canonical query + status to facets,
+  // histogram, and result stats (read-only — the URL is the source of truth)
+  const searchQueryContextValue = useMemo(
+    () => ({ facetParams, searchStatus: results.searchStatus }),
+    [facetParams, results.searchStatus],
+  );
 
-  const { settings } = useSettings({ suspense: false });
-
-  const queryClient = useQueryClient();
-  const queries = queryClient.getQueriesData<IADSApiSearchResponse>([SEARCH_API_KEYS.primary]);
-  // Safely extract numFound with defensive null checks
-  const lastQuery = queries.length > 1 ? last(queries) : null;
-  const numFound = lastQuery?.[1]?.response?.numFound;
   const [isPrint] = useMediaQuery('print');
-
-  // parse the query params from the URL, this should match what the server parsed
-  const parsedParams = parseQueryFromUrl(router.asPath);
-  const hasSortParam = useMemo(() => {
-    const queryString = router.asPath.split('?')[1];
-    if (!queryString) {
-      return false;
-    }
-    return new URLSearchParams(queryString).has('sort');
-  }, [router.asPath]);
-  const preferredSortField = settings?.preferredSearchSort ?? APP_DEFAULTS.PREFERRED_SEARCH_SORT;
-  const preferredSort = useMemo(
-    () => normalizeSolrSort([`${preferredSortField} ${solrDefaultSortDirection[preferredSortField]}`]),
-    [preferredSortField],
-  );
-  const sortWithDefault = hasSortParam ? parsedParams.sort : preferredSort;
-  const { params } = useApplyBoostTypeToParams({
-    params: {
-      ...defaultParams,
-      ...parsedParams,
-      sort: sortWithDefault,
-      rows: storeNumPerPage,
-      start: calculateStartIndex(parsedParams.p, storeNumPerPage, numFound),
-    },
-  });
-
-  const searchParams = omitP(params) as IADSApiSearchParams;
-  const { data, isSuccess, isLoading, isFetching, error, isError, refetch } = useSearch<IADSApiSearchResponse>(
-    searchParams,
-    { select: (data) => data },
-  );
-  const histogramContainerRef = useRef<HTMLDivElement>(null);
   const isClient = useIsClient();
-
-  // Track if search is taking longer than expected
-  const SLOW_SEARCH_THRESHOLD_MS = 5000;
-  const [isSlowSearch, setIsSlowSearch] = useState(false);
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout | null = null;
-    let isMounted = true;
-
-    if (isLoading || isFetching) {
-      timeoutId = setTimeout(() => {
-        if (isMounted) {
-          setIsSlowSearch(true);
-        }
-      }, SLOW_SEARCH_THRESHOLD_MS);
-    } else {
-      setIsSlowSearch(false);
-    }
-
-    return () => {
-      isMounted = false;
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [isLoading, isFetching]);
+  const histogramContainerRef = useRef<HTMLDivElement>(null);
 
   // Scroll restoration hook - automatically restores scroll position when returning from abstract page
   useScrollRestoration();
@@ -225,492 +56,146 @@ const SearchPage: NextPage = () => {
   const { isOpen: isAddToLibraryOpen, onClose: onCloseAddToLibrary, onOpen: onOpenAddToLibrary } = useDisclosure();
 
   // start tour on the first time
-  useTour();
-
-  // on Sort change handler
-  const handleSortChange = (sort: SolrSort) => {
-    const query = store.getState().query;
-    if (query.q.length === 0) {
-      // if query is empty, do not submit search
-      return;
-    }
-
-    // if sort field has changed, use its default sort order
-    const currentSortField = query.sort[0].split(' ')[0];
-    const newSortField = sort.split(' ')[0] as SolrSortField;
-
-    const newSort =
-      currentSortField === newSortField ? sort : `${newSortField} ${solrDefaultSortDirection[newSortField]}`;
-
-    // generate search string and trigger page transition, also update store
-    const search = makeSearchParams({ ...params, ...query, sort: newSort, p: 1 });
-    void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
-  };
-
-  // On submission handler
-  const handleOnSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    const q = new FormData(e.currentTarget).get('q') as string;
-
-    const query = store.getState().query;
-    if (q.length === 0) {
-      // if query is empty, do not submit search
-      return;
-    }
-
-    // clear current docs since we are entering new search
-    clearSelectedDocs();
-
-    // generate a URL search string and trigger a page transition, and update store
-    const overriddenSort = getDefaultSortForQuery(q, params.sort);
-    const search = makeSearchParams({ ...params, ...query, q, sort: overriddenSort, p: 1 });
-    void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
-  };
-
-  // Drive searchStatus and store state based on the main search result.
-  // useIsomorphicLayoutEffect fires before paint on the client (so facets start
-  // loading in the same frame results render), but falls back to useEffect on
-  // the server to avoid the SSR warning React emits for useLayoutEffect.
-  // Uses isLoading (not isFetching) to avoid disabling facets during
-  // background refetches of the same query.
-  useIsomorphicLayoutEffect(() => {
-    if (isLoading) {
-      setSearchStatus('loading');
-      return;
-    }
-    if (isError) {
-      setSearchStatus('error');
-      return;
-    }
-    if (isSuccess) {
-      if (data.response.numFound === 0) {
-        setSearchStatus('empty');
-      } else {
-        setDocs(data.response.docs.map((d) => d.bibcode));
-        setQuery(searchParams);
-        submitQuery();
-        setSearchStatus('success');
-      }
-    }
-  }, [data, isSuccess, isLoading, isError, setDocs, setQuery, submitQuery, setSearchStatus, searchParams]);
-
-  // Memoized retry handler for error alert
-  const handleRetry = useCallback(() => {
-    refetch();
-  }, [refetch]);
-
-  /**
-   * When updating perPage, this updates the store with both the current
-   * numPerPage value and the current query
-   */
-  const handlePerPageChange = (numPerPage: NumPerPageType) => {
-    // should reset to the first page on numPerPage update
-    updateQuery({ start: 0, rows: numPerPage });
-    setNumPerPage(numPerPage);
-  };
-
-  const handleSearchFacetSubmission = (queryUpdates: Partial<IADSApiSearchParams>) => {
-    const search = makeSearchParams({ ...params, ...queryUpdates, p: 1 });
-
-    // clear current docs on filter change
-    clearSelectedDocs();
-
-    void router.push({ pathname: router.pathname, search }, null, { scroll: false, shallow: true });
-  };
+  useSearchResultsTour();
 
   // conditions
-  const loading = isLoading || isFetching;
-  const noResults = !loading && isSuccess && data?.response.numFound === 0;
-  const hasResults = !loading && isSuccess && data?.response.numFound > 0;
+  const loading = results.isLoading || results.isFetching;
+  // 'loading' status means a genuinely new search (not a same-key background
+  // refetch) — show skeletons instead of the previous query's results
+  const isNewSearchLoading = results.searchStatus === 'loading';
+  const noResults = results.searchStatus === 'empty';
+  const hasResults = results.numFound > 0;
+  const hasDocs = results.docs.length > 0;
 
-  // Track the last query that fired search_no_results to prevent duplicate events
-  // when noResults stays true across re-renders (e.g. unstable params.q reference).
-  const lastNoResultsQuery = useRef<string | null>(null);
-  useEffect(() => {
-    if (noResults && params.q !== lastNoResultsQuery.current) {
-      lastNoResultsQuery.current = params.q ?? null;
-      sendGTMEvent({ event: 'search_no_results', query: params.q, query_type: getQueryType(params.q ?? '') });
-    }
-    if (!noResults) {
-      lastNoResultsQuery.current = null;
-    }
-  }, [noResults, params.q]);
   const showFilters = !isPrint && isClient;
   const showListActions = !isPrint && (loading || hasResults);
 
   return (
-    <Box>
-      <Head>
-        <title>{`${params.q} - ${BRAND_NAME_FULL} Search`}</title>
-      </Head>
-      <Stack direction="column" spacing={10}>
-        <HideOnPrint pt={10}>
-          <form method="get" action="/search" onSubmit={handleOnSubmit}>
-            <Flex direction="column" width="full">
-              <SearchBar isLoading={loading} showBackLinkAs="new_search" />
-              <NumFound count={data?.response.numFound} isLoading={loading} />
-            </Flex>
-            <FacetFilters mt="2" />
-          </form>
-          <Box ref={histogramContainerRef} />
-        </HideOnPrint>
-        <Flex direction="row" gap={{ base: 0, lg: 10 }} width="full">
-          {showFilters ? (
-            <QueryErrorResetBoundary>
-              {({ reset }) => (
-                <ErrorBoundary
-                  onReset={reset}
-                  onError={(error, errorInfo) =>
-                    handleBoundaryError(error, errorInfo, { component: 'SearchFacetFilters' })
-                  }
-                  fallbackRender={(props) => (
-                    <ErrorFallback {...props} label="Unable to load filters. Please try again." />
-                  )}
-                >
-                  <SearchFacetFilters
-                    onSearchFacetSubmission={handleSearchFacetSubmission}
-                    histogramContainerRef={histogramContainerRef}
-                  />
-                </ErrorBoundary>
-              )}
-            </QueryErrorResetBoundary>
-          ) : null}
-          <Box width="full">
-            {showListActions ? (
+    <SearchQueryProvider value={searchQueryContextValue}>
+      <Box>
+        <Head>
+          <title>{`${params.q} - ${BRAND_NAME_FULL} Search`}</title>
+        </Head>
+        <Stack direction="column" spacing={10}>
+          <HideOnPrint pt={10}>
+            <form method="get" action="/search" onSubmit={handlers.onSubmit}>
+              <Flex direction="column" width="full">
+                <SearchBar isLoading={loading} showBackLinkAs="new_search" />
+                <NumFound count={results.numFound} isLoading={loading} />
+              </Flex>
+              <FacetFilters mt="2" />
+            </form>
+            <Box ref={histogramContainerRef} />
+          </HideOnPrint>
+          <Flex direction="row" gap={{ base: 0, lg: 10 }} width="full">
+            {showFilters ? (
               <QueryErrorResetBoundary>
                 {({ reset }) => (
                   <ErrorBoundary
                     onReset={reset}
-                    onError={(error, errorInfo) => handleBoundaryError(error, errorInfo, { component: 'ListActions' })}
+                    onError={(error, errorInfo) =>
+                      handleBoundaryError(error, errorInfo, { component: 'SearchFacetFilters' })
+                    }
                     fallbackRender={(props) => (
-                      <ErrorFallback {...props} label="Unable to load actions. Please try again." />
+                      <SearchErrorFallback {...props} label="Unable to load filters. Please try again." />
                     )}
                   >
-                    <ListActions
-                      onSortChange={handleSortChange}
-                      onOpenAddToLibrary={onOpenAddToLibrary}
-                      isLoading={isLoading}
+                    <SearchFacetFilters
+                      onSearchFacetSubmission={handlers.onFacetSubmission}
+                      histogramContainerRef={histogramContainerRef}
                     />
                   </ErrorBoundary>
                 )}
               </QueryErrorResetBoundary>
             ) : null}
-            <VisuallyHidden as="h2" id="search-form-title">
-              Search Results
-            </VisuallyHidden>
-
-            {isError ? (
-              <SearchErrorAlert error={error} onRetry={handleRetry} isRetrying={isFetching} />
-            ) : (
-              <>
-                {noResults ? <NoResultsMsg /> : null}
-                {loading ? (
-                  <>
-                    {isSlowSearch && (
-                      <Alert status="info" mb={2} borderRadius="md" role="status" aria-live="polite">
-                        <AlertIcon />
-                        <Text>This search is taking longer than expected. Please wait...</Text>
-                      </Alert>
-                    )}
-                    <ItemsSkeleton count={storeNumPerPage} />
-                  </>
-                ) : null}
-                <PartialResultsWarning isPartialResults={data?.responseHeader?.partialResults} />
-
-                {data && (
-                  <>
-                    <QueryErrorResetBoundary>
-                      {({ reset }) => (
-                        <ErrorBoundary
-                          onReset={reset}
-                          onError={(error, errorInfo) =>
-                            handleBoundaryError(error, errorInfo, { component: 'SimpleResultList' })
-                          }
-                          fallbackRender={(props) => (
-                            <ErrorFallback {...props} label="Unable to display results. Please try again." />
-                          )}
-                        >
-                          <SimpleResultList
-                            docs={data.response.docs}
-                            indexStart={params.start}
-                            useNormCite={sort.startsWith('citation_count_norm')}
-                            measureRenderSpan
-                          />
-                        </ErrorBoundary>
+            <Box width="full">
+              {showListActions ? (
+                <QueryErrorResetBoundary>
+                  {({ reset }) => (
+                    <ErrorBoundary
+                      onReset={reset}
+                      onError={(error, errorInfo) =>
+                        handleBoundaryError(error, errorInfo, { component: 'ListActions' })
+                      }
+                      fallbackRender={(props) => (
+                        <SearchErrorFallback {...props} label="Unable to load actions. Please try again." />
                       )}
-                    </QueryErrorResetBoundary>
-                    {!isPrint && (
-                      <Pagination
-                        numPerPage={storeNumPerPage}
-                        page={params.p as number}
-                        totalResults={data.response.numFound}
-                        onPerPageSelect={handlePerPageChange}
+                    >
+                      <ListActions
+                        onSortChange={handlers.onSortChange}
+                        onOpenAddToLibrary={onOpenAddToLibrary}
+                        isLoading={isNewSearchLoading}
+                        currentSort={params.sort[0]}
+                        showHighlights={showHighlights}
+                        onToggleHighlights={handlers.onToggleHighlights}
                       />
-                    )}
-                  </>
-                )}
-              </>
-            )}
-          </Box>
-        </Flex>
-      </Stack>
-      <AddToLibraryModal isOpen={isAddToLibraryOpen} onClose={onCloseAddToLibrary} />
-    </Box>
-  );
-};
+                    </ErrorBoundary>
+                  )}
+                </QueryErrorResetBoundary>
+              ) : null}
+              <VisuallyHidden as="h2" id="search-form-title">
+                Search Results
+              </VisuallyHidden>
 
-const SearchFacetFilters = (props: {
-  histogramContainerRef?: RefObject<HTMLDivElement>;
-  onSearchFacetSubmission: (queryUpdates: Partial<IADSApiSearchParams>) => void;
-}) => {
-  const { onSearchFacetSubmission, histogramContainerRef } = props;
-  const showFilters = useStore(selectors.showFilters);
-  const handleToggleFilters = useStore(selectors.toggleSearchFacetsOpen);
-  const handleResetFilters = useStore(selectors.resetSearchFacets);
-  const [histogramExpanded, setHistogramExpanded] = useState(false);
+              {results.isError ? (
+                <SearchErrorAlert error={results.error} onRetry={results.refetch} isRetrying={results.isFetching} />
+              ) : (
+                <>
+                  {noResults ? <NoResultsMsg /> : null}
+                  {loading && results.isSlowSearch ? (
+                    <Alert status="info" mb={2} borderRadius="md" role="status" aria-live="polite">
+                      <AlertIcon />
+                      <Text>This search is taking longer than expected. Please wait...</Text>
+                    </Alert>
+                  ) : null}
+                  {isNewSearchLoading ? <ItemsSkeleton count={params.rows} /> : null}
+                  <PartialResultsWarning isPartialResults={results.isPartialResults} />
 
-  const isMobile = useBreakpointValue({ base: true, lg: false });
-  const { isOpen: isFacetOpen, onClose: onCloseFacet, onOpen: onOpenFacet } = useDisclosure();
-
-  if (isMobile) {
-    return (
-      <>
-        <Box as="aside" aria-labelledby="search-facets">
-          <Portal appendToParentPortal>
-            <Button
-              position="fixed"
-              transform="rotate(90deg)"
-              transformOrigin="bottom left"
-              borderBottomRadius="none"
-              size="xs"
-              type="button"
-              onClick={onOpenFacet}
-              top="240px"
-              left="0"
-              id="tour-search-facets"
-            >
-              Show Filters
-            </Button>
-          </Portal>
-        </Box>
-        <Drawer placement="left" onClose={onCloseFacet} isOpen={isFacetOpen}>
-          <DrawerOverlay />
-          <DrawerContent>
-            <DrawerBody>
-              <SearchFacets onQueryUpdate={onSearchFacetSubmission} />
-            </DrawerBody>
-          </DrawerContent>
-        </Drawer>
-      </>
-    );
-  }
-
-  if (showFilters) {
-    return (
-      <Flex as="aside" aria-labelledby="search-facets" minWidth="250px" direction="column" id="tour-search-facets">
-        <a className="skip-link" href="#results">
-          Skip to search results
-        </a>
-        <Flex mb={5}>
-          <Heading as="h2" id="search-facets" fontSize="normal" flex="1">
-            Filters
-          </Heading>
-          <Tooltip label="Reset filters">
-            <IconButton
-              variant="unstyled"
-              icon={
-                <Center>
-                  <Icon as={ArrowPathIcon} />
-                </Center>
-              }
-              size="xs"
-              fontSize="xl"
-              aria-label="reset filters"
-              type="button"
-              onClick={handleResetFilters}
-              _hover={{
-                backgroundColor: 'blue.50',
-                border: 'solid 1px gray.400',
-              }}
-            />
-          </Tooltip>
-          <Tooltip label="Hide filters">
-            <IconButton
-              variant="unstyled"
-              icon={
-                <Center>
-                  <Icon as={XMarkIcon} />
-                </Center>
-              }
-              size="xs"
-              fontSize="2xl"
-              aria-label="hide filters"
-              type="button"
-              onClick={handleToggleFilters}
-              fontWeight="normal"
-              _hover={{
-                backgroundColor: 'blue.50',
-                border: 'solid 1px gray.400',
-              }}
-            />
-          </Tooltip>
-        </Flex>
-        {histogramExpanded ? (
-          <Portal containerRef={histogramContainerRef}>
-            <Box mt={10}>
-              <YearHistogramSlider
-                onQueryUpdate={onSearchFacetSubmission}
-                onExpand={() => setHistogramExpanded((state) => !state)}
-                expanded={true}
-                width={props.histogramContainerRef?.current?.offsetWidth || 200}
-                height={125}
-              />
+                  {hasDocs && !isNewSearchLoading && (
+                    <>
+                      <QueryErrorResetBoundary>
+                        {({ reset }) => (
+                          <ErrorBoundary
+                            onReset={reset}
+                            onError={(error, errorInfo) =>
+                              handleBoundaryError(error, errorInfo, { component: 'SimpleResultList' })
+                            }
+                            fallbackRender={(props) => (
+                              <SearchErrorFallback {...props} label="Unable to display results. Please try again." />
+                            )}
+                          >
+                            <SimpleResultList
+                              docs={results.docs}
+                              indexStart={start}
+                              useNormCite={params.sort[0].startsWith('citation_count_norm')}
+                              highlightsQuery={searchParams}
+                              showHighlights={showHighlights}
+                              measureRenderSpan
+                            />
+                          </ErrorBoundary>
+                        )}
+                      </QueryErrorResetBoundary>
+                      {!isPrint && (
+                        <Pagination
+                          numPerPage={params.rows}
+                          page={params.p}
+                          totalResults={results.numFound}
+                          onPerPageSelect={handlers.onPerPageChange}
+                        />
+                      )}
+                    </>
+                  )}
+                </>
+              )}
             </Box>
-          </Portal>
-        ) : (
-          <YearHistogramSlider
-            onQueryUpdate={onSearchFacetSubmission}
-            onExpand={() => setHistogramExpanded((state) => !state)}
-            expanded={false}
-            width={200}
-            height={125}
-          />
-        )}
-        <SearchFacets onQueryUpdate={onSearchFacetSubmission} />
-      </Flex>
-    );
-  }
-  return (
-    <>
-      <Portal appendToParentPortal>
-        <Button
-          position="absolute"
-          transform="rotate(90deg)"
-          transformOrigin="bottom left"
-          borderBottomRadius="none"
-          size="xs"
-          type="button"
-          onClick={handleToggleFilters}
-          top="240px"
-          left="0"
-          id="tour-search-facets"
-        >
-          Show Filters
-        </Button>
-      </Portal>
-    </>
+          </Flex>
+        </Stack>
+        <AddToLibraryModal isOpen={isAddToLibraryOpen} onClose={onCloseAddToLibrary} />
+      </Box>
+    </SearchQueryProvider>
   );
 };
-
-const NoResultsMsg = () => (
-  <CustomInfoMessage
-    status="info"
-    alertTitle={<>Sorry no results were found</>}
-    description={
-      <List w="100%">
-        <ListItem>
-          <ListIcon as={CheckCircleIcon} color="green.500" />
-          Try broadening your search
-        </ListItem>
-        <ListItem>
-          <ListIcon as={CheckCircleIcon} color="green.500" />
-          Disable any filters that may be applied
-        </ListItem>
-        <ListItem>
-          <Flex direction="row" alignItems="center">
-            <ListIcon as={CheckCircleIcon} color="green.500" />
-            <SimpleLink href="/">Check out some examples</SimpleLink>
-          </Flex>
-        </ListItem>
-        <ListItem>
-          <Flex direction="row" alignItems="center">
-            <ListIcon as={CheckCircleIcon} color="green.500" />
-            <SimpleLink href="/help/search/search-syntax" newTab={true}>
-              Read our help pages
-            </SimpleLink>
-          </Flex>
-        </ListItem>
-      </List>
-    }
-  />
-);
 
 export default SearchPage;
-
-/**
- * Shows a warning if the returned search is flagged as having partial results.
- * This is used to inform users that the results may not be complete.
- */
-const PartialResultsWarning = ({ isPartialResults }: { isPartialResults?: boolean }) => {
-  if (!isPartialResults) {
-    return null;
-  }
-
-  return (
-    <Alert status="warning" mb={1} borderRadius="md">
-      <AlertIcon />
-      <Text>
-        The search took too long, so some results may be missing. Try refining your query to make it faster and see
-        everything.
-      </Text>
-    </Alert>
-  );
-};
-
-const useTour = () => {
-  const Shepherd = useShepherd();
-  const [isRendered, setIsRendered] = useState(false);
-
-  // tour should not start until the first element is rendered
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      const element = document.getElementById('sort-order');
-      if (element) {
-        setIsRendered(true);
-        observer.disconnect();
-      }
-    });
-
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (isRendered && !localStorage.getItem(LocalSettings.SEEN_RESULTS_TOUR)) {
-      const tour = new Shepherd.Tour({
-        useModalOverlay: true,
-        defaultStepOptions: {
-          scrollTo: false,
-          cancelIcon: {
-            enabled: true,
-          },
-        },
-        exitOnEsc: true,
-      });
-      tour.addSteps(getResultsSteps());
-      localStorage.setItem(LocalSettings.SEEN_RESULTS_TOUR, 'true');
-
-      const listener = (e: MouseEvent) => {
-        if ((e.target as HTMLElement).closest('.shepherd-modal-overlay-container')) {
-          tour.cancel();
-        }
-      };
-      tour.on('start', () => {
-        document.addEventListener('click', listener);
-      });
-      tour.on('cancel', () => {
-        document.removeEventListener('click', listener);
-      });
-      tour.on('complete', () => {
-        document.removeEventListener('click', listener);
-      });
-
-      setTimeout(() => {
-        tour.start();
-      }, 1000);
-    }
-  }, [isRendered, Shepherd]);
-};
 
 export { injectSessionGSSP as getServerSideProps } from '@/ssr-utils';

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -10,15 +10,16 @@ import { logger } from './logger';
 import { theme } from './theme';
 import shallow from 'zustand/shallow';
 import * as Sentry from '@sentry/nextjs';
+import { useRouter } from 'next/router';
 import {
   PERF_SPANS,
   getResultCountBucket,
   getQueryType,
   openFullTextTimingSpan,
   closeFullTextTimingSpan,
-  getPageNumber,
   sendQueryAsTags,
 } from '@/lib/performance';
+import { parseQueryFromUrl } from '@/utils/common/search';
 import { useGlobalErrorHandler } from './lib/useGlobalErrorHandler';
 import { ShepherdJourneyProvider } from 'react-shepherd';
 
@@ -68,7 +69,10 @@ const QCProvider: FC = ({ children }) => {
 };
 
 const Telemetry: FC = () => {
-  const latestQuery = useStore((state) => state.latestQuery, shallow);
+  const router = useRouter();
+  // URL is the source of truth for the submitted query; a change in the
+  // /search URL is a search submission (replaces the store's latestQuery)
+  const searchPath = router.pathname === '/search' ? router.asPath : null;
   const user = useStore((state) => state.user, shallow);
   const docs = useStore((state) => state.docs.current, shallow);
   const searchSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
@@ -91,12 +95,20 @@ const Telemetry: FC = () => {
   }, [user]);
 
   useEffect(() => {
-    if (!latestQuery) {
+    if (!searchPath) {
+      return;
+    }
+    // The search page stamps resolved sort/rows into arriving URLs with a
+    // replace navigation; skip the transient pre-stamp URL so a single search
+    // submission opens one span instead of two.
+    const urlParams = new URLSearchParams(searchPath.split('?')[1] ?? '');
+    if (!urlParams.has('sort') || !urlParams.has('rows')) {
       return;
     }
     try {
-      sendQueryAsTags(latestQuery);
-      const page = getPageNumber(latestQuery.start, latestQuery.rows);
+      const query = parseQueryFromUrl(searchPath);
+      sendQueryAsTags(query);
+      const page = query.p ?? 1;
       // End prior spans so rapid re-submits don't leak them.
       searchSpanRef.current?.end();
       searchSpanRef.current = null;
@@ -107,7 +119,7 @@ const Telemetry: FC = () => {
       searchSpanRef.current = Sentry.startInactiveSpan({
         name: PERF_SPANS.SEARCH_SUBMIT_TOTAL,
         op: 'user.flow',
-        attributes: { query_type: getQueryType(latestQuery.q ?? ''), page },
+        attributes: { query_type: getQueryType(query.q ?? ''), page },
       });
       if (page > 1) {
         paginationSpanRef.current = Sentry.startInactiveSpan({
@@ -119,7 +131,7 @@ const Telemetry: FC = () => {
     } catch (err) {
       logger.error({ err }, 'Telemetry: query span error');
     }
-  }, [latestQuery]);
+  }, [searchPath]);
 
   useEffect(() => {
     if (!docs || docs.length === 0) {

--- a/src/store/slices/search.ts
+++ b/src/store/slices/search.ts
@@ -5,8 +5,6 @@ import { mergeRight } from 'ramda';
 import { isNumPerPageType } from '@/utils/common/guards';
 import { IADSApiSearchParams } from '@/api/search/types';
 
-export type SearchStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
-
 export const defaultQueryParams: IADSApiSearchParams = {
   q: '',
   fl: [
@@ -34,40 +32,27 @@ export const defaultQueryParams: IADSApiSearchParams = {
 
 export interface ISearchState {
   query: IADSApiSearchParams;
-  latestQuery: IADSApiSearchParams;
-  prevQuery: IADSApiSearchParams;
   numPerPage: NumPerPageType;
-  showHighlights: boolean;
   queryAddition: string;
   clearQueryFlag: boolean;
-  searchStatus: SearchStatus;
 }
 
 export interface ISearchAction {
-  setQuery: (query: IADSApiSearchParams) => void;
   updateQuery: (query: Partial<IADSApiSearchParams>) => void;
-  swapQueries: () => void;
-  submitQuery: () => void;
-  resetQuery: () => void;
   setNumPerPage: (numPerPage: NumPerPageType) => void;
-  toggleShowHighlights: () => void;
   setQueryAddition: (queryAddition: string) => void;
   setClearQueryFlag: (clearQueryFlag: boolean) => void;
-  setSearchStatus: (status: SearchStatus) => void;
 }
 
+// The submitted query lives in the URL (nuqs); this slice only holds the
+// SearchBar's intermediate draft state and the numPerPage preference.
 export const searchSlice: StoreSlice<ISearchState & ISearchAction> = (set) => ({
   // intermediate query, this one will be changing frequently
   query: defaultQueryParams,
 
-  // can only be updated using `submitQuery` which just moves the current query over
-  latestQuery: defaultQueryParams,
-  prevQuery: defaultQueryParams,
   numPerPage: APP_DEFAULTS.RESULT_PER_PAGE,
-  showHighlights: false,
   queryAddition: null,
   clearQueryFlag: false,
-  searchStatus: 'idle' as SearchStatus,
 
   setNumPerPage: (numPerPage: NumPerPageType) =>
     set(
@@ -76,20 +61,10 @@ export const searchSlice: StoreSlice<ISearchState & ISearchAction> = (set) => ({
       'search/setNumPerPage',
     ),
 
-  setQuery: (query: IADSApiSearchParams) => set(() => ({ query })),
-
   // merge the current query with the partial (or complete) passed in query
   updateQuery: (query: Partial<IADSApiSearchParams>) =>
     set((state) => ({ query: mergeRight(state.query, query) }), false, 'search/updateQuery'),
 
-  submitQuery: () =>
-    set((state) => ({ prevQuery: state.latestQuery, latestQuery: state.query }), false, 'search/submitQuery'),
-  swapQueries: () =>
-    set((state) => ({ latestQuery: state.prevQuery, prevQuery: state.latestQuery }), false, 'search/swapQueries'),
-  resetQuery: () => set({ query: defaultQueryParams, latestQuery: defaultQueryParams }, false, 'search/resetQuery'),
-  toggleShowHighlights: () =>
-    set(({ showHighlights }) => ({ showHighlights: !showHighlights }), false, 'search/toggleShowHighlights'),
   setQueryAddition: (queryAddition: string) => set(() => ({ queryAddition }), false, 'search/setQueryAddition'),
   setClearQueryFlag: (clearQueryFlag: boolean) => set(() => ({ clearQueryFlag }), false, 'search/setClearQueryFlag'),
-  setSearchStatus: (searchStatus: SearchStatus) => set(() => ({ searchStatus }), false, 'search/setSearchStatus'),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,10 @@ export type NumPerPageType = (typeof APP_DEFAULTS)['PER_PAGE_OPTIONS'][number];
 
 export type SafeSearchUrlParams = Omit<IADSApiSearchParams, 'fl' | 'start' | 'rows' | 'id'> & { p?: number };
 
+// lifecycle of the active search, derived from the query result
+// (see useSearchResults); gates facet fetching and dependent widgets
+export type SearchStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
 export interface IBibstemOption {
   label: string[];
   value: string;
@@ -68,4 +72,3 @@ declare global {
     onResponse: unknown;
   };
 }
-

--- a/src/utils/common/__tests__/search.test.ts
+++ b/src/utils/common/__tests__/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getDefaultSortForQuery } from '@/utils/common/search';
+import { canonicalSearchParams, getDefaultSortForQuery, toFacetSearchParams } from '@/utils/common/search';
 import { SolrSort } from '@/api/models';
 
 const PREF_SORT: SolrSort[] = ['date desc', 'score desc'];
@@ -31,5 +31,123 @@ describe('getDefaultSortForQuery', () => {
     ])('%s', (q) => {
       expect(getDefaultSortForQuery(q, PREF_SORT)).toBe(PREF_SORT);
     });
+  });
+});
+
+describe('canonicalSearchParams', () => {
+  describe('q', () => {
+    test('empty or missing q becomes the match-all query', () => {
+      expect(canonicalSearchParams({}).q).toBe('*:*');
+      expect(canonicalSearchParams({ q: '' }).q).toBe('*:*');
+    });
+
+    test('q passes through', () => {
+      expect(canonicalSearchParams({ q: 'star formation' }).q).toBe('star formation');
+    });
+  });
+
+  describe('sort resolution', () => {
+    test('URL sort wins over the preferred-sort setting', () => {
+      const { sort } = canonicalSearchParams({ sort: ['citation_count desc'] }, { preferredSortField: 'date' });
+      expect(sort).toEqual(['citation_count desc', 'date desc']);
+    });
+
+    test('absent sort resolves to the preferred-sort setting with its default direction', () => {
+      const { sort } = canonicalSearchParams({}, { preferredSortField: 'first_author' });
+      expect(sort).toEqual(['first_author asc', 'date desc']);
+    });
+
+    test('absent sort and no setting falls back to APP_DEFAULTS preferred sort', () => {
+      const { sort } = canonicalSearchParams({});
+      expect(sort).toEqual(['score desc', 'date desc']);
+    });
+
+    test('single string sort is normalized', () => {
+      const { sort } = canonicalSearchParams({ sort: 'date asc' });
+      expect(sort).toEqual(['date asc', 'date desc']);
+    });
+
+    test('invalid sort values fall back to the normalize default', () => {
+      const { sort } = canonicalSearchParams({ sort: ['bogus nonsense'] });
+      expect(sort).toEqual(['score desc', 'date desc']);
+    });
+  });
+
+  describe('p and rows', () => {
+    test('p is clamped to >= 1 and parsed from strings', () => {
+      expect(canonicalSearchParams({ p: '3' }).p).toBe(3);
+      expect(canonicalSearchParams({ p: '0' }).p).toBe(1);
+      expect(canonicalSearchParams({ p: 'junk' }).p).toBe(1);
+      expect(canonicalSearchParams({}).p).toBe(1);
+    });
+
+    test('valid URL rows wins over the preference', () => {
+      expect(canonicalSearchParams({ rows: '25' }, { numPerPage: 50 }).rows).toBe(25);
+      expect(canonicalSearchParams({ rows: 25 }, { numPerPage: 50 }).rows).toBe(25);
+    });
+
+    test('invalid or missing rows falls back to the persisted preference', () => {
+      expect(canonicalSearchParams({ rows: '13' }, { numPerPage: 50 }).rows).toBe(50);
+      expect(canonicalSearchParams({}, { numPerPage: 50 }).rows).toBe(50);
+    });
+
+    test('no rows and no preference falls back to the app default', () => {
+      expect(canonicalSearchParams({}).rows).toBe(10);
+    });
+  });
+
+  describe('fq and passthrough', () => {
+    test('fq array passes through intact, including comma-containing values', () => {
+      const fq = ['{!type=aqp v=$fq_author}', 'year:2020'];
+      expect(canonicalSearchParams({ fq }).fq).toEqual(fq);
+    });
+
+    test('fq is omitted when absent', () => {
+      expect(canonicalSearchParams({})).not.toHaveProperty('fq');
+    });
+
+    test('facet companion params pass through as strings', () => {
+      const params = canonicalSearchParams({
+        fq_author: '(author_facet_hier:"0/Smith, J")',
+        d: 'general',
+      });
+      expect(params).toMatchObject({
+        fq_author: '(author_facet_hier:"0/Smith, J")',
+        d: 'general',
+      });
+    });
+
+    test('fl, start, id, boostType, and showHighlights are never taken from the URL', () => {
+      const params = canonicalSearchParams({
+        fl: 'title',
+        start: '40',
+        id: 'x',
+        boostType: 'astrophysics',
+        showHighlights: 'true',
+      });
+      expect(params).not.toHaveProperty('fl');
+      expect(params).not.toHaveProperty('start');
+      expect(params).not.toHaveProperty('id');
+      expect(params).not.toHaveProperty('boostType');
+      expect(params).not.toHaveProperty('showHighlights');
+    });
+  });
+});
+
+describe('toFacetSearchParams', () => {
+  test('strips pagination and field-list keys, keeps query identity', () => {
+    const canonical = canonicalSearchParams({ q: 'star', fq: ['year:2020'], p: '3', rows: '25' });
+    const facetParams = toFacetSearchParams(canonical);
+    expect(facetParams).not.toHaveProperty('p');
+    expect(facetParams).not.toHaveProperty('rows');
+    expect(facetParams).not.toHaveProperty('start');
+    expect(facetParams).not.toHaveProperty('fl');
+    expect(facetParams).toMatchObject({ q: 'star', fq: ['year:2020'] });
+  });
+
+  test('is stable across page changes', () => {
+    const page1 = toFacetSearchParams(canonicalSearchParams({ q: 'star', p: '1' }));
+    const page5 = toFacetSearchParams(canonicalSearchParams({ q: 'star', p: '5' }));
+    expect(page1).toEqual(page5);
   });
 });

--- a/src/utils/common/search.ts
+++ b/src/utils/common/search.ts
@@ -1,11 +1,11 @@
 import { clamp, filter, head, last, omit, uniq } from 'ramda';
 import qs from 'qs';
 
-import { isSolrSort, isString } from '@/utils/common/guards';
+import { isNumPerPageType, isSolrSort, isString } from '@/utils/common/guards';
 import { APP_DEFAULTS } from '@/config';
 import { ParsedUrlQuery } from 'querystring';
-import { AppMode, SafeSearchUrlParams } from '@/types';
-import { SolrSort } from '@/api/models';
+import { AppMode, NumPerPageType, SafeSearchUrlParams } from '@/types';
+import { SolrSort, SolrSortField, solrDefaultSortDirection } from '@/api/models';
 import { IADSApiSearchParams } from '@/api/search/types';
 import { logger } from '@/logger';
 import { appModeToDisciplineParam, normalizeDisciplineParam } from '@/utils/appMode';
@@ -172,6 +172,99 @@ export const normalizeSolrSort = (rawSolrSort: unknown, postfixSort?: SolrSort):
     return ['score desc', tieBreaker];
   }
   return uniq(validSort.concat(tieBreaker));
+};
+
+export type CanonicalSearchParams = IADSApiSearchParams & { p: number; rows: NumPerPageType };
+
+export interface CanonicalSearchParamsDefaults {
+  // user's preferred-sort setting; applied only when the URL has no sort
+  preferredSortField?: SolrSortField;
+  // user's persisted page-size preference; applied when the URL has no valid rows
+  numPerPage?: number;
+}
+
+// keys resolved explicitly below, plus UI-only params that must never reach the API
+const CANONICAL_RESOLVED_KEYS = new Set(['q', 'sort', 'p', 'rows', 'fq', 'showHighlights']);
+
+const toStringValue = (value: unknown): string | undefined => {
+  if (isString(value)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return filter(isString, value).join(',');
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return undefined;
+};
+
+const resolveRows = (value: unknown, preference?: number): NumPerPageType => {
+  const first = Array.isArray(value) ? value[0] : value;
+  const num = typeof first === 'number' ? first : isString(first) ? parseInt(first, 10) : NaN;
+  if (!Number.isNaN(num) && isNumPerPageType(num)) {
+    return num;
+  }
+  if (typeof preference === 'number' && isNumPerPageType(preference)) {
+    return preference;
+  }
+  return APP_DEFAULTS.RESULT_PER_PAGE;
+};
+
+// Resolves raw URL query values (from router.query or nuqs) into the normalized,
+// defaults-applied search params object — the canonical identity of a search.
+// Rules (matching the pre-rewrite search page):
+// - empty/missing q becomes the match-all query
+// - a sort in the URL wins; otherwise the preferred-sort setting applies, with
+//   its default direction
+// - rows must be a valid page-size option; otherwise the persisted preference
+// - p is clamped to >= 1; start is intentionally NOT computed here
+// - unknown params (fq_author, d, ...) pass through as strings so facet
+//   companion params survive the round trip; fl/start/id/boostType are never
+//   trusted from the URL
+export const canonicalSearchParams = (
+  raw: Record<string, unknown>,
+  defaults: CanonicalSearchParamsDefaults = {},
+): CanonicalSearchParams => {
+  const passthrough: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (CANONICAL_RESOLVED_KEYS.has(key) || IGNORED_URL_KEYS.includes(key)) {
+      continue;
+    }
+    const str = toStringValue(value);
+    if (typeof str !== 'undefined') {
+      passthrough[key] = str;
+    }
+  }
+
+  const preferredSortField = defaults.preferredSortField ?? (APP_DEFAULTS.PREFERRED_SEARCH_SORT as SolrSortField);
+  const hasSort = Array.isArray(raw.sort) ? raw.sort.length > 0 : isString(raw.sort);
+  const sort = hasSort
+    ? normalizeSolrSort(raw.sort)
+    : normalizeSolrSort([`${preferredSortField} ${solrDefaultSortDirection[preferredSortField]}`]);
+
+  const q = toStringValue(raw.q) ?? '';
+
+  return {
+    ...passthrough,
+    q: q === '' ? APP_DEFAULTS.EMPTY_QUERY : q,
+    sort,
+    p: parseNumberAndClamp(raw.p as string | number, 1),
+    rows: resolveRows(raw.rows, defaults.numPerPage),
+    // absent fq stays absent — an empty array (nuqs's "no value") must not add the key
+    ...(raw.fq != null && (!Array.isArray(raw.fq) || raw.fq.length > 0)
+      ? { fq: safeSplitString(raw.fq as string | string[]) }
+      : {}),
+  } as CanonicalSearchParams;
+};
+
+// Shapes canonical search params for facet consumers (facet fetches, histogram,
+// search stats). Strips pagination and field-list keys so the facet query
+// identity is stable across page and page-size changes — matches the previous
+// omit(['fl','start','rows'], latestQuery) plus the page-level p omission.
+export const toFacetSearchParams = (params: IADSApiSearchParams & { p?: number }): IADSApiSearchParams => {
+  const { fl, start, rows, p, ...facetParams } = params;
+  return facetParams;
 };
 
 // Matches second-order operator queries that should default to relevance sort.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "noUncheckedIndexedAccess": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
The search page kept the submitted query in three places — the URL, the store's draft query, and latestQuery — synced imperatively by effects after each response. That dual-write model was the root of a class of stale-state bugs (facet gating, back-button, stale latestQuery) and made the page component effectively untestable.

1. URL is now the single source of truth
2. Facets, histogram, result stats, and the library/notification modals read the active query through a read-only SearchQueryContext instead of the store
3. Search slice reduced to SearchBar draft state and numPerPage; telemetry and the feedback page derive the current search from the URL
4. Generated a new docs page to outline these changes to search page.