### PR TITLE
SCIX-897 feat: reconcile rate limiting and 429 error handling

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { APP_STORAGE_KEY, updateAppUser } from '@/store';
+import { APP_STORAGE_KEY, notifyRateLimit, updateAppUser } from '@/store';
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { defaultRequestConfig } from './config';
 import type { ApiRequestConfig } from './types';
@@ -11,6 +11,7 @@ import { identity } from 'ramda';
 import { IBootstrapPayload, IUserData } from '@/api/user/types';
 import { ApiTargets } from '@/api/models';
 import { handleAPIError } from '@/lib/errorHandler';
+import { isRateLimitError, RATE_LIMIT_STATUS } from '@/utils/common/parseAPIError';
 
 export const isAuthenticated = (user: IUserData) =>
   isUserData(user) && (!user.anonymous || user.username !== 'anonymous@ads');
@@ -126,6 +127,12 @@ class Api {
         // this is important for SSR, just fail fast
         if (!error.response || typeof window === 'undefined') {
           return Promise.reject(error);
+        }
+
+        // Toast 429s from either limiter for background requests. Foreground
+        // queries also render an inline message; the toast dedupes by id.
+        if (error.response.status === RATE_LIMIT_STATUS) {
+          notifyRateLimit();
         }
 
         // check if the incoming error is the exact same status and URL as the last request
@@ -262,6 +269,11 @@ class Api {
         return data.user;
       }
     } catch (e) {
+      // Raw axios, so no interceptor. Catch the limiter's 429 here or it
+      // collapses into a generic access error.
+      if (isRateLimitError(e)) {
+        notifyRateLimit();
+      }
       log.error({ err: e }, 'Failed to fetch API access data from session endpoint');
     }
     return null;
@@ -283,6 +295,11 @@ class Api {
         return data.user;
       }
     } catch (e) {
+      // Raw axios, so no interceptor. Catch the limiter's 429 here or it
+      // collapses into a generic access error.
+      if (isRateLimitError(e)) {
+        notifyRateLimit();
+      }
       log.error({ err: e }, 'Failed to refresh API access data from /api/user');
     }
 

--- a/src/api/search/search.ts
+++ b/src/api/search/search.ts
@@ -34,6 +34,7 @@ import { GetServerSidePropsContext } from 'next';
 import { defaultRequestConfig } from '../config';
 import { APP_DEFAULTS, pickTracingHeaders } from '@/config';
 import { isString } from '@/utils/common/guards';
+import { RATE_LIMIT_STATUS } from '@/utils/common/parseAPIError';
 import { IADSApiSearchParams, IADSApiSearchResponse, IBigQueryMutationParams, IDocsEntity } from '@/api/search/types';
 import { ADSMutation, ADSQuery, InfiniteADSQuery } from '@/api/types';
 import api, { ApiRequestConfig } from '@/api/api';
@@ -121,7 +122,13 @@ export function useSearch<TData = IADSApiSearchResponse['response']>(
     queryFn: fetchSearch,
     meta: { params },
     select,
-    retry: (failCount, error) => failCount < 1 && axios.isAxiosError(error) && error.response?.status !== 400,
+    // Don't retry 429s: a retry just burns another request against the daily
+    // upstream quota and delays the inline rate-limit message.
+    retry: (failCount, error) =>
+      failCount < 1 &&
+      axios.isAxiosError(error) &&
+      error.response?.status !== 400 &&
+      error.response?.status !== RATE_LIMIT_STATUS,
     ...(options as Omit<UseQueryOptions<IADSApiSearchResponse, ErrorType, TData>, 'queryKey' | 'queryFn' | 'select'>),
   });
 }

