### PR TITLE
fix(abs): stop Record Not Found flash; distinguish error from not-found

### DIFF
--- a/src/components/AbsRecordBoundary/AbsRecordBoundary.test.tsx
+++ b/src/components/AbsRecordBoundary/AbsRecordBoundary.test.tsx
@@ -102,7 +102,7 @@ describe('AbsRecordBoundary + useAbsRecordState', () => {
     expect(screen.queryByTestId('record-not-found')).not.toBeInTheDocument();
   });
 
-  test('transient error then recover: skeleton first, then content', () => {
+  test('transient error then recover: skeleton first, then content, and reports the recovery', () => {
     setQuery({ data: undefined, isLoading: true, isFetching: true, isError: false });
     const { rerender } = render(<Harness ssr={{ outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' }} />);
     expect(screen.getByTestId('abs-record-skeleton')).toBeInTheDocument();
@@ -111,6 +111,22 @@ describe('AbsRecordBoundary + useAbsRecordState', () => {
     rerender(<Harness ssr={{ outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' }} />);
 
     expect(screen.getByTestId('content')).toHaveTextContent('2024ApJ...1..1X');
+    expect(captureMessage).toHaveBeenCalledWith(
+      'abs_ssr_false_negative_recovered',
+      expect.objectContaining({ level: 'warning' }),
+    );
+  });
+
+  test('reports recovery again after client-side navigation to a different record', () => {
+    setQuery({ data: { docs: [doc] }, isLoading: false, isFetching: false, isError: false });
+    const err = { outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' } as const;
+    const { rerender } = render(<Harness ssr={err} queryId="BIB-A" />);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+
+    // Same sub-view, different record — the page does not remount; the recovery
+    // signal must still fire for the new queryId.
+    rerender(<Harness ssr={err} queryId="BIB-B" />);
+    expect(captureMessage).toHaveBeenCalledTimes(2);
   });
 
   test('missing ssr props degrade to an error state instead of crashing', () => {

--- a/src/components/AbsRecordBoundary/AbsRecordBoundary.test.tsx
+++ b/src/components/AbsRecordBoundary/AbsRecordBoundary.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AbsRecordBoundary } from './AbsRecordBoundary';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
+import { AbsSSRResult } from '@/lib/abs/absRecordState';
+import { IDocsEntity } from '@/api/search/types';
+
+// Controllable stand-in for the client abstract query. Each test sets the value
+// the hook observes, simulating hydrated cache / loading / error / empty outcomes.
+type QueryResult = {
+  data?: { docs: IDocsEntity[]; numFound?: number };
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+};
+
+let queryResult: QueryResult = { data: undefined, isLoading: false, isFetching: false, isError: false };
+const setQuery = (next: QueryResult) => {
+  queryResult = next;
+};
+
+vi.mock('@/api/search/search', () => ({
+  useGetAbstract: () => queryResult,
+}));
+
+const captureMessage = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+}));
+
+vi.mock('@/components/Layout/AbsLayout', () => ({
+  AbsLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/RecordNotFound', () => ({
+  RecordNotFound: () => <div data-testid="record-not-found" />,
+}));
+vi.mock('@/components/ServiceUnavailable', () => ({
+  ServiceUnavailable: ({ statusCode }: { statusCode?: number }) => (
+    <div data-testid="service-unavailable">{statusCode}</div>
+  ),
+}));
+vi.mock('./AbsRecordSkeleton', () => ({
+  AbsRecordSkeleton: () => <div data-testid="abs-record-skeleton" />,
+}));
+
+const doc = { bibcode: '2024ApJ...1..1X' } as IDocsEntity;
+
+const Harness = ({
+  ssr,
+  initialDoc = null,
+  queryId = 'BIB',
+}: {
+  ssr?: AbsSSRResult;
+  initialDoc?: IDocsEntity | null;
+  queryId?: string;
+}) => {
+  const { state } = useAbsRecordState({ ssr, queryId, initialDoc });
+  return (
+    <AbsRecordBoundary state={state} recordId={queryId} label="Abstract" titleDescription="">
+      {(d) => <div data-testid="content">{d.bibcode}</div>}
+    </AbsRecordBoundary>
+  );
+};
+
+afterEach(() => {
+  captureMessage.mockReset();
+  setQuery({ data: undefined, isLoading: false, isFetching: false, isError: false });
+});
+
+describe('AbsRecordBoundary + useAbsRecordState', () => {
+  test('found record renders content immediately with no not-found flash', () => {
+    setQuery({ data: { docs: [doc] }, isLoading: false, isFetching: false, isError: false });
+    render(<Harness ssr={{ outcome: 'found' }} initialDoc={doc} />);
+
+    expect(screen.getByTestId('content')).toHaveTextContent('2024ApJ...1..1X');
+    expect(screen.queryByTestId('record-not-found')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('abs-record-skeleton')).not.toBeInTheDocument();
+  });
+
+  test('ambiguous found (still loading, no doc) shows the skeleton, never not-found', () => {
+    setQuery({ data: undefined, isLoading: true, isFetching: true, isError: false });
+    render(<Harness ssr={{ outcome: 'found' }} />);
+
+    expect(screen.getByTestId('abs-record-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('record-not-found')).not.toBeInTheDocument();
+  });
+
+  test('genuine not-found (client-confirmed empty) renders RecordNotFound', () => {
+    setQuery({ data: { docs: [] }, isLoading: false, isFetching: false, isError: false });
+    render(<Harness ssr={{ outcome: 'not-found' }} />);
+
+    expect(screen.getByTestId('record-not-found')).toBeInTheDocument();
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+
+  test('persistent error shows ServiceUnavailable with the SSR status code', () => {
+    setQuery({ data: undefined, isLoading: false, isFetching: false, isError: true });
+    render(<Harness ssr={{ outcome: 'error', statusCode: 502, reason: 'fetch-not-ok' }} />);
+
+    expect(screen.getByTestId('service-unavailable')).toHaveTextContent('502');
+    expect(screen.queryByTestId('record-not-found')).not.toBeInTheDocument();
+  });
+
+  test('transient error then recover: skeleton first, then content', () => {
+    setQuery({ data: undefined, isLoading: true, isFetching: true, isError: false });
+    const { rerender } = render(<Harness ssr={{ outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' }} />);
+    expect(screen.getByTestId('abs-record-skeleton')).toBeInTheDocument();
+
+    setQuery({ data: { docs: [doc] }, isLoading: false, isFetching: false, isError: false });
+    rerender(<Harness ssr={{ outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' }} />);
+
+    expect(screen.getByTestId('content')).toHaveTextContent('2024ApJ...1..1X');
+  });
+
+  test('missing ssr props degrade to an error state instead of crashing', () => {
+    setQuery({ data: undefined, isLoading: false, isFetching: false, isError: false });
+    render(<Harness ssr={undefined} queryId="" />);
+
+    expect(screen.getByTestId('service-unavailable')).toHaveTextContent('500');
+    expect(screen.queryByTestId('record-not-found')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AbsRecordBoundary/AbsRecordBoundary.tsx
+++ b/src/components/AbsRecordBoundary/AbsRecordBoundary.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+
+import { AbsLayout } from '@/components/Layout/AbsLayout';
+import { RecordNotFound } from '@/components/RecordNotFound';
+import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { IDocsEntity } from '@/api/search/types';
+import { AbsRecordUIState } from '@/lib/abs/absRecordState';
+import { AbsRecordSkeleton } from './AbsRecordSkeleton';
+
+type AbsRecordBoundaryProps = {
+  state: AbsRecordUIState;
+  recordId: string;
+  label: string;
+  titleDescription: string;
+  onFeedback?: () => void;
+  children: (doc: IDocsEntity) => ReactNode;
+};
+
+// One place for the loading / not-found / error / content branch across all
+// abstract sub-views. Content is a render prop so markup dereferencing `doc` only
+// runs once the record is present.
+export const AbsRecordBoundary = ({
+  state,
+  recordId,
+  label,
+  titleDescription,
+  onFeedback,
+  children,
+}: AbsRecordBoundaryProps) => {
+  const doc = state.kind === 'content' ? state.doc : undefined;
+
+  return (
+    <AbsLayout doc={doc} titleDescription={titleDescription} label={label}>
+      {state.kind === 'content' ? (
+        children(state.doc)
+      ) : state.kind === 'loading' ? (
+        <AbsRecordSkeleton />
+      ) : state.kind === 'error' ? (
+        <ServiceUnavailable recordId={recordId || 'N/A'} statusCode={state.statusCode} />
+      ) : (
+        <RecordNotFound recordId={recordId || 'N/A'} onFeedback={onFeedback} />
+      )}
+    </AbsLayout>
+  );
+};

--- a/src/components/AbsRecordBoundary/AbsRecordSkeleton.test.tsx
+++ b/src/components/AbsRecordBoundary/AbsRecordSkeleton.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+
+import { render, screen } from '@/test-utils';
+import { AbsRecordSkeleton } from './AbsRecordSkeleton';
+
+describe('AbsRecordSkeleton', () => {
+  test('renders the loading status region', () => {
+    render(<AbsRecordSkeleton />);
+    const region = screen.getByTestId('abs-record-skeleton');
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Loading record…')).toBeInTheDocument();
+  });
+});

--- a/src/components/AbsRecordBoundary/AbsRecordSkeleton.tsx
+++ b/src/components/AbsRecordBoundary/AbsRecordSkeleton.tsx
@@ -1,0 +1,82 @@
+import { Box, Flex, Skeleton, SkeletonText, Stack, VisuallyHidden } from '@chakra-ui/react';
+import { range } from 'ramda';
+
+import { useColorModeColors } from '@/lib/useColorModeColors';
+
+// Mirrors the loaded AbsLayout: search bar, left sidebar (full text sources +
+// side nav) and the main content column. Matching the real structure keeps the
+// loading -> loaded transition from shifting layout.
+export const AbsRecordSkeleton = () => {
+  const colors = useColorModeColors();
+
+  return (
+    <Box role="status" aria-live="polite" data-testid="abs-record-skeleton">
+      <VisuallyHidden>Loading record…</VisuallyHidden>
+      <Stack direction="column" spacing={10}>
+        <SearchBarSkeleton />
+        <Stack direction={{ base: 'column', lg: 'row' }} spacing={6}>
+          <SidebarSkeleton borderColor={colors.border} />
+          <MainContentSkeleton borderColor={colors.border} />
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+const SearchBarSkeleton = () => (
+  <Stack direction="column" spacing={3}>
+    <Skeleton height="1rem" width="8rem" />
+    <Flex gap={2}>
+      <Skeleton height="2.5rem" flex="1" />
+      <Skeleton height="2.5rem" width="3rem" />
+    </Flex>
+  </Stack>
+);
+
+const SidebarSkeleton = ({ borderColor }: { borderColor: string }) => (
+  <Stack direction="column" spacing={4} display={{ base: 'none', lg: 'flex' }} flexShrink={0} w="72">
+    <Stack direction="column" spacing={2}>
+      {range(0, 3).map((i) => (
+        <Box key={i} borderWidth="1px" borderColor={borderColor} borderRadius="md" px={4} py={3}>
+          <Skeleton height="1rem" width="55%" />
+        </Box>
+      ))}
+    </Stack>
+    <Stack direction="column" spacing={1} mt={2}>
+      {range(0, 10).map((i) => (
+        <Flex key={i} align="center" gap={3} px={2} py={2}>
+          <Skeleton height="1.25rem" width="1.25rem" borderRadius="sm" />
+          <Skeleton height="0.9rem" width={`${45 + ((i * 7) % 35)}%`} />
+        </Flex>
+      ))}
+    </Stack>
+  </Stack>
+);
+
+const MainContentSkeleton = ({ borderColor }: { borderColor: string }) => (
+  <Stack direction="column" spacing={5} width="full">
+    <Stack direction="column" spacing={2}>
+      <Skeleton height="1.75rem" width="90%" />
+      <Skeleton height="1.75rem" width="60%" />
+    </Stack>
+    <Flex wrap="wrap" gap={2}>
+      {range(0, 4).map((i) => (
+        <Skeleton key={i} height="1.1rem" width={`${6 + ((i * 3) % 7)}rem`} />
+      ))}
+    </Flex>
+    <Skeleton height="1.5rem" width="5rem" borderRadius="md" />
+    <SkeletonText noOfLines={8} spacing={3} skeletonHeight="0.9rem" />
+    <DetailsTableSkeleton borderColor={borderColor} />
+  </Stack>
+);
+
+const DetailsTableSkeleton = ({ borderColor }: { borderColor: string }) => (
+  <Box borderWidth="1px" borderColor={borderColor} borderRadius="md" mt={2}>
+    {range(0, 6).map((i) => (
+      <Flex key={i} gap={6} px={4} py={3} borderBottomWidth={i === 5 ? 0 : '1px'} borderColor={borderColor}>
+        <Skeleton height="1rem" width="8rem" flexShrink={0} />
+        <Skeleton height="1rem" width={`${30 + ((i * 11) % 45)}%`} />
+      </Flex>
+    ))}
+  </Box>
+);

--- a/src/components/AbsRecordBoundary/index.ts
+++ b/src/components/AbsRecordBoundary/index.ts
@@ -1,0 +1,2 @@
+export { AbsRecordBoundary } from './AbsRecordBoundary';
+export { AbsRecordSkeleton } from './AbsRecordSkeleton';

--- a/src/components/Layout/AbsLayout.tsx
+++ b/src/components/Layout/AbsLayout.tsx
@@ -2,7 +2,7 @@ import { Box, Heading, Stack, Text } from '@chakra-ui/react';
 
 import { MathJax } from 'better-react-mathjax';
 import Head from 'next/head';
-import { FC, useEffect } from 'react';
+import { FC, ReactNode, useEffect } from 'react';
 import { BRAND_NAME_FULL } from '@/config';
 import { Metatags } from '@/components/Metatags';
 import { AbstractSources } from '@/components/AbstractSources';
@@ -16,6 +16,7 @@ interface IAbsLayoutProps {
   doc?: IDocsEntity;
   titleDescription: string;
   label: string;
+  children?: ReactNode;
 }
 
 export const AbsLayout: FC<IAbsLayoutProps> = ({ children, doc, titleDescription, label }) => {

--- a/src/lib/abs/absRecordState.test.ts
+++ b/src/lib/abs/absRecordState.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+
+import { AbsSSRResult, deriveAbsRecordState } from './absRecordState';
+import { IDocsEntity } from '@/api/search/types';
+
+const doc = { bibcode: '2024ApJ...1..1X' } as IDocsEntity;
+
+const base = {
+  doc: undefined as IDocsEntity | undefined,
+  hasClientData: false,
+  clientDocsCount: 0,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+};
+
+describe('deriveAbsRecordState', () => {
+  const found: AbsSSRResult = { outcome: 'found' };
+  const notFound: AbsSSRResult = { outcome: 'not-found' };
+  const errored: AbsSSRResult = { outcome: 'error', statusCode: 503, reason: 'fetch-not-ok' };
+
+  test('renders content whenever a doc is present, regardless of SSR outcome', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored, doc })).toEqual({ kind: 'content', doc });
+  });
+
+  test('shows loading while the client query is loading and no doc yet', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: found, isLoading: true })).toEqual({ kind: 'loading' });
+  });
+
+  test('shows loading while the client is re-fetching a negative SSR outcome', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored, isFetching: true })).toEqual({ kind: 'loading' });
+  });
+
+  test('shows error when the client query errors, carrying the SSR status code', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored, isError: true })).toEqual({
+      kind: 'error',
+      statusCode: 503,
+    });
+  });
+
+  test('shows error for an SSR error even before the client resolves', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored })).toEqual({ kind: 'error', statusCode: 503 });
+  });
+
+  test('client-confirmed empty overrides a stale SSR error (fresher client wins)', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored, hasClientData: true, clientDocsCount: 0 })).toEqual({
+      kind: 'not-found',
+    });
+  });
+
+  test('a client fetch error still shows error even when SSR errored', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: errored, isError: true })).toEqual({ kind: 'error', statusCode: 503 });
+  });
+
+  test('reserves not-found for a client-confirmed empty result', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: notFound, hasClientData: true, clientDocsCount: 0 })).toEqual({
+      kind: 'not-found',
+    });
+  });
+
+  test('treats an SSR not-found as not-found even before the client hydrates', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: notFound })).toEqual({ kind: 'not-found' });
+  });
+
+  test('never flashes not-found for an ambiguous found outcome with no client data yet', () => {
+    expect(deriveAbsRecordState({ ...base, ssr: found })).toEqual({ kind: 'loading' });
+  });
+});

