### PR TITLE
SCIX-890 fix(vis): keep paper limit and CSV reachable on empty viz

### DIFF
--- a/src/api/vis/types.ts
+++ b/src/api/vis/types.ts
@@ -12,8 +12,27 @@ export interface IADSApiWordCloudParams {
 }
 
 export interface IADSApiAuthorNetworkResponse {
-  data: { bibcode_dict: IBibcodeDict; link_data: number[][]; root: IADSApiAuthorNetworkNode };
+  data: {
+    bibcode_dict: IBibcodeDict;
+    link_data: number[][];
+    root: IADSApiAuthorNetworkNode;
+    // Present only in the "not enough data" fallback, where the service drops
+    // `root` and returns the raw ungrouped force graph instead.
+    fullGraph?: IADSApiNetworkErrorGraph<IADSApiAuthorNetworkErrorGraphNode>;
+  };
   msg: { numFound: number; start: number; rows: number };
+}
+
+// "Not enough data" responses (author and paper) share this ungrouped graph
+// shape under `data.fullGraph`; node contents differ per network.
+export interface IADSApiNetworkErrorGraph<TNode> {
+  nodes: TNode[];
+  links: { source: number; target: number; value: number; overlap?: string[] }[];
+}
+
+export interface IADSApiAuthorNetworkErrorGraphNode {
+  nodeName: string; // author name
+  nodeWeight: number;
 }
 
 export interface IBibcodeDict {
@@ -100,6 +119,10 @@ export interface IADSApiPaperNetworkFullGraphNode {
   node_name: string;
   id: number;
   nodeWeight: number;
+  // Present only in the "not enough data" fallback, where `fullGraph` nodes are
+  // individual papers keyed by bibcode rather than grouped summary nodes.
+  nodeName?: string; // bibcode
+  year?: string;
 }
 
 export interface IADSApiWordCloudResponse {

--- a/src/components/Visualizations/Containers/AuthorNetworkPageContainer.tsx
+++ b/src/components/Visualizations/Containers/AuthorNetworkPageContainer.tsx
@@ -9,13 +9,13 @@ import { uniq } from 'ramda';
 import { ReactElement, Reducer, useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { IView } from '../GraphPanes/types';
 import { ILineGraph } from '../types';
-import { getAuthorNetworkNodeDetails, getAuthorNetworkSummaryGraph } from '../utils';
-import { FilterSearchBar, IFilterSearchBarProps, NotEnoughData } from '../Widgets';
+import { getAuthorNetworkErrorCSV, getAuthorNetworkNodeDetails, getAuthorNetworkSummaryGraph } from '../utils';
+import { FilterSearchBar, IFilterSearchBarProps, NetworkNotEnoughData } from '../Widgets';
 import { AuthorNetworkDetailsPane } from '../Panes/NetworkDetails/AuthorNetworkDetailsPane';
 import { IAuthorNetworkNodeDetails } from '../Panes/NetworkDetails/types';
 import { AuthorNetworkGraphPane } from '../GraphPanes/AuthorNetworkGraphPane';
 import { ITagItem } from '@/components/Tags';
-import { CustomInfoMessage, LoadingMessage, StandardAlertMessage } from '@/components/Feedbacks';
+import { LoadingMessage, StandardAlertMessage } from '@/components/Feedbacks';
 import { Expandable } from '@/components/Expandable';
 import { SimpleLink } from '@/components/SimpleLink';
 import { DataDownloader } from '@/components/DataDownloader';
@@ -185,6 +185,13 @@ export const AuthorNetworkPageContainer = ({ query }: IAuthorNetworkPageContaine
     return output;
   }, [authorNetworkData?.data?.root?.children]);
 
+  // In the "not enough data" state `root` is absent; the service instead returns
+  // the raw ungrouped author graph under `fullGraph`, which is all we can export.
+  const errorNodes = authorNetworkData?.data?.fullGraph?.nodes;
+  const hasErrorData = Array.isArray(errorNodes) && errorNodes.length > 0;
+
+  const getErrorCSVDataContent = useCallback(() => getAuthorNetworkErrorCSV(errorNodes ?? []), [errorNodes]);
+
   return (
     <Box as="section" aria-label="Author network graph" my={10}>
       <StatusDisplay
@@ -193,7 +200,12 @@ export const AuthorNetworkPageContainer = ({ query }: IAuthorNetworkPageContaine
         authorNetworkError={authorNetworkError}
       />
       {!authorNetworkIsLoading && authorNetworkIsSuccess && !authorNetworkData.data?.root && (
-        <CustomInfoMessage status="info" alertTitle="Could not generate" description={<NotEnoughData />} />
+        <NetworkNotEnoughData
+          paperLimit={state.rowsToFetch}
+          maxPaperLimit={Math.min(numFound, MAX_ROWS_TO_FETCH)}
+          onChangePaperLimit={(limit) => dispatch({ type: 'CHANGE_PAPER_LIMIT', payload: limit })}
+          csv={hasErrorData ? { getFileContent: getErrorCSVDataContent, fileName: 'author-network.csv' } : undefined}
+        />
       )}
       {!authorNetworkIsLoading && authorNetworkIsSuccess && authorNetworkData.data?.root && (
         <SimpleGrid columns={columns} spacing={16}>

--- a/src/components/Visualizations/Containers/PaperNetworkPageContainer.tsx
+++ b/src/components/Visualizations/Containers/PaperNetworkPageContainer.tsx
@@ -9,13 +9,18 @@ import { sort, uniq } from 'ramda';
 import { ReactElement, Reducer, useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { IView } from '../GraphPanes/types';
 import { ILineGraph } from '../types';
-import { getPaperNetworkLinkDetails, getPaperNetworkNodeDetails, getPaperNetworkSummaryGraph } from '../utils';
-import { FilterSearchBar, IFilterSearchBarProps, NotEnoughData } from '../Widgets';
+import {
+  getPaperNetworkErrorCSV,
+  getPaperNetworkLinkDetails,
+  getPaperNetworkNodeDetails,
+  getPaperNetworkSummaryGraph,
+} from '../utils';
+import { FilterSearchBar, IFilterSearchBarProps, NetworkNotEnoughData } from '../Widgets';
 import { PaperNetworkDetailsPane } from '../Panes/NetworkDetails/PaperNetworkDetailsPane';
 import { IPaperNetworkLinkDetails, IPaperNetworkNodeDetails } from '../Panes/NetworkDetails/types';
 import { PaperNetworkGraphPane } from '../GraphPanes/PaperNetworkGraphPane';
 import { ITagItem } from '@/components/Tags';
-import { CustomInfoMessage, LoadingMessage, StandardAlertMessage } from '@/components/Feedbacks';
+import { LoadingMessage, StandardAlertMessage } from '@/components/Feedbacks';
 import { Expandable } from '@/components/Expandable';
 import { SimpleLink } from '@/components/SimpleLink';
 import { DataDownloader } from '@/components/DataDownloader';
@@ -216,6 +221,13 @@ export const PaperNetworkPageContainer = ({ query }: IPaperNetworkPageContainerP
     return output;
   }, [paperNetworkData?.data?.summaryGraph?.nodes]);
 
+  // In the "not enough data" state `summaryGraph` is absent; the service returns
+  // the raw ungrouped paper rows under `fullGraph`, which is what we export.
+  const errorNodes = paperNetworkData?.data?.fullGraph?.nodes;
+  const hasErrorData = Array.isArray(errorNodes) && errorNodes.length > 0;
+
+  const getErrorCSVDataContent = useCallback(() => getPaperNetworkErrorCSV(errorNodes ?? []), [errorNodes]);
+
   return (
     <Box as="section" aria-label="Paper network graph" my={10}>
       <StatusDisplay
@@ -224,7 +236,12 @@ export const PaperNetworkPageContainer = ({ query }: IPaperNetworkPageContainerP
         paperNetworkError={paperNetworkError}
       />
       {!paperNetworkIsLoading && paperNetworkIsSuccess && !paperNetworkData.data?.summaryGraph && (
-        <CustomInfoMessage status="info" alertTitle="Could not generate" description={<NotEnoughData />} />
+        <NetworkNotEnoughData
+          paperLimit={state.rowsToFetch}
+          maxPaperLimit={Math.min(numFound, MAX_ROWS_TO_FETCH)}
+          onChangePaperLimit={(limit) => dispatch({ type: 'CHANGE_PAPER_LIMIT', payload: limit })}
+          csv={hasErrorData ? { getFileContent: getErrorCSVDataContent, fileName: 'paper-network.csv' } : undefined}
+        />
       )}
       {!paperNetworkIsLoading && paperNetworkIsSuccess && paperNetworkData.data?.summaryGraph && (
         <SimpleGrid columns={columns} spacing={16}>

--- a/src/components/Visualizations/Widgets/NetworkNotEnoughData.test.tsx
+++ b/src/components/Visualizations/Widgets/NetworkNotEnoughData.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NetworkNotEnoughData } from './NetworkNotEnoughData';
+
+const baseProps = {
+  paperLimit: 5,
+  maxPaperLimit: 100,
+  onChangePaperLimit: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // DataDownloader builds an object URL on render; jsdom lacks the impl.
+  window.URL.createObjectURL = vi.fn(() => 'blob:mock');
+});
+
+describe('NetworkNotEnoughData', () => {
+  test('keeps the paper limit control reachable in the error state', () => {
+    render(<NetworkNotEnoughData {...baseProps} />);
+    expect(screen.getByText('Could not generate')).toBeInTheDocument();
+    expect(screen.getByLabelText('max number of papers')).toBeInTheDocument();
+  });
+
+  test('raising the limit and applying calls onChangePaperLimit with the new value', () => {
+    render(<NetworkNotEnoughData {...baseProps} />);
+    fireEvent.change(screen.getByLabelText('max number of papers'), { target: { value: '50' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(baseProps.onChangePaperLimit).toHaveBeenCalledWith(50);
+  });
+
+  test('omits the download button when there is no usable data', () => {
+    render(<NetworkNotEnoughData {...baseProps} />);
+    expect(screen.queryByRole('button', { name: /download csv data/i })).not.toBeInTheDocument();
+  });
+
+  test('renders the download button when usable data is provided', () => {
+    const getFileContent = vi.fn(() => 'a,b\n1,2\n');
+    render(<NetworkNotEnoughData {...baseProps} csv={{ getFileContent, fileName: 'network.csv' }} />);
+    expect(screen.getByRole('button', { name: /download csv data/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/Visualizations/Widgets/NetworkNotEnoughData.tsx
+++ b/src/components/Visualizations/Widgets/NetworkNotEnoughData.tsx
@@ -1,0 +1,37 @@
+import { Stack } from '@chakra-ui/react';
+import { ReactElement } from 'react';
+
+import { CustomInfoMessage } from '@/components/Feedbacks';
+import { DataDownloader } from '@/components/DataDownloader';
+import { NotEnoughData } from './NotEnoughData';
+import { PaperLimit } from './PaperLimit';
+
+export interface INetworkNotEnoughDataProps {
+  paperLimit: number;
+  maxPaperLimit: number;
+  onChangePaperLimit: (limit: number) => void;
+  // Only provided when the response carries usable rows to export; when
+  // omitted the download button is not rendered (AC: omit when no data).
+  csv?: { getFileContent: () => string; fileName: string };
+}
+
+/**
+ * Error-state widget shown when the network grouping algorithm cannot build
+ * groups. Keeps the PaperLimit control reachable so the user can raise an
+ * over-restricted limit and retry, and offers a CSV export of whatever raw
+ * data did come back.
+ */
+export const NetworkNotEnoughData = ({
+  paperLimit,
+  maxPaperLimit,
+  onChangePaperLimit,
+  csv,
+}: INetworkNotEnoughDataProps): ReactElement => {
+  return (
+    <Stack as="section" aria-label="Not enough data" alignItems="center" spacing={2}>
+      <CustomInfoMessage status="info" alertTitle="Could not generate" description={<NotEnoughData />} />
+      <PaperLimit initialLimit={paperLimit} max={maxPaperLimit} onApply={onChangePaperLimit} />
+      {csv && <DataDownloader label="Download CSV Data" getFileContent={csv.getFileContent} fileName={csv.fileName} />}
+    </Stack>
+  );
+};

--- a/src/components/Visualizations/Widgets/index.ts
+++ b/src/components/Visualizations/Widgets/index.ts
@@ -1,3 +1,4 @@
 export * from './FilterSearchBar';
+export * from './NetworkNotEnoughData';
 export * from './NotEnoughData';
 export * from './PaperLimit';

--- a/src/components/Visualizations/utils/graphUtils.test.ts
+++ b/src/components/Visualizations/utils/graphUtils.test.ts
@@ -14,9 +14,11 @@ import {
 } from '@/api/metrics/types';
 import type { IFacetCountsFields, IDocsEntity, IBucket } from '@/api/search/types';
 import {
+  getAuthorNetworkErrorCSV,
   getCitationTableData,
   getHIndexGraphData,
   getIndicesTableData,
+  getPaperNetworkErrorCSV,
   getPapersTableData,
   getReadsTableData,
   getResultsGraph,
@@ -516,5 +518,44 @@ describe('getResultsGraph', () => {
 
     expect(result.groups).toEqual([]);
     expect(result.data.every((item) => item.pub === 'other')).toBe(true);
+  });
+});
+
+describe('getAuthorNetworkErrorCSV', () => {
+  test('builds an author,weight CSV from the ungrouped fallback nodes', () => {
+    const csv = getAuthorNetworkErrorCSV([
+      { nodeName: 'Bieniosek, F', nodeWeight: 22.4 },
+      { nodeName: 'Lee, E', nodeWeight: 150 },
+    ]);
+
+    expect(csv).toBe('author,weight\n"Bieniosek, F",22.4\n"Lee, E",150\n');
+  });
+
+  test('returns just the header when there are no nodes', () => {
+    expect(getAuthorNetworkErrorCSV([])).toBe('author,weight\n');
+  });
+});
+
+describe('getPaperNetworkErrorCSV', () => {
+  test('builds a per-paper CSV from the ungrouped fallback nodes', () => {
+    const csv = getPaperNetworkErrorCSV([
+      {
+        nodeName: '2000PhyC..337..187S',
+        first_author: 'Sumption, M. D.',
+        title: 'Influence of filamentary and strand aspect ratios',
+        year: '2000',
+        citation_count: 9,
+        read_count: 0,
+      },
+    ]);
+
+    expect(csv).toBe(
+      'bibcode,first author,title,year,citations,download count\n' +
+        '"2000PhyC..337..187S","Sumption, M. D.","Influence of filamentary and strand aspect ratios","2000",9,0\n',
+    );
+  });
+
+  test('returns just the header when there are no nodes', () => {
+    expect(getPaperNetworkErrorCSV([])).toBe('bibcode,first author,title,year,citations,download count\n');
   });
 });

--- a/src/components/Visualizations/utils/graphUtils.ts
+++ b/src/components/Visualizations/utils/graphUtils.ts
@@ -1,7 +1,9 @@
 import {
+  IADSApiAuthorNetworkErrorGraphNode,
   IADSApiAuthorNetworkNode,
   IADSApiAuthorNetworkResponse,
   IADSApiPaperNetworkFullGraph,
+  IADSApiPaperNetworkFullGraphNode,
   IADSApiPaperNetworkResponse,
   IADSApiPaperNetworkSummaryGraphNode,
   IADSApiWordCloudResponse,
@@ -480,6 +482,33 @@ export const getAuthorNetworkSummaryGraph = (response: IADSApiAuthorNetworkRespo
   } catch (err) {
     return { data: [], error: err instanceof Error ? err : new Error('Cannot generate network') };
   }
+};
+
+// "Not enough data" author responses only carry author name + weight in the
+// ungrouped `fullGraph`, so that is all the CSV can offer in the error state.
+export const getAuthorNetworkErrorCSV = (nodes: IADSApiAuthorNetworkErrorGraphNode[]): string => {
+  let output = 'author,weight\n';
+  nodes.forEach((node) => {
+    output += `"${node.nodeName}",${node.nodeWeight}\n`;
+  });
+
+  return output;
+};
+
+// "Not enough data" paper responses carry per-paper rows in the ungrouped
+// `fullGraph` (bibcode + metadata), which is richer than the author fallback.
+type PaperNetworkErrorNode = Pick<
+  IADSApiPaperNetworkFullGraphNode,
+  'nodeName' | 'first_author' | 'title' | 'year' | 'citation_count' | 'read_count'
+>;
+
+export const getPaperNetworkErrorCSV = (nodes: PaperNetworkErrorNode[]): string => {
+  let output = 'bibcode,first author,title,year,citations,download count\n';
+  nodes.forEach((node) => {
+    output += `"${node.nodeName}","${node.first_author}","${node.title}","${node.year}",${node.citation_count},${node.read_count}\n`;
+  });
+
+  return output;
 };
 
 export const getAuthorNetworkNodeDetails = (


### PR DESCRIPTION
The author and paper network pages dropped the entire graph pane when the
backend couldn't build groups, so a user who over-restricted the paper limit
had no way to raise it back and nothing to export. The "not enough data"
response also uses a different shape than success (no root/summaryGraph; raw
rows under fullGraph), which the CSV path wasn't reading.

1. Add a shared NotEnoughData panel that keeps the paper limit control on
   screen and offers an optional CSV download.
2. Build the error-state CSV from fullGraph.nodes (author name and weight;
   paper bibcode and metadata), omitting the button when there are no rows.
3. Model the fullGraph fallback in the vis response types.
<img width="709" height="504" alt="image" src="https://github.com/user-attachments/assets/4082db64-7df4-4e05-9193-1273ca4bcadd" />