--- a/src/components/SolrErrorAlert/SolrErrorAlert.tsx
+++ b/src/components/SolrErrorAlert/SolrErrorAlert.tsx
@@ -17,6 +17,10 @@ import { ChevronDownIcon, ChevronRightIcon, CopyIcon } from '@chakra-ui/icons';
 import { AxiosError } from 'axios';
 import { IADSApiSearchResponse } from '@/api/search/types';
 import { ParsedSolrError, SOLR_ERROR, useSolrError } from '@/lib/useSolrError';
+import { SimpleLink } from '@/components/SimpleLink';
+import { RATE_LIMIT_ERROR_TITLE, RATE_LIMIT_REGISTER_HREF } from '@/utils/common/parseAPIError';
+import { useColorModeColors } from '@/lib/useColorModeColors';
+import { useSession } from '@/lib/useSession';
 
 interface ISolrErrorAlertProps {
   error: AxiosError<IADSApiSearchResponse> | Error;
@@ -31,7 +35,11 @@ export const SearchErrorAlert = ({ error, onRetry, isRetrying = false }: ISolrEr
   const { onCopy, hasCopied } = useClipboard(
     typeof data?.originalMsg === 'string' ? data.originalMsg : String(data?.originalMsg ?? ''),
   );
-  const { title, message } = solrErrorToCopy(data, { includeFieldName: !!data.field });
+  const { isAuthenticated } = useSession();
+  const { title, message } = solrErrorToCopy(data, { includeFieldName: !!data.field, isAuthenticated });
+  const isRateLimited = data.error === SOLR_ERROR.TOO_MANY_REQUESTS;
+  const showAccountCta = isRateLimited && !isAuthenticated;
+  const colors = useColorModeColors();
 
   return (
     <Box w="full">
@@ -41,7 +49,18 @@ export const SearchErrorAlert = ({ error, onRetry, isRetrying = false }: ISolrEr
             <AlertIcon />
             <VStack align="start" spacing={1} flex="1">
               <AlertTitle>{title}</AlertTitle>
-              <AlertDescription>{message}</AlertDescription>
+              <AlertDescription>
+                {message}
+                {showAccountCta && (
+                  <>
+                    {' '}
+                    <SimpleLink href={RATE_LIMIT_REGISTER_HREF} display="inline" color={colors.link}>
+                      Create a free account
+                    </SimpleLink>{' '}
+                    for higher limits, or try again later.
+                  </>
+                )}
+              </AlertDescription>
             </VStack>
 
             <HStack>
@@ -81,7 +100,7 @@ export const SearchErrorAlert = ({ error, onRetry, isRetrying = false }: ISolrEr
 };
 
 type Copy = { title: string; message: string };
-type CopyOptions = { includeFieldName?: boolean };
+type CopyOptions = { includeFieldName?: boolean; isAuthenticated?: boolean };
 
 export const solrErrorToCopy = (e: ParsedSolrError, opts: CopyOptions = {}): Copy => {
   const includeField = opts.includeFieldName && 'field' in e && e.field;
@@ -150,6 +169,16 @@ export const solrErrorToCopy = (e: ParsedSolrError, opts: CopyOptions = {}): Cop
 
   // HTTP / infra / concurrency
   switch (e.error) {
+    case SOLR_ERROR.TOO_MANY_REQUESTS:
+      return {
+        title: RATE_LIMIT_ERROR_TITLE,
+        // Anonymous copy is the bare lead; the component appends the account
+        // link + "for higher limits, or try again later" so it matches the
+        // toast and full-page wording exactly.
+        message: opts.isAuthenticated
+          ? 'You’ve made too many requests. Please try again later.'
+          : 'You’ve made too many requests.',
+      };
     case SOLR_ERROR.VERSION_CONFLICT:
       return {
         title: 'Item changed',

--- a/src/lib/useSolrError.test.ts
+++ b/src/lib/useSolrError.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { AxiosError, AxiosResponse } from 'axios';
+import { SOLR_ERROR, useSolrError } from './useSolrError';
+import { solrErrorToCopy } from '@/components/SolrErrorAlert/SolrErrorAlert';
+
+const makeAxiosError = (status: number, data: unknown = {}): AxiosError => {
+  const response = { status, data, statusText: '', headers: {}, config: {} } as AxiosResponse;
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, response);
+};
+
+describe('useSolrError 429 mapping', () => {
+  test('maps an HTTP 429 to TOO_MANY_REQUESTS', () => {
+    expect(useSolrError(makeAxiosError(429)).error).toBe(SOLR_ERROR.TOO_MANY_REQUESTS);
+  });
+
+  test('maps a solr body code 429 to TOO_MANY_REQUESTS', () => {
+    const error = makeAxiosError(429, { error: { code: 429, msg: 'too many requests' } });
+    expect(useSolrError(error).error).toBe(SOLR_ERROR.TOO_MANY_REQUESTS);
+  });
+});
+
+describe('solrErrorToCopy for rate limiting', () => {
+  const rlError = { error: SOLR_ERROR.TOO_MANY_REQUESTS, originalMsg: 'too many requests' };
+
+  test('anonymous copy is the bare lead — the component appends the CTA and tail', () => {
+    const copy = solrErrorToCopy(rlError, { isAuthenticated: false });
+    expect(copy.title).toMatch(/rate limit/i);
+    expect(copy.message).toMatch(/too many requests/i);
+    expect(copy.message).not.toMatch(/try again later|higher limits|account/i);
+  });
+
+  test('authenticated copy completes with a try-again tail and no CTA', () => {
+    const copy = solrErrorToCopy(rlError, { isAuthenticated: true });
+    expect(copy.message).toMatch(/try again later/i);
+    expect(copy.message).not.toMatch(/higher limits|account/i);
+  });
+});

--- a/src/lib/useSolrError.ts
+++ b/src/lib/useSolrError.ts
@@ -31,6 +31,7 @@ export enum SOLR_ERROR {
   SERVER_ERROR,
   SERVICE_UNAVAILABLE,
   CONFLICT,
+  TOO_MANY_REQUESTS,
 }
 
 export type ParsedSolrError = {
@@ -84,6 +85,8 @@ const mapHttpCode = (code?: number): SOLR_ERROR | undefined => {
       return SOLR_ERROR.NOT_FOUND;
     case 409:
       return SOLR_ERROR.CONFLICT;
+    case 429:
+      return SOLR_ERROR.TOO_MANY_REQUESTS;
     case 500:
       return SOLR_ERROR.SERVER_ERROR;
     case 503:

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { verifyMiddleware } from '@/middlewares/verifyMiddleware';
 import { getIronSession } from 'iron-session/edge';
 import { edgeLogger } from '@/logger';
 import { NextRequest, NextResponse } from 'next/server';
-import { rateLimit } from '@/rateLimit';
+import { rateLimit, RATE_LIMIT_RETRY_AFTER_SECONDS } from '@/rateLimit';
 import { isLegacySearchURL, legacySearchURLMiddleware } from '@/middlewares/legacySearchURLMiddleware';
 import { ErrorSource, handleError } from '@/lib/errorHandler.edge';
 import { getUserLogId, sanitizeHeaderValue } from '@/utils/logging';
@@ -46,6 +46,55 @@ const redirect = (
   );
 
   return NextResponse.redirect(url, req);
+};
+
+// Minimal self-contained 429 page for document navigations — edge responses
+// can't use the app shell. Only renders for hard loads that trip the limiter
+// (bots, refresh-under-throttle). Authenticated users skip the account nudge.
+const rateLimitHtml = (isAuthenticated: boolean) => {
+  const body = isAuthenticated
+    ? 'You&rsquo;ve made too many requests. Please try again later.'
+    : 'You&rsquo;ve made too many requests. <a href="/user/account/register">Create a free account</a> for higher limits, or try again later.';
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rate limit reached</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; display: grid;
+    place-items: center; min-height: 100vh; padding: 1.5rem; color: #1a202c; }
+  main { max-width: 32rem; text-align: center; }
+  h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+  a { color: #3182ce; }
+</style>
+</head>
+<body>
+<main>
+<h1>Rate limit reached</h1>
+<p>${body}</p>
+</main>
+</body>
+</html>`;
+};
+
+// Real HTTP 429 for the node limiter instead of redirecting home, so it shares
+// the client 429 path with upstream API 429s. Document navigations get a
+// readable page; XHRs get JSON the client parses. Both carry the real status
+// and Retry-After.
+const tooManyRequests = async (req: NextRequest) => {
+  const headers = { 'Retry-After': String(RATE_LIMIT_RETRY_AFTER_SECONDS) };
+
+  if (req.headers.get('accept')?.includes('text/html')) {
+    // Read the session only for the page copy (rare path); XHRs skip it.
+    const session = await getIronSession(req, NextResponse.next(), sessionConfig);
+    return new NextResponse(rateLimitHtml(session.isAuthenticated), {
+      status: 429,
+      headers: { ...headers, 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  return NextResponse.json({ message: 'rate-limit-exceeded' }, { status: 429, headers });
 };
 
 const redirectIfAuthenticated = async (req: NextRequest, res: NextResponse) => {
@@ -337,6 +386,15 @@ const setPrefsCookie = (response: NextResponse, req: NextRequest, updates: Recor
   });
 };
 
+// The whole auth/account surface is exempt from the node limiter: login,
+// register, forgotpassword, and the emailed verify/reset flows are all
+// low-volume, account-critical navigations we point rate-limited users to.
+// /api/user is the session endpoint the app needs to function at all. A DoS
+// backstop shouldn't gate its own escape hatch, and it only exempts these page
+// navigations — the /v1 API calls they fire stay limited.
+export const isRateLimitExempt = (path: string): boolean =>
+  path.startsWith('/user/account/') || path.startsWith('/api/user');
+
 export async function middleware(req: NextRequest) {
   const startTime = Date.now();
   const path = req.nextUrl.pathname;
@@ -432,12 +490,10 @@ export async function middleware(req: NextRequest) {
     return res;
   }
 
-  // Apply rate limiting
-  if (!rateLimit(ip)) {
+  // Apply rate limiting (auth/session routes exempt — see isRateLimitExempt)
+  if (!isRateLimitExempt(path) && !rateLimit(ip)) {
     log.warn({ ip, path, duration: Date.now() - startTime }, 'Rate limit exceeded');
-    const url = req.nextUrl.clone();
-    url.pathname = '/';
-    return redirect(url, req, { message: 'rate-limit-exceeded' });
+    return tooManyRequests(req);
   }
 
   log.debug({ ip, path }, 'Rate limit check passed');

--- a/src/middlewares/__tests__/middleware.routes.integration.test.ts
+++ b/src/middlewares/__tests__/middleware.routes.integration.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/middlewares/legacySearchURLMiddleware', () => {
 
 vi.mock('@/rateLimit', () => ({
   rateLimit: vi.fn().mockReturnValue(true),
+  RATE_LIMIT_RETRY_AFTER_SECONDS: 60,
 }));
 
 describe('middleware route integration', () => {
@@ -317,11 +318,54 @@ describe('middleware route integration', () => {
     expect(requests[0]).toBe('https://base.example.com/link_gateway/789/abstract');
   });
 
-  test('honors rate limiting and short-circuits', async () => {
+  test('honors rate limiting with a JSON 429 for XHRs', async () => {
     rateLimitMock.mockReturnValue(false);
-    const req = makeReq('https://example.com/search');
+    const req = makeReq('https://example.com/search', { headers: { accept: 'application/json' } });
     const res = (await middleware(req)) as NextResponse;
-    expect(res.headers.get('location')).toContain('notify=rate-limit-exceeded');
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    await expect(res.json()).resolves.toEqual({ message: 'rate-limit-exceeded' });
+  });
+
+  test('anonymous HTML 429 includes the account CTA', async () => {
+    rateLimitMock.mockReturnValue(false);
+    getIronSessionMock.mockResolvedValue({ isAuthenticated: false });
+    const req = makeReq('https://example.com/search', {
+      headers: { accept: 'text/html,application/xhtml+xml' },
+    });
+    const res = (await middleware(req)) as NextResponse;
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('Rate limit reached');
+    expect(body).toContain('/user/account/register');
+  });
+
+  test('authenticated HTML 429 omits the account CTA', async () => {
+    rateLimitMock.mockReturnValue(false);
+    getIronSessionMock.mockResolvedValue({ isAuthenticated: true });
+    const req = makeReq('https://example.com/search', {
+      headers: { accept: 'text/html,application/xhtml+xml' },
+    });
+    const res = (await middleware(req)) as NextResponse;
+    expect(res.status).toBe(429);
+    const body = await res.text();
+    expect(body).toContain('Rate limit reached');
+    expect(body).not.toContain('/user/account/register');
+  });
+
+  test.each([
+    '/user/account/login',
+    '/user/account/register',
+    '/user/account/forgotpassword',
+    '/user/account/verify/reset-password',
+    '/api/user',
+  ])('exempts %s from the node limiter', async (path) => {
+    rateLimitMock.mockReturnValue(false);
+    const req = makeReq(`https://example.com${path}`, { headers: { accept: 'text/html' } });
+    const res = (await middleware(req)) as NextResponse;
+    expect(res.status).not.toBe(429);
   });
 
   test('handles requests with tracing headers', async () => {

--- a/src/rateLimit.ts
+++ b/src/rateLimit.ts
@@ -5,6 +5,9 @@ const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX ?? '1500', 10);
 const RATE_LIMIT_TTL = parseInt(process.env.RATE_LIMIT_TTL ?? '60000', 10); // 1 minute
 const RATE_LIMIT_COUNT = parseInt(process.env.RATE_LIMIT_COUNT ?? '100', 10); // Max requests allowed within the TTL
 
+// Retry-After hint (seconds) for a tripped limiter — the TTL window rounded up.
+export const RATE_LIMIT_RETRY_AFTER_SECONDS = Math.max(1, Math.ceil(RATE_LIMIT_TTL / 1000));
+
 // LRU cache to store request count per IP
 const rateLimitCache = new LRUCache<string, { count: number; lastRequest: number }>({
   max: RATE_LIMIT_MAX,

--- a/src/store/slices/notification.ts
+++ b/src/store/slices/notification.ts
@@ -1,4 +1,5 @@
 import { StoreSlice } from '@/store';
+import { RATE_LIMIT_ERROR_MESSAGE, RATE_LIMIT_ERROR_MESSAGE_PLAIN } from '@/utils/common/parseAPIError';
 
 export type Notification = {
   id: NotificationId;
@@ -80,7 +81,12 @@ export const NOTIFICATIONS: Record<NotificationId, Notification> = {
   'rate-limit-exceeded': {
     id: 'rate-limit-exceeded',
     status: 'error',
-    message: 'You have exceeded the rate limit. Please try again later.',
+    message: RATE_LIMIT_ERROR_MESSAGE,
+  },
+  'rate-limit-exceeded-auth': {
+    id: 'rate-limit-exceeded-auth',
+    status: 'error',
+    message: RATE_LIMIT_ERROR_MESSAGE_PLAIN,
   },
   'account-login-success': {
     id: 'account-login-success',
@@ -159,6 +165,7 @@ export type NotificationId =
   | 'orcid-auth-failed'
   | 'orcid-session-expired'
   | 'rate-limit-exceeded'
+  | 'rate-limit-exceeded-auth'
   | 'verify-account-failed'
   | 'verify-account-success'
   | 'verify-account-was-valid'

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -16,6 +16,7 @@ import { AppSerializableState, AppState } from './types';
 import { isPlainObject, isPrimitive } from 'ramda-adjunct';
 import { logger } from '@/logger';
 import { IUserData } from '@/api/user/types';
+import { isAuthenticated } from '@/auth-utils';
 
 export const APP_STORAGE_KEY = 'nectar-app-state';
 
@@ -128,6 +129,19 @@ export const useStoreApi = appContext.useStoreApi;
 // handler to be used outside react (non-hook)
 export const updateAppUser = (user: IUserData): void => {
   store?.setState({ user });
+};
+
+// Fire a global notification (toast) from outside React, e.g. the axios
+// interceptor surfacing a background 429. No-op server-side (store is unset).
+export const notify = (id: Parameters<AppState['setNotification']>[0]): void => {
+  store?.getState().setNotification(id);
+};
+
+// Rate-limit toast, keyed off the same store user useSession reads so the toast
+// and inline alert agree. Anonymous users get the account nudge.
+export const notifyRateLimit = (): void => {
+  const authed = !!store && isAuthenticated(store.getState().user);
+  notify(authed ? 'rate-limit-exceeded-auth' : 'rate-limit-exceeded');
 };
 
 export const getSerializableDefaultStore = () => {

--- a/src/utils/common/parseAPIError.test.ts
+++ b/src/utils/common/parseAPIError.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { AxiosError, AxiosResponse } from 'axios';
+import {
+  isRateLimitError,
+  parseAPIError,
+  RATE_LIMIT_ERROR_MESSAGE,
+  RATE_LIMIT_ERROR_MESSAGE_PLAIN,
+  RATE_LIMIT_STATUS,
+} from './parseAPIError';
+
+const makeAxiosError = (status: number, data: unknown = {}): AxiosError => {
+  const response = { status, data, statusText: '', headers: {}, config: {} } as AxiosResponse;
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, response);
+};
+
+describe('isRateLimitError', () => {
+  test('is true for an axios 429', () => {
+    expect(isRateLimitError(makeAxiosError(RATE_LIMIT_STATUS))).toBe(true);
+  });
+
+  test('is false for other axios statuses', () => {
+    expect(isRateLimitError(makeAxiosError(500))).toBe(false);
+  });
+
+  test('is false for non-axios errors', () => {
+    expect(isRateLimitError(new Error('boom'))).toBe(false);
+    expect(isRateLimitError('nope')).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+  });
+});
+
+describe('parseAPIError with 429', () => {
+  test('returns the plain rate-limit message for a 429', () => {
+    expect(parseAPIError(makeAxiosError(RATE_LIMIT_STATUS))).toBe(RATE_LIMIT_ERROR_MESSAGE_PLAIN);
+  });
+
+  test('rate-limit message wins over any body message on a 429', () => {
+    const error = makeAxiosError(RATE_LIMIT_STATUS, { message: 'rate-limit-exceeded' });
+    expect(parseAPIError(error)).toBe(RATE_LIMIT_ERROR_MESSAGE_PLAIN);
+  });
+
+  test('does not push account creation (no auth context here)', () => {
+    expect(parseAPIError(makeAxiosError(RATE_LIMIT_STATUS))).not.toMatch(/account/i);
+  });
+
+  test('the anonymous surface copy still encourages account creation', () => {
+    expect(RATE_LIMIT_ERROR_MESSAGE).toMatch(/account/i);
+  });
+
+  test('non-429 errors still use the body message', () => {
+    const error = makeAxiosError(500, { message: 'Boom from server' });
+    expect(parseAPIError(error)).toBe('Boom from server');
+  });
+});

--- a/src/utils/common/parseAPIError.ts
+++ b/src/utils/common/parseAPIError.ts
@@ -12,6 +12,27 @@ type getErrorMessageOptions = {
   defaultMessage: string;
 };
 
+// HTTP 429. Both the node edge limiter and the upstream API gateway return this
+// status, so keying on it routes every rate-limit error through one path.
+export const RATE_LIMIT_STATUS = 429;
+
+// Account creation is the real remedy: signed-in accounts get higher upstream
+// limits, and the upstream quota resets slowly (daily), so "try again later" is
+// deliberately soft rather than promising a quick retry.
+export const RATE_LIMIT_REGISTER_HREF = '/user/account/register';
+export const RATE_LIMIT_ERROR_TITLE = 'Rate limit reached';
+export const RATE_LIMIT_ERROR_MESSAGE =
+  'You’ve made too many requests. Create a free account for higher limits, or try again later.';
+
+// No-CTA variant: for authenticated users (nothing to sign up for) and for
+// auth-unaware surfaces like parseAPIError, which can't tell who's asking.
+export const RATE_LIMIT_ERROR_MESSAGE_PLAIN = 'You’ve made too many requests. Please try again later.';
+
+// True for an axios HTTP 429 (rate limited) from either the node edge limiter
+// or the upstream API gateway.
+export const isRateLimitError = (error: unknown): boolean =>
+  axios.isAxiosError(error) && error.response?.status === RATE_LIMIT_STATUS;
+
 /**
  * Parses an API error and returns a human-readable error message.
  *
@@ -43,6 +64,13 @@ export const parseAPIError = (
   // return generic message if error is invalid
   if (!error || !(error instanceof Error)) {
     return options.defaultMessage;
+  }
+
+  // 429s get dedicated copy regardless of the body message the limiter returned.
+  // No account CTA here — this parser has no auth context, and the account-aware
+  // surfaces (toast, inline alert, edge page) add the nudge for anonymous users.
+  if (isRateLimitError(error)) {
+    return RATE_LIMIT_ERROR_MESSAGE_PLAIN;
   }
 
   // if error is an axios error, check for a message


### PR DESCRIPTION
The node edge middleware's IP rate limiter redirected rate-limited users to the
home page with a generic toast, so its 429s and the upstream API gateway's 429s
took different code paths and no caller ever saw a real HTTP 429. Users got
inconsistent feedback and no path to a higher limit.

- Middleware returns a real HTTP 429 with Retry-After instead of redirecting: a
  minimal HTML page for document navigations, JSON for XHRs
- Node and upstream 429s flow through one client path: a toast for background
  requests and an inline SearchErrorAlert for foreground queries
- 429 copy encourages account creation, but only for anonymous users;
  authenticated users and the auth-unaware parseAPIError get a plain message
- Exempted the auth routes and /api/user from the node limiter so the
  account-creation link stays reachable when rate limited
- Stopped retrying 429 search requests; React Query stays retry:false
- Unified the 429 wording across the toast, inline alert, and full-page

Authenticated:
<img width="598" height="498" alt="image5" src="https://github.com/user-attachments/assets/6c772f2f-2e39-4a8f-906b-c2db781a40df" />
<img width="527" height="73" alt="image4" src="https://github.com/user-attachments/assets/3897ccec-7e6d-4070-9fe0-fd0783a78d96" />
<img width="822" height="229" alt="image2" src="https://github.com/user-attachments/assets/9f2c165d-ee84-4bda-899d-3ad01dd548d1" />

Anonymous:
<img width="701" height="476" alt="image3" src="https://github.com/user-attachments/assets/7f175f4b-c9d4-4fd5-ae5c-f47c5d639186" />
<img width="689" height="91" alt="image1" src="https://github.com/user-attachments/assets/66d64811-2ab3-446e-9a4a-0586134a6032" />
<img width="770" height="215" alt="image6" src="https://github.com/user-attachments/assets/2e5b9c9a-dbda-46c3-a762-9f1eee7931ac" />

