### PR TITLE
SCIX-850 feat(citation): redesign citation modal, gate settings link by auth

### DIFF
--- a/src/api/export/getBibtexExportParams.test.ts
+++ b/src/api/export/getBibtexExportParams.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { getBibtexExportParams } from './getBibtexExportParams';
+import { ExportApiFormatKey, ExportApiJournalFormat } from './types';
+import { IADSApiUserDataResponse } from '@/api/user/types';
+import { JournalFormatName, UserDataKeys } from '@/api/user/types';
+
+const makeSettings = (overrides?: Partial<IADSApiUserDataResponse>): IADSApiUserDataResponse =>
+  ({
+    [UserDataKeys.BIBTEX_FORMAT]: '%1H+%Y',
+    [UserDataKeys.ABS_FORMAT]: '%2H+%q',
+    [UserDataKeys.BIBTEX_JOURNAL_FORMAT]: JournalFormatName.Abbreviations,
+    [UserDataKeys.BIBTEX_AUTHOR_CUTOFF]: '5',
+    [UserDataKeys.ABS_AUTHOR_CUTOFF]: '6',
+    [UserDataKeys.BIBTEX_MAX_AUTHORS]: '10',
+    [UserDataKeys.ABS_MAX_AUTHORS]: '11',
+    ...overrides,
+  } as IADSApiUserDataResponse);
+
+describe('getBibtexExportParams', () => {
+  test('includes custom bibtex params for the bibtex format', () => {
+    const params = getBibtexExportParams(makeSettings(), ExportApiFormatKey.bibtex);
+
+    expect(params).toEqual({
+      keyformat: ['%1H+%Y'],
+      journalformat: [ExportApiJournalFormat.Abbreviations],
+      authorcutoff: [5],
+      maxauthor: [10],
+    });
+  });
+
+  test('includes ABS-specific bibtex params for the bibtexabs format', () => {
+    const params = getBibtexExportParams(makeSettings(), ExportApiFormatKey.bibtexabs);
+
+    expect(params).toEqual({
+      keyformat: ['%2H+%q'],
+      journalformat: [ExportApiJournalFormat.Abbreviations],
+      authorcutoff: [6],
+      maxauthor: [11],
+    });
+  });
+
+  test('returns defaults for an anonymous user (no bibtex settings customized)', () => {
+    const params = getBibtexExportParams(
+      makeSettings({
+        [UserDataKeys.BIBTEX_FORMAT]: '',
+        [UserDataKeys.BIBTEX_JOURNAL_FORMAT]: JournalFormatName.AASTeXMacros,
+        [UserDataKeys.BIBTEX_AUTHOR_CUTOFF]: '200',
+        [UserDataKeys.BIBTEX_MAX_AUTHORS]: '10',
+      }),
+      ExportApiFormatKey.bibtex,
+    );
+
+    expect(params).toEqual({
+      keyformat: [''],
+      journalformat: [ExportApiJournalFormat.AASTeXMacros],
+      authorcutoff: [200],
+      maxauthor: [10],
+    });
+  });
+
+  test('returns no bibtex-only params for a non-bibtex format', () => {
+    const params = getBibtexExportParams(makeSettings(), ExportApiFormatKey.agu);
+
+    expect(params).toEqual({});
+  });
+
+  test('sanitizes keyformat before including it in the params', () => {
+    const params = getBibtexExportParams(
+      makeSettings({ [UserDataKeys.BIBTEX_FORMAT]: '<script>alert(1)</script>%1H+%Y' }),
+      ExportApiFormatKey.bibtex,
+    );
+
+    expect(params.keyformat).toEqual(['%1H+%Y']);
+  });
+});