--- a/src/lib/abs/absRecordState.ts
+++ b/src/lib/abs/absRecordState.ts
@@ -1,0 +1,73 @@
+import { IDocsEntity } from '@/api/search/types';
+
+// SSR outcome for an abstract record. Absence is a 200 with zero docs; upstream
+// 4xx/5xx are errors, never not-found.
+export type AbsSSRResult =
+  | { outcome: 'found' }
+  | { outcome: 'not-found' }
+  | { outcome: 'error'; statusCode: number; reason: string };
+
+// Props every abstract sub-view page receives from the shared SSR helper.
+export type AbsPageProps = {
+  ssr: AbsSSRResult;
+  queryId: string;
+  initialDoc?: IDocsEntity | null;
+  isAuthenticated?: boolean;
+};
+
+// Discriminated UI state the boundary renders from.
+export type AbsRecordUIState =
+  | { kind: 'content'; doc: IDocsEntity }
+  | { kind: 'loading' }
+  | { kind: 'not-found' }
+  | { kind: 'error'; statusCode?: number };
+
+type DeriveAbsRecordStateInput = {
+  ssr: AbsSSRResult;
+  doc?: IDocsEntity;
+  hasClientData: boolean;
+  clientDocsCount: number;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+};
+
+// Never render not-found while ambiguous — default to loading. not-found is
+// reserved for a confirmed empty result the client hasn't contradicted.
+export const deriveAbsRecordState = (input: DeriveAbsRecordStateInput): AbsRecordUIState => {
+  const { ssr, doc, hasClientData, clientDocsCount, isLoading, isFetching, isError } = input;
+
+  if (doc) {
+    return { kind: 'content', doc };
+  }
+
+  // Client is actively resolving (or re-checking a negative SSR outcome) — wait.
+  if (isLoading || isFetching) {
+    return { kind: 'loading' };
+  }
+
+  // Client fetch failed.
+  if (isError) {
+    return { kind: 'error', statusCode: ssr.outcome === 'error' ? ssr.statusCode : undefined };
+  }
+
+  // Client-confirmed empty. The client is fresher than SSR, so this wins over a
+  // stale SSR error — a record confirmed absent is not-found, not unavailable.
+  // Also covers SSR not-found (seeded empty cache).
+  if (hasClientData && clientDocsCount === 0) {
+    return { kind: 'not-found' };
+  }
+
+  // SSR error the client didn't override.
+  if (ssr.outcome === 'error') {
+    return { kind: 'error', statusCode: ssr.statusCode };
+  }
+
+  // SSR-confirmed empty; the seeded cache means the client will agree.
+  if (ssr.outcome === 'not-found') {
+    return { kind: 'not-found' };
+  }
+
+  // Ambiguous — never flash not-found.
+  return { kind: 'loading' };
+};

--- a/src/lib/abs/useAbsRecordState.ts
+++ b/src/lib/abs/useAbsRecordState.ts
@@ -1,0 +1,53 @@
+import { path } from 'ramda';
+
+import { useGetAbstract } from '@/api/search/search';
+import { IDocsEntity } from '@/api/search/types';
+import { AbsRecordUIState, AbsSSRResult, deriveAbsRecordState } from './absRecordState';
+
+// AbsPageProps types ssr/queryId as required, but composeNextGSSP's catch path can
+// drop them (a throw before absCanonicalize's try). Accept undefined and degrade to
+// error rather than crash on ssr.outcome.
+type UseAbsRecordStateArgs = {
+  ssr?: AbsSSRResult;
+  queryId?: string;
+  initialDoc?: IDocsEntity | null;
+};
+
+type UseAbsRecordStateResult = {
+  doc?: IDocsEntity;
+  state: AbsRecordUIState;
+};
+
+const MISSING_SSR: AbsSSRResult = { outcome: 'error', statusCode: 500, reason: 'missing-ssr-props' };
+
+export const useAbsRecordState = ({ ssr, queryId, initialDoc }: UseAbsRecordStateArgs): UseAbsRecordStateResult => {
+  const resolvedSSR = ssr ?? MISSING_SSR;
+  const resolvedQueryId = queryId ?? '';
+  const isNegativeSSR = resolvedSSR.outcome !== 'found';
+
+  const { data, isLoading, isFetching, isError } = useGetAbstract(
+    { id: resolvedQueryId },
+    {
+      enabled: resolvedQueryId.length > 0,
+      // Found/not-found hydrate from the seeded cache and never refetch. Only the
+      // error path fetches client-side — retry it so a transient SSR failure
+      // recovers via the browser session.
+      retry: isNegativeSSR ? 2 : false,
+    },
+  );
+
+  const clientDoc = path<IDocsEntity>(['docs', 0], data);
+  const doc = clientDoc ?? initialDoc ?? undefined;
+
+  const state = deriveAbsRecordState({
+    ssr: resolvedSSR,
+    doc,
+    hasClientData: data !== undefined,
+    clientDocsCount: data?.docs?.length ?? 0,
+    isLoading,
+    isFetching,
+    isError,
+  });
+
+  return { doc, state };
+};

--- a/src/lib/abs/useAbsRecordState.ts
+++ b/src/lib/abs/useAbsRecordState.ts
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { path } from 'ramda';
+import * as Sentry from '@sentry/nextjs';
 
 import { useGetAbstract } from '@/api/search/search';
 import { IDocsEntity } from '@/api/search/types';
@@ -48,6 +50,26 @@ export const useAbsRecordState = ({ ssr, queryId, initialDoc }: UseAbsRecordStat
     isFetching,
     isError,
   });
+
+  // SSR rendered a negative but the client resolved a real record — measures
+  // residual false negatives. Keyed by queryId (not a bool) so it re-fires across
+  // client-side navigation without a remount.
+  const recoveredQueryId = useRef<string | null>(null);
+  useEffect(() => {
+    if (isNegativeSSR && clientDoc && recoveredQueryId.current !== resolvedQueryId) {
+      recoveredQueryId.current = resolvedQueryId;
+      Sentry.captureMessage('abs_ssr_false_negative_recovered', {
+        level: 'warning',
+        contexts: {
+          absRecord: {
+            queryId: resolvedQueryId,
+            ssrOutcome: resolvedSSR.outcome,
+            bibcode: clientDoc.bibcode ?? null,
+          },
+        },
+      });
+    }
+  }, [isNegativeSSR, clientDoc, resolvedQueryId, resolvedSSR.outcome]);
 
   return { doc, state };
 };

--- a/src/lib/serverside/__tests__/absCanonicalization.test.ts
+++ b/src/lib/serverside/__tests__/absCanonicalization.test.ts
@@ -300,7 +300,11 @@ describe('createAbsGetServerSideProps', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result).toHaveProperty('props');
     if ('props' in result) {
-      expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 404 }, initialDoc: null });
+      expect(result.props).toMatchObject({
+        ssr: { outcome: 'error', statusCode: 404 },
+        initialDoc: null,
+        isAuthenticated: true,
+      });
     }
     expect((ctx.res as unknown as { setHeader: ReturnType<typeof vi.fn> }).setHeader).toHaveBeenCalledWith(
       'Cache-Control',
@@ -331,7 +335,7 @@ describe('createAbsGetServerSideProps', () => {
 
     expect(result).toHaveProperty('props');
     if ('props' in result) {
-      expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 500 } });
+      expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 500 }, isAuthenticated: true });
     }
   });
 });

--- a/src/lib/serverside/__tests__/absCanonicalization.test.ts
+++ b/src/lib/serverside/__tests__/absCanonicalization.test.ts
@@ -96,7 +96,7 @@ describe('createAbsGetServerSideProps', () => {
     expect(result).toHaveProperty('redirect');
     if ('redirect' in result) {
       expect(result.redirect?.destination).toBe('/abs/canonical%26%2Fbib/abstract?foo=1');
-      expect(result.redirect?.statusCode).toBe(302);
+      expect((result.redirect as { statusCode?: number })?.statusCode).toBe(302);
     }
   });
 
@@ -119,7 +119,7 @@ describe('createAbsGetServerSideProps', () => {
     expect(result).toHaveProperty('redirect');
     if ('redirect' in result) {
       expect(result.redirect?.destination).toBe('/abs/BIBCODE/citations?p=2');
-      expect(result.redirect?.statusCode).toBe(302);
+      expect((result.redirect as { statusCode?: number })?.statusCode).toBe(302);
     }
   });
 