--- a/src/api/export/getBibtexExportParams.ts
+++ b/src/api/export/getBibtexExportParams.ts
@@ -1,0 +1,26 @@
+import { ExportApiFormatKey, IExportApiParams } from '@/api/export/types';
+import { IADSApiUserDataResponse } from '@/api/user/types';
+import { JournalFormatMap } from '@/components/Settings/model';
+import { purifyString } from '@/utils/common/formatters';
+
+/**
+ * Builds bibtex-only export params (keyformat, journalformat, authorcutoff,
+ * maxauthor) from user settings. Returns {} for non-bibtex formats.
+ */
+export const getBibtexExportParams = (
+  settings: IADSApiUserDataResponse,
+  format: string,
+): Pick<IExportApiParams, 'keyformat' | 'journalformat' | 'authorcutoff' | 'maxauthor'> => {
+  if (format !== ExportApiFormatKey.bibtex && format !== ExportApiFormatKey.bibtexabs) {
+    return {};
+  }
+
+  const isAbs = format === ExportApiFormatKey.bibtexabs;
+
+  return {
+    keyformat: [purifyString(isAbs ? settings.bibtexABSKeyFormat : settings.bibtexKeyFormat)],
+    journalformat: [JournalFormatMap[settings.bibtexJournalFormat]],
+    authorcutoff: [parseInt(isAbs ? settings.bibtexABSAuthorCutoff : settings.bibtexAuthorCutoff, 10)],
+    maxauthor: [parseInt(isAbs ? settings.bibtexABSMaxAuthors : settings.bibtexMaxAuthors, 10)],
+  };
+};