@@ -144,7 +144,7 @@ describe('createAbsGetServerSideProps', () => {
     if ('props' in result) {
       expect(result.props).toHaveProperty('initialDoc');
     }
-    expect((ctx.res as { setHeader: () => void } & Record<string, unknown>).setHeader).toHaveBeenCalledWith(
+    expect((ctx.res as unknown as { setHeader: ReturnType<typeof vi.fn> }).setHeader).toHaveBeenCalledWith(
       'Cache-Control',
       's-maxage=60, stale-while-revalidate=300',
     );
@@ -186,7 +186,7 @@ describe('createAbsGetServerSideProps', () => {
     fetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({
-        response: { docs: [] },
+        response: { docs: [] as Array<{ bibcode: string }> },
       }),
     });
 
@@ -209,7 +209,7 @@ describe('createAbsGetServerSideProps', () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ response: { docs: [] } }),
+        json: async () => ({ response: { docs: [] as Array<{ bibcode: string }> } }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -228,14 +228,14 @@ describe('createAbsGetServerSideProps', () => {
     expect(result).toHaveProperty('redirect');
     if ('redirect' in result) {
       expect(result.redirect?.destination).toBe('/abs/1999AN....320..163H/abstract');
-      expect(result.redirect?.statusCode).toBe(302);
+      expect((result.redirect as { statusCode?: number })?.statusCode).toBe(302);
     }
   });
 
   test('does not retry with # for non-DOI identifiers', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
-      json: async () => ({ response: { docs: [] } }),
+      json: async () => ({ response: { docs: [] as Array<{ bibcode: string }> } }),
     });
 
     const ctx = buildCtx({
@@ -267,10 +267,10 @@ describe('createAbsGetServerSideProps', () => {
     }
   });
 
-  test('confirmed empty result returns ssr:not-found', async () => {
+  test('confirmed empty result returns ssr:not-found and marks the response non-cacheable', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
-      json: async () => ({ response: { docs: [] } }),
+      json: async () => ({ response: { docs: [] as Array<{ bibcode: string }> } }),
     });
 
     const ctx = buildCtx({ id: '2024ApJ...123..456X', resolvedUrl: '/abs/2024ApJ...123..456X/abstract' });
@@ -280,9 +280,18 @@ describe('createAbsGetServerSideProps', () => {
     if ('props' in result) {
       expect(result.props).toMatchObject({ ssr: { outcome: 'not-found' } });
     }
+    // Negatives must override the wrapper's shared cache header (setHeader replaces).
+    expect((ctx.res as unknown as { setHeader: ReturnType<typeof vi.fn> }).setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'no-store',
+    );
+    expect((ctx.res as unknown as { setHeader: ReturnType<typeof vi.fn> }).setHeader).not.toHaveBeenCalledWith(
+      'Cache-Control',
+      expect.stringContaining('s-maxage'),
+    );
   });
 
-  test('non-retryable upstream 404 is classified as an error, not not-found', async () => {
+  test('non-retryable upstream 404 is classified as an error, not not-found, and is non-cacheable', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) });
 
     const ctx = buildCtx({ id: 'BIB', resolvedUrl: '/abs/BIB/abstract' });
@@ -292,6 +301,25 @@ describe('createAbsGetServerSideProps', () => {
     expect(result).toHaveProperty('props');
     if ('props' in result) {
       expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 404 }, initialDoc: null });
+    }
+    expect((ctx.res as unknown as { setHeader: ReturnType<typeof vi.fn> }).setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'no-store',
+    );
+  });
+
+  test('retries a transient 503 during SSR and recovers to a found record', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Unavailable', json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ response: { docs: [{ bibcode: 'BIB' }] } }) });
+
+    const ctx = buildCtx({ id: 'BIB', resolvedUrl: '/abs/BIB/abstract' });
+    const result = await createAbsGetServerSideProps('abstract')(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toHaveProperty('props');
+    if ('props' in result) {
+      expect(result.props).toMatchObject({ ssr: { outcome: 'found' } });
     }
   });
 

--- a/src/lib/serverside/__tests__/absCanonicalization.test.ts
+++ b/src/lib/serverside/__tests__/absCanonicalization.test.ts
@@ -250,4 +250,60 @@ describe('createAbsGetServerSideProps', () => {
     expect(result).not.toHaveProperty('redirect');
     expect(result).toHaveProperty('props');
   });
+
+  test('found outcome carries ssr:found and the queryId used for the cache', async () => {
+    const bibcode = 'CANONICAL';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { docs: [{ bibcode }] } }),
+    });
+
+    const ctx = buildCtx({ id: bibcode, resolvedUrl: `/abs/${bibcode}/abstract` });
+    const result = await createAbsGetServerSideProps('abstract')(ctx);
+
+    expect(result).toHaveProperty('props');
+    if ('props' in result) {
+      expect(result.props).toMatchObject({ ssr: { outcome: 'found' }, queryId: bibcode });
+    }
+  });
+
+  test('confirmed empty result returns ssr:not-found', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { docs: [] } }),
+    });
+
+    const ctx = buildCtx({ id: '2024ApJ...123..456X', resolvedUrl: '/abs/2024ApJ...123..456X/abstract' });
+    const result = await createAbsGetServerSideProps('abstract')(ctx);
+
+    expect(result).toHaveProperty('props');
+    if ('props' in result) {
+      expect(result.props).toMatchObject({ ssr: { outcome: 'not-found' } });
+    }
+  });
+
+  test('non-retryable upstream 404 is classified as an error, not not-found', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) });
+
+    const ctx = buildCtx({ id: 'BIB', resolvedUrl: '/abs/BIB/abstract' });
+    const result = await createAbsGetServerSideProps('abstract')(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toHaveProperty('props');
+    if ('props' in result) {
+      expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 404 }, initialDoc: null });
+    }
+  });
+
+  test('a thrown fetch is classified as a 500 error', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+
+    const ctx = buildCtx({ id: 'BIB', resolvedUrl: '/abs/BIB/abstract' });
+    const result = await createAbsGetServerSideProps('abstract')(ctx);
+
+    expect(result).toHaveProperty('props');
+    if ('props' in result) {
+      expect(result.props).toMatchObject({ ssr: { outcome: 'error', statusCode: 500 } });
+    }
+  });
 });

--- a/src/lib/serverside/absCanonicalization.ts
+++ b/src/lib/serverside/absCanonicalization.ts
@@ -34,8 +34,13 @@ const addOutcomeBreadcrumb = (data: Record<string, unknown>) => {
   Sentry.addBreadcrumb({ category: 'abs-ssr', level: 'info', message: 'abs-ssr-outcome', data });
 };
 
-const absErrorProps = (queryId: string, statusCode: number, reason: string): { props: AbsProps } => ({
-  props: { initialDoc: null, queryId, ssr: { outcome: 'error', statusCode, reason } },
+const absErrorProps = (
+  queryId: string,
+  statusCode: number,
+  reason: string,
+  isAuthenticated?: boolean,
+): { props: AbsProps } => ({
+  props: { initialDoc: null, isAuthenticated, queryId, ssr: { outcome: 'error', statusCode, reason } },
 });
 
 // composeNextGSSP sets a cache header on every response before we run; mark
@@ -176,7 +181,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         });
         addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'error', stage: 'fetch', statusCode: response.status });
         setNoStore(ctx);
-        return absErrorProps(requestedId, response.status, 'fetch-not-ok');
+        return absErrorProps(requestedId, response.status, 'fetch-not-ok', isAuthenticated(bootstrapResult.token));
       }
 
       const data = (await response.json()) as IADSApiSearchResponse;
@@ -273,7 +278,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
       });
       addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'error', stage: 'fetch-throw', statusCode: 500 });
       setNoStore(ctx);
-      return absErrorProps(requestedId, 500, 'fetch-threw');
+      return absErrorProps(requestedId, 500, 'fetch-threw', isAuthenticated(bootstrapResult.token));
     }
   };
 };

--- a/src/lib/serverside/absCanonicalization.ts
+++ b/src/lib/serverside/absCanonicalization.ts
@@ -1,5 +1,6 @@
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import * as Sentry from '@sentry/nextjs';
 
 import { ApiTargets } from '@/api/models';
 import { searchKeys } from '@/api/search/search';
@@ -8,6 +9,7 @@ import { IADSApiSearchResponse, IDocsEntity } from '@/api/search/types';
 import { stringifySearchParams } from '@/utils/common/search';
 import { pickTracingHeaders } from '@/config';
 import { bootstrap } from './bootstrap';
+import { fetchWithRetry } from './fetchWithRetry';
 import { logger } from '@/logger';
 import { composeNextGSSP } from '@/ssr-utils';
 import { isAuthenticated } from '@/api/api';
@@ -17,6 +19,9 @@ import { AbsSSRResult } from '@/lib/abs/absRecordState';
 
 const log = logger.child({ module: 'abs-canonical' }, { msgPrefix: '[abs-canonical] ' });
 
+const SSR_FETCH_RETRIES = 2;
+const SSR_FETCH_BACKOFF_MS = 150;
+
 type AbsProps = {
   dehydratedState?: unknown;
   initialDoc?: IDocsEntity | null;
@@ -25,9 +30,20 @@ type AbsProps = {
   ssr: AbsSSRResult;
 };
 
+const addOutcomeBreadcrumb = (data: Record<string, unknown>) => {
+  Sentry.addBreadcrumb({ category: 'abs-ssr', level: 'info', message: 'abs-ssr-outcome', data });
+};
+
 const absErrorProps = (queryId: string, statusCode: number, reason: string): { props: AbsProps } => ({
   props: { initialDoc: null, queryId, ssr: { outcome: 'error', statusCode, reason } },
 });
+
+// composeNextGSSP sets a cache header on every response before we run; mark
+// negatives non-cacheable so a transient error/not-found isn't edge-cached and
+// served stale (setHeader replaces).
+const setNoStore = (ctx: GetServerSidePropsContext) => {
+  ctx.res.setHeader('Cache-Control', 'no-store');
+};
 
 type IncomingGSSPResult = GetServerSidePropsResult<AbsProps>;
 type IncomingGSSP = (
@@ -104,6 +120,8 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         context: { bootstrapError: bootstrapResult.error, url: ctx.resolvedUrl },
         tags: { feature: 'abs-canonical', stage: 'bootstrap' },
       });
+      addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'error', stage: 'bootstrap', statusCode: 500 });
+      setNoStore(ctx);
       return absErrorProps(requestedId, 500, 'bootstrap-failed');
     }
 
@@ -127,7 +145,19 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
           : viewPath === 'references'
           ? PERF_SPANS.ABSTRACT_REFERENCES_LOAD
           : PERF_SPANS.ABSTRACT_LOAD_TOTAL;
-      const response = await trackUserFlow(spanName, () => fetch(url, requestInit));
+      const response = await trackUserFlow(spanName, () =>
+        fetchWithRetry(url, requestInit, {
+          retries: SSR_FETCH_RETRIES,
+          backoffMs: SSR_FETCH_BACKOFF_MS,
+          onAttempt: ({ attempt, status, error, willRetry }) =>
+            Sentry.addBreadcrumb({
+              category: 'abs-ssr',
+              level: willRetry ? 'warning' : 'info',
+              message: 'abs-ssr-fetch-attempt',
+              data: { requestedId, viewPath, attempt, status, willRetry, error: error ? String(error) : undefined },
+            }),
+        }),
+      );
 
       if (!response.ok) {
         // Upstream 4xx/5xx are errors, never not-found. Absence is a 200 with zero
@@ -144,6 +174,8 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
           },
           tags: { feature: 'abs-canonical', stage: 'fetch' },
         });
+        addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'error', stage: 'fetch', statusCode: response.status });
+        setNoStore(ctx);
         return absErrorProps(requestedId, response.status, 'fetch-not-ok');
       }
 