--- a/src/components/AbstractDetails/AbstractCitationModal.test.tsx
+++ b/src/components/AbstractDetails/AbstractCitationModal.test.tsx
@@ -1,0 +1,110 @@
+import { render, waitFor } from '@/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AbstractCitationModal } from './AbstractCitationModal';
+import { IADSApiUserDataResponse, JournalFormatName } from '@/api/user/types';
+import { ExportApiJournalFormat, IExportApiParams } from '@/api/export/types';
+
+const bibtexOption = { id: 'bibtex', value: 'bibtex', label: 'BibTeX', type: 'text', ext: 'bib', route: '/bibtex' };
+const aguOption = { id: 'agu', value: 'agu', label: 'AGU', type: 'text', ext: 'agu', route: '/agu' };
+
+const mocks = vi.hoisted(() => ({
+  useSettings: vi.fn((): { settings: Partial<IADSApiUserDataResponse> } => ({
+    settings: { defaultCitationFormat: 'agu' },
+  })),
+  useExportFormats: vi.fn(),
+  useGetExportCitation: vi.fn(() => ({
+    data: { export: '' },
+    isLoading: false,
+    isError: false,
+    error: null as Error | null,
+  })),
+}));
+
+vi.mock('@/lib/useSettings', () => ({ useSettings: mocks.useSettings }));
+vi.mock('@/lib/useExportFormats', () => ({ useExportFormats: mocks.useExportFormats }));
+vi.mock('@/api/export/export', () => ({
+  useGetExportCitation: mocks.useGetExportCitation,
+}));
+
+describe('AbstractCitationModal', () => {
+  beforeEach(() => {
+    mocks.useGetExportCitation.mockClear();
+    mocks.useSettings.mockReturnValue({ settings: { defaultCitationFormat: 'agu' } });
+    mocks.useExportFormats.mockReturnValue({
+      formatOptions: [bibtexOption, aguOption],
+      getFormatOptionById: (id: string) => [bibtexOption, aguOption].find((o) => o.id === id),
+    });
+  });
+
+  test('includes custom bibtex params for a logged-in user when the default format is bibtex', async () => {
+    mocks.useSettings.mockReturnValue({
+      settings: {
+        defaultCitationFormat: 'bibtex',
+        bibtexKeyFormat: '%1H+%Y',
+        bibtexABSKeyFormat: '%R',
+        bibtexJournalFormat: JournalFormatName.AASTeXMacros,
+        bibtexAuthorCutoff: '200',
+        bibtexABSAuthorCutoff: '200',
+        bibtexMaxAuthors: '10',
+        bibtexABSMaxAuthors: '10',
+      },
+    });
+
+    render(<AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />);
+
+    await waitFor(() => {
+      expect(mocks.useGetExportCitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'bibtex',
+          bibcode: ['2020ApJ...123..456A'],
+          keyformat: ['%1H+%Y'],
+          journalformat: [ExportApiJournalFormat.AASTeXMacros],
+          authorcutoff: [200],
+          maxauthor: [10],
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+
+  test('passes an empty keyformat through when bibtex settings are unset', async () => {
+    mocks.useSettings.mockReturnValue({
+      settings: {
+        defaultCitationFormat: 'bibtex',
+        bibtexKeyFormat: '',
+        bibtexABSKeyFormat: '',
+        bibtexJournalFormat: JournalFormatName.AASTeXMacros,
+        bibtexAuthorCutoff: '200',
+        bibtexABSAuthorCutoff: '200',
+        bibtexMaxAuthors: '10',
+        bibtexABSMaxAuthors: '10',
+      },
+    });
+
+    render(<AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />);
+
+    await waitFor(() => {
+      expect(mocks.useGetExportCitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'bibtex',
+          keyformat: [''],
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+
+  test('does not send bibtex-only params for the real anonymous-user default format (agu)', async () => {
+    render(<AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />);
+
+    await waitFor(() => {
+      expect(mocks.useGetExportCitation).toHaveBeenCalledWith(
+        expect.objectContaining({ format: 'agu' }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+
+    const lastCall = mocks.useGetExportCitation.mock.calls.at(-1) as unknown as [IExportApiParams, unknown] | undefined;
+    expect(lastCall?.[0]).not.toHaveProperty('keyformat');
+  });
+});

--- a/src/components/AbstractDetails/AbstractCitationModal.test.tsx
+++ b/src/components/AbstractDetails/AbstractCitationModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@/test-utils';
+import { fireEvent, render, waitFor } from '@/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { AbstractCitationModal } from './AbstractCitationModal';
 import { IADSApiUserDataResponse, JournalFormatName } from '@/api/user/types';
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     settings: { defaultCitationFormat: 'agu' },
   })),
   useExportFormats: vi.fn(),
+  useSession: vi.fn(() => ({ isAuthenticated: false })),
   useGetExportCitation: vi.fn(() => ({
     data: { export: '' },
     isLoading: false,
@@ -22,6 +23,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/useSettings', () => ({ useSettings: mocks.useSettings }));
 vi.mock('@/lib/useExportFormats', () => ({ useExportFormats: mocks.useExportFormats }));
+vi.mock('@/lib/useSession', () => ({ useSession: mocks.useSession }));
 vi.mock('@/api/export/export', () => ({
   useGetExportCitation: mocks.useGetExportCitation,
 }));
@@ -30,6 +32,7 @@ describe('AbstractCitationModal', () => {
   beforeEach(() => {
     mocks.useGetExportCitation.mockClear();
     mocks.useSettings.mockReturnValue({ settings: { defaultCitationFormat: 'agu' } });
+    mocks.useSession.mockReturnValue({ isAuthenticated: false });
     mocks.useExportFormats.mockReturnValue({
       formatOptions: [bibtexOption, aguOption],
       getFormatOptionById: (id: string) => [bibtexOption, aguOption].find((o) => o.id === id),
@@ -106,5 +109,41 @@ describe('AbstractCitationModal', () => {
 
     const lastCall = mocks.useGetExportCitation.mock.calls.at(-1) as unknown as [IExportApiParams, unknown] | undefined;
     expect(lastCall?.[0]).not.toHaveProperty('keyformat');
+  });
+
+  test('disables the citation format settings button for an anonymous user', async () => {
+    const { getByRole, queryByRole, user, findByRole } = render(
+      <AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />,
+    );
+
+    const settingsButton = getByRole('button', { name: /copy citation settings/i });
+    expect(settingsButton).toBeDisabled();
+    expect(queryByRole('link', { name: /copy citation settings/i })).not.toBeInTheDocument();
+
+    await user.hover(settingsButton);
+    expect(await findByRole('tooltip')).toHaveTextContent('Create an account to manage Copy Citation settings');
+  });
+
+  test('surfaces the citation format settings tooltip on keyboard focus for an anonymous user', async () => {
+    const { getByText, findByRole } = render(
+      <AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />,
+    );
+
+    const focusableWrapper = getByText('Copy citation settings').closest('span[tabindex="0"]');
+    expect(focusableWrapper).not.toBeNull();
+
+    fireEvent.focus(focusableWrapper);
+    expect(await findByRole('tooltip')).toHaveTextContent('Create an account to manage Copy Citation settings');
+  });
+
+  test('enables the citation format settings link for a logged-in user', () => {
+    mocks.useSession.mockReturnValue({ isAuthenticated: true });
+
+    const { getByRole } = render(<AbstractCitationModal isOpen onClose={vi.fn()} bibcode="2020ApJ...123..456A" />);
+
+    expect(getByRole('link', { name: /copy citation settings/i })).toHaveAttribute(
+      'href',
+      '/user/settings/export?tab=3',
+    );
   });
 });

--- a/src/components/AbstractDetails/AbstractCitationModal.test.tsx
+++ b/src/components/AbstractDetails/AbstractCitationModal.test.tsx
@@ -39,7 +39,7 @@ describe('AbstractCitationModal', () => {
     });
   });
 
-  test('includes custom bibtex params for a logged-in user when the default format is bibtex', async () => {
+  test('includes custom bibtex params when the default format is bibtex', async () => {
     mocks.useSettings.mockReturnValue({
       settings: {
         defaultCitationFormat: 'bibtex',

--- a/src/components/AbstractDetails/AbstractCitationModal.tsx
+++ b/src/components/AbstractDetails/AbstractCitationModal.tsx
@@ -2,6 +2,7 @@ import { useGetExportCitation } from '@/api/export/export';
 import { getBibtexExportParams } from '@/api/export/getBibtexExportParams';
 import { ExportApiFormatKey, MostUsedExportFormats } from '@/api/export/types';
 import { useExportFormats } from '@/lib/useExportFormats';
+import { useSession } from '@/lib/useSession';
 import { useSettings } from '@/lib/useSettings';
 import { parseAPIError } from '@/utils/common/parseAPIError';
 import {
@@ -16,11 +17,18 @@ import {
   AlertIcon,
   AlertTitle,
   AlertDescription,
+  Button,
+  Divider,
   Flex,
+  Icon,
+  Text,
   Textarea,
+  Tooltip,
 } from '@chakra-ui/react';
+import { SettingsIcon } from '@chakra-ui/icons';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { useEffect, useState } from 'react';
-import { SimpleCopyButton } from '../CopyButton';
+import { LabeledCopyButton } from '../CopyButton';
 import { LoadingMessage } from '../Feedbacks';
 import { Select } from '../Select';
 import { SimpleLink } from '../SimpleLink';
@@ -35,6 +43,8 @@ export const AbstractCitationModal = ({
   bibcode: string;
 }) => {
   const { settings } = useSettings();
+
+  const { isAuthenticated } = useSession();
 
   const { formatOptions, getFormatOptionById } = useExportFormats();
 
@@ -68,28 +78,25 @@ export const AbstractCitationModal = ({
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Citation</ModalHeader>
+        <ModalHeader fontSize="2xl">Citation</ModalHeader>
         <ModalCloseButton />
-        <ModalBody>
+        <ModalBody pb={6}>
+          <Text fontSize="sm" color="gray.500" mb={6}>
+            Copy and paste a citation for this record.
+          </Text>
           <Select
             name="format"
-            label="Citation Format"
-            hideLabel
+            label="Format"
             id="citation-format-selector"
             options={options}
             value={selectedOption}
             onChange={(o) => setSelectedOption(o)}
             stylesTheme="default.sm"
           />
-          <Flex justifyContent="end" my={1}>
-            <SimpleLink href={`/abs/${bibcode}/exportcitation/bibtex`} fontSize="sm" fontWeight="bold">
-              Advanced options
-            </SimpleLink>
-          </Flex>
-          <Box my={6}>
+          <Box mt={6} mb={8}>
             {isLoading ? (
               <LoadingMessage message="Loading" />
             ) : isError ? (
@@ -101,23 +108,53 @@ export const AbstractCitationModal = ({
             ) : (
               <>
                 {selectedOption.type === 'HTML' ? (
-                  <>
-                    <Box fontSize="sm" fontWeight="medium" dangerouslySetInnerHTML={{ __html: data.export }} />
-                    <Flex justifyContent="end">
-                      <SimpleCopyButton text={data.export} variant="outline" size="xs" asHtml />
-                    </Flex>
-                  </>
+                  <Box fontSize="sm" fontWeight="medium" dangerouslySetInnerHTML={{ __html: data.export }} />
                 ) : (
-                  <>
-                    <Textarea value={data.export} fontSize="sm" fontWeight="medium" mb={2} h={150} />
-                    <Flex justifyContent="end">
-                      <SimpleCopyButton text={data.export} variant="outline" size="xs" />
-                    </Flex>
-                  </>
+                  <Textarea value={data.export} fontSize="sm" fontWeight="medium" h={200} isReadOnly />
                 )}
+                <Flex justifyContent="end" mt={4}>
+                  <LabeledCopyButton
+                    label="Copy"
+                    text={data.export}
+                    asHtml={selectedOption.type === 'HTML'}
+                    colorScheme="blue"
+                    variant="solid"
+                  />
+                </Flex>
               </>
             )}
           </Box>
+          <Divider />
+          <Flex justifyContent="space-between" alignItems="flex-start" mt={6}>
+            <SimpleLink
+              href={`/abs/${bibcode}/exportcitation/bibtex`}
+              icon={<Icon as={ArrowTopRightOnSquareIcon} boxSize={4} mr={1} />}
+              display="flex"
+              alignItems="center"
+              fontSize="sm"
+              fontWeight="bold"
+            >
+              More export options
+            </SimpleLink>
+            {isAuthenticated ? (
+              <SimpleLink
+                href="/user/settings/export?tab=3"
+                icon={<SettingsIcon mr={1} />}
+                display="flex"
+                alignItems="center"
+                fontSize="sm"
+                fontWeight="bold"
+              >
+                Copy citation settings
+              </SimpleLink>
+            ) : (
+              <Tooltip label="Create an account to manage Copy Citation settings" shouldWrapChildren>
+                <Button variant="link" size="sm" leftIcon={<SettingsIcon />} isDisabled>
+                  Copy citation settings
+                </Button>
+              </Tooltip>
+            )}
+          </Flex>
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/src/components/AbstractDetails/AbstractCitationModal.tsx
+++ b/src/components/AbstractDetails/AbstractCitationModal.tsx
@@ -1,4 +1,5 @@
 import { useGetExportCitation } from '@/api/export/export';
+import { getBibtexExportParams } from '@/api/export/getBibtexExportParams';
 import { ExportApiFormatKey, MostUsedExportFormats } from '@/api/export/types';
 import { useExportFormats } from '@/lib/useExportFormats';
 import { useSettings } from '@/lib/useSettings';
@@ -61,6 +62,7 @@ export const AbstractCitationModal = ({
     {
       format: selectedOption.id,
       bibcode: [bibcode],
+      ...getBibtexExportParams(settings, selectedOption.id),
     },
     { enabled: !!bibcode && isOpen },
   );

--- a/src/components/ResultList/Item/ItemResourceDropdowns.test.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.test.tsx
@@ -2,6 +2,8 @@ import { render, waitFor } from '@/test-utils';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { ItemResourceDropdowns } from './ItemResourceDropdowns';
 import { IDocsEntity } from '@/api/search/types';
+import { IADSApiUserDataResponse, JournalFormatName } from '@/api/user/types';
+import { ExportApiJournalFormat } from '@/api/export/types';
 
 const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(() => ({
@@ -10,7 +12,7 @@ const mocks = vi.hoisted(() => ({
     push: vi.fn(),
     events: { on: vi.fn(), off: vi.fn() },
   })),
-  useSettings: vi.fn(() => ({
+  useSettings: vi.fn((): { settings: Partial<IADSApiUserDataResponse> } => ({
     settings: { defaultCitationFormat: 'agu' },
   })),
   useGetExportCitation: vi.fn(() => ({ data: undefined as { export: string } | undefined })),
@@ -39,6 +41,7 @@ describe('ItemResourceDropdowns', () => {
   afterEach(() => {
     mocks.useGetExportCitation.mockClear();
     mocks.useGetExportCitation.mockReturnValue({ data: undefined });
+    mocks.useSettings.mockReturnValue({ settings: { defaultCitationFormat: 'agu' } });
   });
 
   test('does not fetch citation on mount', () => {
@@ -94,6 +97,51 @@ describe('ItemResourceDropdowns', () => {
     const { getByLabelText } = render(<ItemResourceDropdowns doc={makeDoc()} />);
 
     expect(getByLabelText('share options')).toBeInTheDocument();
+  });
+
+  test('includes custom bibtex keyformat when default citation format is bibtex', async () => {
+    mocks.useSettings.mockReturnValue({
+      settings: {
+        defaultCitationFormat: 'bibtex',
+        bibtexKeyFormat: '%1H+%Y',
+        bibtexABSKeyFormat: '%R',
+        bibtexJournalFormat: JournalFormatName.AASTeXMacros,
+        bibtexAuthorCutoff: '200',
+        bibtexABSAuthorCutoff: '200',
+        bibtexMaxAuthors: '10',
+        bibtexABSMaxAuthors: '10',
+      },
+    });
+
+    const { user, getByLabelText } = render(<ItemResourceDropdowns doc={makeDoc()} />);
+
+    await user.click(getByLabelText('share options'));
+
+    await waitFor(() => {
+      expect(mocks.useGetExportCitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'bibtex',
+          keyformat: ['%1H+%Y'],
+          journalformat: [ExportApiJournalFormat.AASTeXMacros],
+          authorcutoff: [200],
+          maxauthor: [10],
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+
+  test('does not send bibtex params when default citation format is not bibtex', async () => {
+    const { user, getByLabelText } = render(<ItemResourceDropdowns doc={makeDoc()} />);
+
+    await user.click(getByLabelText('share options'));
+
+    await waitFor(() => {
+      expect(mocks.useGetExportCitation).toHaveBeenCalledWith(
+        expect.not.objectContaining({ keyformat: expect.anything() }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
   });
 
   describe('tooltip dismissal when menu opens', () => {

--- a/src/components/ResultList/Item/ItemResourceDropdowns.tsx
+++ b/src/components/ResultList/Item/ItemResourceDropdowns.tsx
@@ -20,6 +20,7 @@ import { isBrowser } from '@/utils/common/guards';
 import { IDocsEntity } from '@/api/search/types';
 import { CopyMenuItem } from '@/components/CopyButton';
 import { useGetExportCitation } from '@/api/export/export';
+import { getBibtexExportParams } from '@/api/export/getBibtexExportParams';
 import { useSettings } from '@/lib/useSettings';
 import { sendGTMEvent } from '@next/third-parties/google';
 import { closeFullTextTimingSpan } from '@/lib/performance';
@@ -52,6 +53,7 @@ export const ItemResourceDropdowns = ({ doc, rank }: IItemResourceDropdownsProps
     {
       format: settings.defaultCitationFormat,
       bibcode: [doc.bibcode],
+      ...getBibtexExportParams(settings, settings.defaultCitationFormat),
     },
     { enabled: isShareOpen && !!doc.bibcode },
   );


### PR DESCRIPTION
Copy Citation (abstract-page share options and result-list share menu)
ignored the user's custom BibTeX export key format from account
settings, unlike the full export page. The modal itself was also due
for a visual refresh and a way to reach the citation format setting.

1. Add getBibtexExportParams helper deriving keyformat/journalformat/authorcutoff/maxauthor from settings, bibtex vs bibtexabs aware
2. Wire it into AbstractCitationModal and ItemResourceDropdowns
3. Sanitize keyformat via purifyString to match the export page
4. Redesign the Copy Citation modal to match the new mockup
5. Footer links to advanced export options and citation format settings, disabled with a tooltip for anonymous users

<img width="594" height="579" alt="image" src="https://github.com/user-attachments/assets/6783ca1e-ee2f-4622-8239-3990b9a364c1" />