@@ -206,7 +238,10 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
       }
 
       if (!initialDoc) {
-        // Confirmed empty (200, zero docs). Seed the cache so the client agrees.
+        // Confirmed empty (200, zero docs). Seed the cache so the client agrees, but
+        // don't edge-cache a negative.
+        addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'not-found', statusCode: 200 });
+        setNoStore(ctx);
         return {
           props: {
             dehydratedState: dehydrate(queryClient),
@@ -220,6 +255,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
 
       // Only edge-cache confirmed found records.
       ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+      addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'found', statusCode: 200, bibcode: initialDoc.bibcode });
       return {
         props: {
           dehydratedState: dehydrate(queryClient),
@@ -235,6 +271,8 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         context: { url: url.toString(), requestedId, viewPath },
         tags: { feature: 'abs-canonical', stage: 'fetch' },
       });
+      addOutcomeBreadcrumb({ requestedId, viewPath, outcome: 'error', stage: 'fetch-throw', statusCode: 500 });
+      setNoStore(ctx);
       return absErrorProps(requestedId, 500, 'fetch-threw');
     }
   };
@@ -250,6 +288,8 @@ export const createAbsGetServerSideProps = (viewPathResolver: ViewPathResolver) 
     if ('notFound' in result) {
       return { notFound: result.notFound };
     }
-    return result;
+    // composeNextGSSP widens props to Record<string, unknown>; here the shape is
+    // always AbsProps, so restore the concrete return type.
+    return result as IncomingGSSPResult;
   };
 };

--- a/src/lib/serverside/absCanonicalization.ts
+++ b/src/lib/serverside/absCanonicalization.ts
@@ -13,6 +13,7 @@ import { composeNextGSSP } from '@/ssr-utils';
 import { isAuthenticated } from '@/api/api';
 import { ErrorSeverity, ErrorSource, handleError } from '@/lib/errorHandler';
 import { trackUserFlow, PERF_SPANS } from '@/lib/performance';
+import { AbsSSRResult } from '@/lib/abs/absRecordState';
 
 const log = logger.child({ module: 'abs-canonical' }, { msgPrefix: '[abs-canonical] ' });
 
@@ -20,9 +21,13 @@ type AbsProps = {
   dehydratedState?: unknown;
   initialDoc?: IDocsEntity | null;
   isAuthenticated?: boolean;
-  pageError?: string;
-  statusCode?: number;
+  queryId: string;
+  ssr: AbsSSRResult;
 };
+
+const absErrorProps = (queryId: string, statusCode: number, reason: string): { props: AbsProps } => ({
+  props: { initialDoc: null, queryId, ssr: { outcome: 'error', statusCode, reason } },
+});
 
 type IncomingGSSPResult = GetServerSidePropsResult<AbsProps>;
 type IncomingGSSP = (
@@ -99,7 +104,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         context: { bootstrapError: bootstrapResult.error, url: ctx.resolvedUrl },
         tags: { feature: 'abs-canonical', stage: 'bootstrap' },
       });
-      return { props: { pageError: bootstrapResult.error, initialDoc: null, statusCode: 500 } };
+      return absErrorProps(requestedId, 500, 'bootstrap-failed');
     }
 
     const params = getAbstractParams(requestedId);
@@ -110,22 +115,23 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
 
     try {
       const tracingHeaders = pickTracingHeaders(ctx.req.headers);
+      const requestInit: RequestInit = {
+        headers: {
+          Authorization: `Bearer ${bootstrapResult.token.access_token}`,
+          ...tracingHeaders,
+        },
+      };
       const spanName =
         viewPath === 'citations'
           ? PERF_SPANS.ABSTRACT_CITATIONS_LOAD
           : viewPath === 'references'
           ? PERF_SPANS.ABSTRACT_REFERENCES_LOAD
           : PERF_SPANS.ABSTRACT_LOAD_TOTAL;
-      const response = await trackUserFlow(spanName, () =>
-        fetch(url, {
-          headers: {
-            Authorization: `Bearer ${bootstrapResult.token.access_token}`,
-            ...tracingHeaders,
-          },
-        }),
-      );
+      const response = await trackUserFlow(spanName, () => fetch(url, requestInit));
 
       if (!response.ok) {
+        // Upstream 4xx/5xx are errors, never not-found. Absence is a 200 with zero
+        // docs (below).
         const error = new Error(`Abstract fetch failed with status ${response.status}`);
         handleError(error, {
           source: ErrorSource.SERVER,
@@ -138,18 +144,11 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
           },
           tags: { feature: 'abs-canonical', stage: 'fetch' },
         });
-        return {
-          props: {
-            pageError: 'Failed to load abstract data',
-            initialDoc: null,
-            statusCode: response.status,
-          },
-        };
+        return absErrorProps(requestedId, response.status, 'fetch-not-ok');
       }
 
       const data = (await response.json()) as IADSApiSearchResponse;
       queryClient.setQueryData(searchKeys.abstract(requestedId), data);
-      ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
 
       const initialDoc = data?.response?.docs?.[0] ?? null;
 
@@ -206,11 +205,28 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         };
       }
 
+      if (!initialDoc) {
+        // Confirmed empty (200, zero docs). Seed the cache so the client agrees.
+        return {
+          props: {
+            dehydratedState: dehydrate(queryClient),
+            initialDoc: null,
+            isAuthenticated: isAuthenticated(bootstrapResult.token),
+            queryId: requestedId,
+            ssr: { outcome: 'not-found' },
+          },
+        };
+      }
+
+      // Only edge-cache confirmed found records.
+      ctx.res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
       return {
         props: {
           dehydratedState: dehydrate(queryClient),
           initialDoc,
           isAuthenticated: isAuthenticated(bootstrapResult.token),
+          queryId: requestedId,
+          ssr: { outcome: 'found' },
         },
       };
     } catch (error) {
@@ -219,13 +235,7 @@ const absCanonicalize = (viewPathResolver: ViewPathResolver): IncomingGSSP => {
         context: { url: url.toString(), requestedId, viewPath },
         tags: { feature: 'abs-canonical', stage: 'fetch' },
       });
-      return {
-        props: {
-          pageError: 'Failed to load abstract data',
-          initialDoc: null,
-          statusCode: 500,
-        },
-      };
+      return absErrorProps(requestedId, 500, 'fetch-threw');
     }
   };
 };

--- a/src/lib/serverside/fetchWithRetry.test.ts
+++ b/src/lib/serverside/fetchWithRetry.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { fetchWithRetry, isRetryableStatus } from './fetchWithRetry';
+import { server } from '@/mocks/server';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+const res = (status: number): Response => ({ ok: status >= 200 && status < 300, status } as Response);
+
+beforeAll(() => {
+  // disable msw for this suite; we stub fetch manually
+  server.close();
+});
+
+afterAll(() => {
+  // restart msw for other suites
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('isRetryableStatus', () => {
+  test('treats 429 and 5xx as retryable', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  test('treats 2xx and 4xx (except 429) as non-retryable', () => {
+    expect(isRetryableStatus(200)).toBe(false);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(401)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+});
+
+describe('fetchWithRetry', () => {
+  test('returns immediately on a 2xx without retrying', async () => {
+    fetchMock.mockResolvedValueOnce(res(200));
+    const response = await fetchWithRetry('https://x', {}, { backoffMs: 0 });
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry a non-retryable 4xx', async () => {
+    fetchMock.mockResolvedValueOnce(res(404));
+    const response = await fetchWithRetry('https://x', {}, { retries: 2, backoffMs: 0 });
+    expect(response.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries a transient 503 and returns the recovered 200', async () => {
+    fetchMock.mockResolvedValueOnce(res(503)).mockResolvedValueOnce(res(200));
+    const response = await fetchWithRetry('https://x', {}, { retries: 2, backoffMs: 0 });
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns the last response after exhausting retries on a persistent 500', async () => {
+    fetchMock.mockResolvedValue(res(500));
+    const response = await fetchWithRetry('https://x', {}, { retries: 2, backoffMs: 0 });
+    expect(response.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('retries a network error then resolves', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce(res(200));
+    const response = await fetchWithRetry('https://x', {}, { retries: 2, backoffMs: 0 });
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('rethrows a persistent network error after exhausting retries', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    await expect(fetchWithRetry('https://x', {}, { retries: 1, backoffMs: 0 })).rejects.toThrow('ECONNRESET');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('reports each attempt to onAttempt with willRetry flags', async () => {
+    fetchMock.mockResolvedValueOnce(res(503)).mockResolvedValueOnce(res(200));
+    const attempts: Array<{ attempt: number; status?: number; willRetry: boolean }> = [];
+    await fetchWithRetry(
+      'https://x',
+      {},
+      {
+        retries: 2,
+        backoffMs: 0,
+        onAttempt: ({ attempt, status, willRetry }) => attempts.push({ attempt, status, willRetry }),
+      },
+    );
+    expect(attempts).toEqual([
+      { attempt: 0, status: 503, willRetry: true },
+      { attempt: 1, status: 200, willRetry: false },
+    ]);
+  });
+});

--- a/src/lib/serverside/fetchWithRetry.test.ts
+++ b/src/lib/serverside/fetchWithRetry.test.ts
@@ -1,21 +1,19 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import { fetchWithRetry, isRetryableStatus } from './fetchWithRetry';
-import { server } from '@/mocks/server';
 
 const fetchMock = vi.fn();
-vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 
 const res = (status: number): Response => ({ ok: status >= 200 && status < 300, status } as Response);
 
 beforeAll(() => {
-  // disable msw for this suite; we stub fetch manually
-  server.close();
+  // stub fetch for this suite; MSW is left intact and the real fetch is
+  // restored in afterAll so the mock can't leak into other suites.
+  vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 });
 
 afterAll(() => {
-  // restart msw for other suites
-  server.listen({ onUnhandledRequest: 'error' });
+  vi.unstubAllGlobals();
 });
 
 afterEach(() => {

--- a/src/lib/serverside/fetchWithRetry.ts
+++ b/src/lib/serverside/fetchWithRetry.ts
@@ -1,0 +1,51 @@
+// Server-side fetch with bounded retry on the outcomes a retry can fix — 429, 5xx,
+// network/timeout — so a transient Solr/token blip doesn't paint a false negative
+// into the SSR HTML. Client retries are React Query's job.
+
+export const isRetryableStatus = (status: number): boolean => status === 429 || status >= 500;
+
+export type FetchAttemptInfo = {
+  attempt: number;
+  status?: number;
+  error?: unknown;
+  willRetry: boolean;
+};
+
+type FetchWithRetryOptions = {
+  retries?: number;
+  backoffMs?: number;
+  onAttempt?: (info: FetchAttemptInfo) => void;
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const fetchWithRetry = async (
+  input: URL | string,
+  init: RequestInit,
+  options: FetchWithRetryOptions = {},
+): Promise<Response> => {
+  const { retries = 2, backoffMs = 150, onAttempt } = options;
+  let attempt = 0;
+
+  for (;;) {
+    try {
+      const response = await fetch(input, init);
+      const willRetry = attempt < retries && isRetryableStatus(response.status);
+      onAttempt?.({ attempt, status: response.status, willRetry });
+      if (!willRetry) {
+        return response;
+      }
+    } catch (error) {
+      const willRetry = attempt < retries;
+      onAttempt?.({ attempt, error, willRetry });
+      if (!willRetry) {
+        throw error;
+      }
+    }
+
+    if (backoffMs > 0) {
+      await wait(backoffMs * (attempt + 1));
+    }
+    attempt += 1;
+  }
+};

--- a/src/pages/abs/[id]/abstract.tsx
+++ b/src/pages/abs/[id]/abstract.tsx
@@ -5,16 +5,14 @@ import dynamic from 'next/dynamic';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { isNil, path } from 'ramda';
+import { isNil } from 'ramda';
 import { useShepherd } from 'react-shepherd';
 import { SafeAbstract } from '@/components/SafeAbstract';
 
 import { IAllAuthorsModalProps } from '@/components/AllAuthorsModal';
 import { useGetAuthors } from '@/components/AllAuthorsModal/useGetAuthors';
 import { OrcidActiveIcon } from '@/components/icons/Orcid';
-import { AbsLayout } from '@/components/Layout/AbsLayout';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
 import { feedbackItems, getAbstractSteps } from '@/components/NavBar';
 import { SearchQueryLink } from '@/components/SearchQueryLink';
 import { AbstractSources } from '@/components/AbstractSources';
@@ -25,8 +23,9 @@ import { useTrackAbstractView } from '@/lib/useTrackAbstractView';
 import { useScreenSize } from '@/lib/useScreenSize';
 import { LocalSettings } from '@/types';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
-import { IADSApiSearchParams, IDocsEntity } from '@/api/search/types';
-import { useGetAbstract } from '@/api/search/search';
+import { IADSApiSearchParams } from '@/api/search/types';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 import { useStore } from '@/store/store';
 
 const AllAuthorsModal = dynamic<IAllAuthorsModalProps>(
@@ -54,23 +53,11 @@ const safeDecode = (value?: string) => {
   }
 };
 
-interface AbstractPageProps {
-  initialDoc?: IDocsEntity | null;
-  isAuthenticated?: boolean;
-  statusCode?: number;
-}
-
-const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc, isAuthenticated, statusCode }) => {
+const AbstractPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc, isAuthenticated }) => {
   const router = useRouter();
-  const { data } = useGetAbstract({ id: router.query.id as string });
-  const doc = path<IDocsEntity>(['docs', 0], data) ?? initialDoc ?? undefined;
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
   useTrackAbstractView(doc);
 
-  const metadata: IAbstractMetadata = {
-    refereed: !!doc?.property?.includes('REFEREED'),
-    doctype: doc?.doctype && doc.doctype !== 'erratum' ? doc.doctype : undefined,
-    erratum: doc?.doctype === 'erratum',
-  };
   const identifier = safeDecode(router.query.id as string);
 
   const authors = useGetAuthors({ doc, includeAff: false });
@@ -87,111 +74,121 @@ const AbstractPage: NextPage<AbstractPageProps> = ({ initialDoc, isAuthenticated
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription={''} label="Abstract">
-      <Box as="article" aria-labelledby="title">
-        {!doc && statusCode !== undefined && statusCode >= 500 ? (
-          <ServiceUnavailable recordId={identifier || 'N/A'} statusCode={statusCode} />
-        ) : !doc ? (
-          <RecordNotFound recordId={identifier || 'N/A'} onFeedback={handleFeedback} />
-        ) : (
-          <Stack direction="column" gap={2}>
-            <a className="skip-link" href="#abstract-section">
-              Skip authors list
-            </a>
-            <Flex wrap="wrap" as="section" aria-labelledby="author-list" data-tour="authors-list">
-              <VisuallyHidden as="h3" id="author-list">
-                Authors
-              </VisuallyHidden>
-              {authors.map(([, author, orcid], index) => {
-                const showOrcid = typeof orcid === 'string' && orcid.length > 0;
-                const isTerminalAuthor = index === MAX - 1 || index === doc.author_count - 1;
-                return (
-                  <Flex key={`${author}-${index}`} mr={1} align="center">
-                    <Tooltip label="View all records by this author" shouldWrapChildren>
-                      <SearchQueryLink
-                        params={createQuery('author', author)}
-                        px={1}
-                        aria-label={`author "${author}", search by name`}
-                        flexShrink="0"
-                      >
-                        {author}
-                      </SearchQueryLink>
-                    </Tooltip>
-                    {showOrcid ? (
-                      <Box as="span" display="inline-flex" justifyContent="center" mx={1}>
-                        <Tooltip label="Search by ORCiD" shouldWrapChildren>
+    <AbsRecordBoundary
+      state={state}
+      recordId={identifier}
+      label="Abstract"
+      titleDescription={''}
+      onFeedback={handleFeedback}
+    >
+      {(doc) => {
+        const metadata: IAbstractMetadata = {
+          refereed: !!doc.property?.includes('REFEREED'),
+          doctype: doc.doctype && doc.doctype !== 'erratum' ? doc.doctype : undefined,
+          erratum: doc.doctype === 'erratum',
+        };
+        return (
+          <>
+            <Box as="article" aria-labelledby="title">
+              <Stack direction="column" gap={2}>
+                <a className="skip-link" href="#abstract-section">
+                  Skip authors list
+                </a>
+                <Flex wrap="wrap" as="section" aria-labelledby="author-list" data-tour="authors-list">
+                  <VisuallyHidden as="h3" id="author-list">
+                    Authors
+                  </VisuallyHidden>
+                  {authors.map(([, author, orcid], index) => {
+                    const showOrcid = typeof orcid === 'string' && orcid.length > 0;
+                    const isTerminalAuthor = index === MAX - 1 || index === doc.author_count - 1;
+                    return (
+                      <Flex key={`${author}-${index}`} mr={1} align="center">
+                        <Tooltip label="View all records by this author" shouldWrapChildren>
+
                           <SearchQueryLink
-                            params={createQuery('orcid', orcid)}
-                            aria-label={`author "${author}", search by orKid`}
+                            params={createQuery('author', author)}
+                            px={1}
+                            aria-label={`author "${author}", search by name`}
+                            flexShrink="0"
                           >
-                            <OrcidActiveIcon fontSize={'large'} />
+                            {author}
                           </SearchQueryLink>
                         </Tooltip>
-                      </Box>
-                    ) : null}
-                    {isTerminalAuthor ? null : (
-                      <Text as="span" ml={showOrcid ? 1 : 0} mr={1}>
-                        ;
-                      </Text>
-                    )}
-                  </Flex>
-                );
-              })}
-              {doc.author_count > MAX ? (
-                <AllAuthorsModal bibcode={doc.bibcode} label={`and ${doc.author_count - MAX} more`} />
-              ) : (
-                <>
-                  {doc.author_count > 0 && (
-                    <Tooltip label="List all authors and affiliations" shouldWrapChildren>
-                      <AllAuthorsModal bibcode={doc.bibcode} label={'show details'} />
-                    </Tooltip>
+                        {showOrcid ? (
+                          <Box as="span" display="inline-flex" justifyContent="center" mx={1}>
+                            <Tooltip label="Search by ORCiD" shouldWrapChildren>
+                              <SearchQueryLink
+                                params={createQuery('orcid', orcid)}
+                                aria-label={`author "${author}", search by orKid`}
+                              >
+                                <OrcidActiveIcon fontSize={'large'} />
+                              </SearchQueryLink>
+                            </Tooltip>
+                          </Box>
+                        ) : null}
+                        {isTerminalAuthor ? null : (
+                          <Text as="span" ml={showOrcid ? 1 : 0} mr={1}>
+                            ;
+                          </Text>
+                        )}
+                      </Flex>
+                    );
+                  })}
+                  {doc.author_count > MAX ? (
+                    <AllAuthorsModal bibcode={doc.bibcode} label={`and ${doc.author_count - MAX} more`} />
+                  ) : (
+                    <>
+                      {doc.author_count > 0 && (
+                        <Tooltip label="List all authors and affiliations" shouldWrapChildren>
+                          <AllAuthorsModal bibcode={doc.bibcode} label={'show details'} />
+                        </Tooltip>
+                      )}
+                    </>
                   )}
-                </>
-              )}
-            </Flex>
+                </Flex>
 
-            <Stack direction="column" id="abstract-section" gap={2}>
-              <AbstractMetadata {...metadata} />
+                <Stack direction="column" id="abstract-section" gap={2}>
+                  <AbstractMetadata {...metadata} />
 
-              <Flex justifyContent="space-between">
-                <Box display={{ base: 'block', lg: 'none' }}>
-                  <AbstractSources doc={doc} style="menu" />
-                </Box>
-                {isAuthenticated ? (
-                  <Flex minH={8} align="center" justify="center">
-                    <Tooltip label="add to library">
-                      <IconButton
-                        aria-label="Add to library"
-                        icon={<FolderPlusIcon width={40} height={40} />}
-                        variant="ghost"
-                        onClick={onOpenAddToLibrary}
-                        data-tour="add-to-library"
-                      />
-                    </Tooltip>
+                  <Flex justifyContent="space-between">
+                    <Box display={{ base: 'block', lg: 'none' }}>
+                      <AbstractSources doc={doc} style="menu" />
+                    </Box>
+                    {isAuthenticated ? (
+                      <Flex minH={8} align="center" justify="center">
+                        <Tooltip label="add to library">
+                          <IconButton
+                            aria-label="Add to library"
+                            icon={<FolderPlusIcon width={40} height={40} />}
+                            variant="ghost"
+                            onClick={onOpenAddToLibrary}
+                            data-tour="add-to-library"
+                          />
+                        </Tooltip>
+                      </Flex>
+                    ) : null}
                   </Flex>
-                ) : null}
-              </Flex>
 
-              <Box as="section" pb="2" aria-labelledby="abstract">
-                <VisuallyHidden as="h3" id="abstract">
-                  Abstract
-                </VisuallyHidden>
-                {isNil(doc?.abstract) ? <Text>No Abstract</Text> : <SafeAbstract html={doc.abstract} />}
-              </Box>
-              <AbstractDetails doc={doc} />
-              <Flex justifyContent="end">
-                <Button variant="link" size="sm" onClick={handleFeedback}>
-                  <EditIcon mr={2} /> Make Corrections
-                </Button>
-              </Flex>
-            </Stack>
-          </Stack>
-        )}
-      </Box>
-      {doc ? (
-        <AddToLibraryModal isOpen={isAddToLibraryOpen} onClose={onCloseAddToLibrary} bibcodes={[doc.bibcode]} />
-      ) : null}
-    </AbsLayout>
+                  <Box as="section" pb="2" aria-labelledby="abstract">
+                    <VisuallyHidden as="h3" id="abstract">
+                      Abstract
+                    </VisuallyHidden>
+                    {isNil(doc.abstract) ? <Text>No Abstract</Text> : <SafeAbstract html={doc.abstract} />}
+                  </Box>
+                  <AbstractDetails doc={doc} />
+                  <Flex justifyContent="end">
+                    <Button variant="link" size="sm" onClick={handleFeedback}>
+                      <EditIcon mr={2} /> Make Corrections
+                    </Button>
+                  </Flex>
+                </Stack>
+              </Stack>
+            </Box>
+            <AddToLibraryModal isOpen={isAddToLibraryOpen} onClose={onCloseAddToLibrary} bibcodes={[doc.bibcode]} />
+          </>
+        );
+      }}
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getCitationsParams } from '@/api/search/models';
-import { useGetAbstract, useGetCitations } from '@/api/search/search';
+import { useGetCitations } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
 import { feedbackItems } from '@/components/NavBar';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const CitationsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const CitationsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -35,7 +34,7 @@ const CitationsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
     start: pageIndex * rows,
   });
 
-  const hasError = abstractError || citationsError;
+  const hasError = citationsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const citationsParams = getCitationsParams(doc?.bibcode, 0, rows);
 
@@ -46,12 +45,14 @@ const CitationsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers that cite" label="Citations">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Citations"
+      titleDescription="Papers that cite"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {hasError && <StandardAlertMessage title={parseAPIError(hasError)} />}
@@ -78,7 +79,7 @@ const CitationsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/citations.tsx
+++ b/src/pages/abs/[id]/citations.tsx
@@ -29,10 +29,13 @@ const CitationsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => 
     error: citationsError,
     isLoading,
     isFetching,
-  } = useGetCitations({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  } = useGetCitations(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const hasError = citationsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -23,10 +23,13 @@ const CoreadsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
 
-  const { data, isSuccess, isLoading, isFetching, error, isError } = useGetCoreads({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  const { data, isSuccess, isLoading, isFetching, error, isError } = useGetCoreads(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const coreadsParams = getCoreadsParams(doc?.bibcode, 0, rows);

--- a/src/pages/abs/[id]/coreads.tsx
+++ b/src/pages/abs/[id]/coreads.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getCoreadsParams } from '@/api/search/models';
-import { useGetAbstract, useGetCoreads } from '@/api/search/search';
+import { useGetCoreads } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const CoreadsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const CoreadsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -39,12 +38,14 @@ const CoreadsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers also read by those who read" label="Coreads">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Coreads"
+      titleDescription="Papers also read by those who read"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {isError && <StandardAlertMessage title={parseAPIError(error)} />}
@@ -71,7 +72,7 @@ const CoreadsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/credits.tsx
+++ b/src/pages/abs/[id]/credits.tsx
@@ -29,10 +29,13 @@ const CreditsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
     error: creditsError,
     isLoading,
     isFetching,
-  } = useGetCredits({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  } = useGetCredits(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const hasError = creditsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);

--- a/src/pages/abs/[id]/credits.tsx
+++ b/src/pages/abs/[id]/credits.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getCreditsParams } from '@/api/search/models';
-import { useGetAbstract, useGetCredits } from '@/api/search/search';
+import { useGetCredits } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const CreditsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const CreditsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -35,7 +34,7 @@ const CreditsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
     start: pageIndex * rows,
   });
 
-  const hasError = abstractError || creditsError;
+  const hasError = creditsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const creditsParams = getCreditsParams(doc?.bibcode, 0, rows);
 
@@ -46,12 +45,14 @@ const CreditsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers that credited" label="Credits">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Credits"
+      titleDescription="Papers that credited"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {hasError && <StandardAlertMessage title={parseAPIError(hasError)} />}
@@ -78,7 +79,7 @@ const CreditsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/exportcitation/[format].tsx
+++ b/src/pages/abs/[id]/exportcitation/[format].tsx
@@ -1,30 +1,26 @@
 import { Box } from '@chakra-ui/react';
 
-import { AbsLayout } from '@/components/Layout/AbsLayout';
 import { NextPage } from 'next';
-import { path } from 'ramda';
 import { useRouter } from 'next/router';
 import { useSettings } from '@/lib/useSettings';
 import { CitationExporter } from '@/components/CitationExporter';
 import { JournalFormatMap } from '@/components/Settings';
 import { ExportApiFormatKey } from '@/api/export/types';
-import { useGetAbstract } from '@/api/search/search';
-import { IDocsEntity } from '@/api/search/types';
 import { useExportFormats } from '@/lib/useExportFormats';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const ExportCitationPage: NextPage = () => {
+const ExportCitationPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
 
   const { isValidFormat } = useExportFormats();
 
   const id = router.query.id as string;
 
-  const { data } = useGetAbstract({ id });
-
-  const doc = path<IDocsEntity>(['docs', 0], data);
+  const { state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   // get export related user settings
   const { settings } = useSettings({
@@ -58,10 +54,14 @@ const ExportCitationPage: NextPage = () => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Export citation for" label="Export Citations">
-      {!doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Export Citations"
+      titleDescription="Export citation for"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <Box pt="1">
           <CitationExporter
             initialFormat={format}
@@ -74,7 +74,7 @@ const ExportCitationPage: NextPage = () => {
           />
         </Box>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/graphics.tsx
+++ b/src/pages/abs/[id]/graphics.tsx
@@ -2,26 +2,22 @@ import { useRouter } from 'next/router';
 import { NextPage } from 'next';
 import NextImage from 'next/image';
 
-import { path } from 'ramda';
-import { AbsLayout } from '@/components/Layout';
 import { Box, Center, Flex, Text } from '@chakra-ui/react';
 import { LoadingMessage } from '@/components/Feedbacks';
 import { SimpleLink } from '@/components/SimpleLink';
-import { useGetAbstract } from '@/api/search/search';
-import { IDocsEntity } from '@/api/search/types';
 import { useGetGraphics } from '@/api/graphics/graphics';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faImage } from '@fortawesome/free-solid-svg-icons';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const GraphicsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const GraphicsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
-  const { data } = useGetAbstract({ id });
-  const doc = path<IDocsEntity>(['docs', 0], data);
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const {
     data: graphics,
@@ -37,12 +33,14 @@ const GraphicsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Graphics from" label="Graphics">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Graphics"
+      titleDescription="Graphics from"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {() => (
         <>
           {isError && (
             <Box mt={5} fontSize="xl">
@@ -106,7 +104,7 @@ const GraphicsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/mentions.tsx
+++ b/src/pages/abs/[id]/mentions.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getMentionsParams } from '@/api/search/models';
-import { useGetAbstract, useGetMentions } from '@/api/search/search';
+import { useGetMentions } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const MentionsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const MentionsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -35,7 +34,7 @@ const MentionsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
     start: pageIndex * rows,
   });
 
-  const hasError = abstractError || mentionsError;
+  const hasError = mentionsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const mentionsParams = getMentionsParams(doc?.bibcode, 0, rows);
 
@@ -46,12 +45,14 @@ const MentionsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers mentioned by" label="Mentions">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Mentions"
+      titleDescription="Papers mentioned by"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {hasError && <StandardAlertMessage title={parseAPIError(hasError)} />}
@@ -78,7 +79,7 @@ const MentionsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/mentions.tsx
+++ b/src/pages/abs/[id]/mentions.tsx
@@ -29,10 +29,13 @@ const MentionsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
     error: mentionsError,
     isLoading,
     isFetching,
-  } = useGetMentions({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  } = useGetMentions(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const hasError = mentionsError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);

--- a/src/pages/abs/[id]/metrics.tsx
+++ b/src/pages/abs/[id]/metrics.tsx
@@ -1,24 +1,20 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { path } from 'ramda';
 import { BasicStatsKey, CitationsStatsKey, MetricsResponseKey } from '@/api/lib/metrics/types';
-import { AbsLayout } from '@/components/Layout';
 import { Box } from '@chakra-ui/react';
 import { LoadingMessage } from '@/components/Feedbacks';
 import { MetricsPane } from '@/components/Visualizations';
-import { useGetAbstract } from '@/api/search/search';
-import { IDocsEntity } from '@/api/search/types';
 import { useGetMetrics } from '@/api/metrics/metrics';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const MetricsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const MetricsPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
-  const { data } = useGetAbstract({ id });
-  const doc = path<IDocsEntity>(['docs', 0], data);
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const {
     data: metrics,
@@ -37,12 +33,14 @@ const MetricsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Metrics for" label="Metrics">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Metrics"
+      titleDescription="Metrics for"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {() => (
         <>
           {isError && (
             <Box mt={5} fontSize="xl">
@@ -60,7 +58,7 @@ const MetricsPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -29,10 +29,13 @@ const ReferencesPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) =>
     isLoading,
     isFetching,
     error: referencesError,
-  } = useGetReferences({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  } = useGetReferences(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const hasError = referencesError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);

--- a/src/pages/abs/[id]/references.tsx
+++ b/src/pages/abs/[id]/references.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getReferencesParams } from '@/api/search/models';
-import { useGetAbstract, useGetReferences } from '@/api/search/search';
+import { useGetReferences } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const ReferencesPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const ReferencesPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc, error: abstractError } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -35,7 +34,7 @@ const ReferencesPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
     start: pageIndex * rows,
   });
 
-  const hasError = abstractError || referencesError;
+  const hasError = referencesError;
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const referencesParams = getReferencesParams(doc?.bibcode, 0, rows);
 
@@ -46,12 +45,14 @@ const ReferencesPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers referenced by" label="References">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="References"
+      titleDescription="Papers referenced by"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {hasError && <StandardAlertMessage title={parseAPIError(hasError)} />}
@@ -78,7 +79,7 @@ const ReferencesPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -23,10 +23,13 @@ const SimilarPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
 
-  const { data, isSuccess, isLoading, isFetching, isError, error } = useGetSimilar({
-    ...getParams(),
-    start: pageIndex * rows,
-  });
+  const { data, isSuccess, isLoading, isFetching, isError, error } = useGetSimilar(
+    {
+      ...getParams(),
+      start: pageIndex * rows,
+    },
+    { enabled: !!doc?.bibcode },
+  );
 
   const isEmpty = isSuccess && !isFetching && (!data?.docs || data.docs.length === 0);
   const similarParams = getSimilarParams(doc?.bibcode, 0, rows);

--- a/src/pages/abs/[id]/similar.tsx
+++ b/src/pages/abs/[id]/similar.tsx
@@ -1,25 +1,24 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getSimilarParams } from '@/api/search/models';
-import { useGetAbstract, useGetSimilar } from '@/api/search/search';
+import { useGetSimilar } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const SimilarPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const SimilarPage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
   const pageIndex = router.query.p ? parseInt(router.query.p as string) - 1 : 0;
 
-  const { data: abstractDoc } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -39,12 +38,14 @@ const SimilarPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers similar to" label="Similar Papers">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Similar Papers"
+      titleDescription="Papers similar to"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {isError && <StandardAlertMessage title={parseAPIError(error)} />}
@@ -71,7 +72,7 @@ const SimilarPage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 

--- a/src/pages/abs/[id]/toc.tsx
+++ b/src/pages/abs/[id]/toc.tsx
@@ -1,24 +1,23 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { getTocParams } from '@/api/search/models';
-import { useGetAbstract, useGetToc } from '@/api/search/search';
+import { useGetToc } from '@/api/search/search';
 import { AbstractRefList } from '@/components/AbstractRefList';
 import { EmptyStatePanel, StandardAlertMessage } from '@/components/Feedbacks';
-import { AbsLayout } from '@/components/Layout';
 import { ItemsSkeleton } from '@/components/ResultList';
 import { createAbsGetServerSideProps } from '@/lib/serverside/absCanonicalization';
 import { useGetAbstractParams } from '@/lib/useGetAbstractParams';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import { feedbackItems } from '@/components/NavBar';
-import { RecordNotFound } from '@/components/RecordNotFound';
-import { ServiceUnavailable } from '@/components/ServiceUnavailable';
+import { AbsRecordBoundary } from '@/components/AbsRecordBoundary';
+import { AbsPageProps } from '@/lib/abs/absRecordState';
+import { useAbsRecordState } from '@/lib/abs/useAbsRecordState';
 
-const VolumePage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
+const VolumePage: NextPage<AbsPageProps> = ({ ssr, queryId, initialDoc }) => {
   const router = useRouter();
   const id = router.query.id as string;
 
-  const { data: abstractDoc } = useGetAbstract({ id });
-  const doc = abstractDoc?.docs?.[0];
+  const { doc, state } = useAbsRecordState({ ssr, queryId, initialDoc });
 
   const { getParams, onPageChange, onPageSizeChange } = useGetAbstractParams(doc?.bibcode);
   const { rows } = getParams();
@@ -37,12 +36,14 @@ const VolumePage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
   };
 
   return (
-    <AbsLayout doc={doc} titleDescription="Papers in the same volume as" label="Volume Content">
-      {!doc && statusCode !== undefined && statusCode >= 500 ? (
-        <ServiceUnavailable recordId={id || 'N/A'} statusCode={statusCode} />
-      ) : !doc ? (
-        <RecordNotFound recordId={id || 'N/A'} onFeedback={handleMissingRecordFeedback} />
-      ) : (
+    <AbsRecordBoundary
+      state={state}
+      recordId={id}
+      label="Volume Content"
+      titleDescription="Papers in the same volume as"
+      onFeedback={handleMissingRecordFeedback}
+    >
+      {(doc) => (
         <>
           {isLoading || isFetching ? <ItemsSkeleton count={10} /> : null}
           {isError && <StandardAlertMessage title={parseAPIError(error)} />}
@@ -69,7 +70,7 @@ const VolumePage: NextPage<{ statusCode?: number }> = ({ statusCode }) => {
           )}
         </>
       )}
-    </AbsLayout>
+    </AbsRecordBoundary>
   );
 };
 


### PR DESCRIPTION
Abstract pages briefly flashed "Record Not Found" before the real record
rendered — the server painted not-found into the HTML on any empty or errored
SSR lookup, and the client query then swapped in the record. The branch was
duplicated across all 11 sub-views with no loading state, so any transient
missing doc rendered RecordNotFound, and non-5xx errors were mislabeled as
not-found.

- SSR returns an explicit outcome (found | not-found | error) and the queryId it
  seeded the cache under, so the client hydrates the same key.
- Shared useAbsRecordState + AbsRecordBoundary own the loading / not-found /
  error / content branch; not-found only for a client-confirmed empty result.
- Migrated all 11 abstract sub-views onto the boundary.
- SSR fetch retries 429/5xx/network; not-found/error marked no-store.
- Sentry breadcrumbs for SSR fetch/outcome, plus a client recovery signal.

Loading Skeleton:
<img width="1432" height="788" alt="localhost_8000_abs_2026arXiv260706436B_abstract (1)" src="https://github.com/user-attachments/assets/39b1533f-3d9b-4543-99c8-2668d548f34e" />

Error:
<img width="1447" height="479" alt="localhost_8000_abs_2026arXiv260706436B_abstract (2)" src="https://github.com/user-attachments/assets/c2566c7e-8c35-49a8-9f70-d0ed4d25c32b" />

Missing Record:
<img width="1447" height="459" alt="localhost_8000_abs_2026arXiv260706436B_abstract (3)" src="https://github.com/user-attachments/assets/0f75d0da-6511-4411-9bdf-afca93ee634e" />
