### PR TITLE
Condense classic form UI

### DIFF
--- a/src/components/ClassicForm/ClassicForm.tsx
+++ b/src/components/ClassicForm/ClassicForm.tsx
@@ -20,9 +20,10 @@ import {
   Stack,
   Text,
   Textarea,
+  Tooltip,
   VisuallyHidden,
 } from '@chakra-ui/react';
-import { CalendarIcon } from '@chakra-ui/icons';
+import { CalendarIcon, ExternalLinkIcon, InfoIcon } from '@chakra-ui/icons';
 
 import { useErrorMessage } from '@/lib/useErrorMessage';
 import { useIsClient } from '@/lib/useIsClient';
@@ -110,73 +111,77 @@ export const ClassicForm = (props: IClassicFormProps) => {
 
         {/* Collection selection */}
         <FormControl as="fieldset">
-          <FormLabel as="legend">Collection</FormLabel>
-          <CheckboxGroup defaultValue={['astronomy', 'physics']}>
-            <HStack spacing="6">
-              <Checkbox value="astronomy" {...register('limit')}>
-                Astronomy
-              </Checkbox>
-              <Checkbox value="physics" {...register('limit')}>
-                Physics
-              </Checkbox>
-              <Checkbox value="general" {...register('limit')}>
-                General
-              </Checkbox>
-              <Checkbox value="earthscience" {...register('limit')}>
-                Earth Science
-              </Checkbox>
-            </HStack>
-          </CheckboxGroup>
+          <Flex alignItems="top">
+            <FormLabel as="legend" m={0} mr={4}>
+              Collection
+            </FormLabel>
+            <CheckboxGroup defaultValue={['astronomy', 'physics']}>
+              <HStack spacing="6" wrap="wrap">
+                <Checkbox value="astronomy" {...register('limit')}>
+                  Astronomy
+                </Checkbox>
+                <Checkbox value="physics" {...register('limit')}>
+                  Physics
+                </Checkbox>
+                <Checkbox value="general" {...register('limit')}>
+                  General
+                </Checkbox>
+                <Checkbox value="earthscience" {...register('limit')}>
+                  Earth Science
+                </Checkbox>
+              </HStack>
+            </CheckboxGroup>
+          </Flex>
         </FormControl>
 
-        {/* Author text area */}
-        <FormControl>
-          <Flex direction="row" justifyContent="space-between">
-            <FormLabel htmlFor={'author'}>Author</FormLabel>
-            <LogicRadios variant="andor" radioProps={register('logic_author')} />
-          </Flex>
-          <Textarea
-            {...register('author')}
-            as="textarea"
-            id="author"
-            rows={3}
-            placeholder={`Smith, John A\nSmith, Jane B`}
-          />
-          <FormHelperText lineHeight="5">
-            <Text>Author names, enter (Last, First M) one per line.</Text>
-            <Text fontWeight="bold">Example Operators:</Text>
-            <Text>
-              Use <Code>-</Code> to filter out an author. (Ex: <Code>-Smith, John</Code>)
-            </Text>
-            <Text>
-              Use <Code>=</Code> to restrict name expansion. For example <Code>=Smith, Jim</Code> will match &#34;Smith,
-              Jim&#34; but not &#34;Smith, James&#34;.
-            </Text>
-            <Text>
-              Surround name with <Code>^ $</Code> to match papers with only one particular author. (Ex:{' '}
-              <Code>^Smith, J$</Code>)
-            </Text>
-            <Text>
-              <SimpleLink href="https://ui.adsabs.harvard.edu/help/search/search-syntax#author">Learn More</SimpleLink>
-            </Text>
-          </FormHelperText>
-        </FormControl>
+        <Stack direction={['column', 'row']} justifyContent="space-evenly" spacing={5}>
+          {/* Author text area */}
+          <FormControl>
+            <Flex direction="row" justifyContent="space-between">
+              <FormLabel htmlFor={'author'}>Author</FormLabel>
+              <LogicRadios variant="andor" radioProps={register('logic_author')} />
+            </Flex>
+            <Textarea
+              {...register('author')}
+              as="textarea"
+              id="author"
+              rows={3}
+              placeholder={`Smith, John A\nSmith, Jane B`}
+            />
+            <FormHelperText lineHeight="5">
+              <Text>
+                Author names, enter (Last, First M) one per line.
+                <SimpleLink ml={1} href="scixhelp/search-scix/search-syntax#author" newTab>
+                  <Tooltip
+                    label={
+                      <>
+                        Learn more about author search syntax <ExternalLinkIcon aria-label="opens new tab" />
+                      </>
+                    }
+                  >
+                    <InfoIcon aria-label="Learn more about author search syntax" />
+                  </Tooltip>
+                </SimpleLink>
+              </Text>
+            </FormHelperText>
+          </FormControl>
 
-        {/* Object text area */}
-        <FormControl>
-          <Flex direction="row" justifyContent="space-between">
-            <FormLabel htmlFor="object">Object</FormLabel>
-            <LogicRadios variant="andor" radioProps={register('logic_object')} />
-          </Flex>
-          <Textarea
-            {...register('object')}
-            as="textarea"
-            id="object"
-            rows={3}
-            placeholder={`M 31\nHD 187642\nSgr A*`}
-          />
-          <FormHelperText>SIMBAD object search, one per line.</FormHelperText>
-        </FormControl>
+          {/* Object text area */}
+          <FormControl>
+            <Flex direction="row" justifyContent="space-between">
+              <FormLabel htmlFor="object">Object</FormLabel>
+              <LogicRadios variant="andor" radioProps={register('logic_object')} />
+            </Flex>
+            <Textarea
+              {...register('object')}
+              as="textarea"
+              id="object"
+              rows={3}
+              placeholder={`M 31\nHD 187642\nSgr A*`}
+            />
+            <FormHelperText>SIMBAD object search, one per line.</FormHelperText>
+          </FormControl>
+        </Stack>
 
         {/* Publication dates */}
         <Stack
@@ -196,7 +201,6 @@ export const ClassicForm = (props: IClassicFormProps) => {
               </InputLeftElement>
               <Input placeholder="YYYY/MM" type="text" {...register('pubdate_start')} />
             </InputGroup>
-            <FormHelperText>Ex: &#34;2011/04&#34;</FormHelperText>
           </FormControl>
           <FormControl>
             <FormLabel>Publication Date End</FormLabel>
@@ -206,7 +210,6 @@ export const ClassicForm = (props: IClassicFormProps) => {
               </InputLeftElement>
               <Input placeholder="YYYY/MM" {...register('pubdate_end')} />
             </InputGroup>
-            <FormHelperText>Ex: &#34;2014/12&#34;</FormHelperText>
           </FormControl>
         </Stack>
 
@@ -217,7 +220,6 @@ export const ClassicForm = (props: IClassicFormProps) => {
             <LogicRadios variant="all" radioProps={register('logic_title')} />
           </Flex>
           <Input {...register('title')} />
-          <FormHelperText>Ex: &#34;Content of the Future in the ADS&#34;</FormHelperText>
         </FormControl>
 
         {/* Abstract / Keywords */}
@@ -227,7 +229,6 @@ export const ClassicForm = (props: IClassicFormProps) => {
             <LogicRadios variant="all" radioProps={register('logic_abstract_keywords')} />
           </Flex>
           <Input {...register('abstract_keywords')} />
-          <FormHelperText>Ex: &#34;Dark Energy&#34;</FormHelperText>
         </FormControl>
 
         {/* Property */}
@@ -255,7 +256,6 @@ export const ClassicForm = (props: IClassicFormProps) => {
                 <VisuallyHidden id="bibstem">Publications</VisuallyHidden>
                 <FormLabel htmlFor="bibstem-picker">Publications</FormLabel>
                 <BibstemPicker isMultiple onChange={(items) => field.onChange(items)} id="bibstem-picker" />
-                <FormHelperText>Ex. &#34;A&amp;A&#34; or &#34;-A&amp;A&#34;</FormHelperText>
               </FormControl>
             )}
           />

--- a/src/components/Libraries/LibraryEntityPane.tsx
+++ b/src/components/Libraries/LibraryEntityPane.tsx
@@ -413,6 +413,7 @@ export const LibraryEntityPane = ({ id, publicView }: ILibraryEntityPaneProps) =
                   onChange={handleChangeSort}
                   options={biblibSortOptions}
                   disableWhenNoJs
+                  theme="action"
                 />
                 <SearchQueryLink
                   params={{

--- a/src/components/ResultList/ListActions.tsx
+++ b/src/components/ResultList/ListActions.tsx
@@ -315,7 +315,13 @@ const SortWrapper = ({ onChange }: { onChange: ISortProps<SolrSort, SolrSortFiel
   const query = useStore(...sortSelector);
 
   return (
-    <Sort<SolrSort, SolrSortField> sort={query.sort[0]} onChange={onChange} options={solrSortOptions} id="sort-order" />
+    <Sort<SolrSort, SolrSortField>
+      sort={query.sort[0]}
+      onChange={onChange}
+      options={solrSortOptions}
+      id="sort-order"
+      theme="action"
+    />
   );
 };
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -18,7 +18,7 @@ export interface ISelectProps<
 > extends Partial<Props<Option, isMulti, Group>> {
   label: ReactNode;
   hideLabel?: boolean;
-  stylesTheme?: 'theme' | 'sort' | 'default' | 'default.sm';
+  stylesTheme?: 'theme' | 'sort' | 'sort_form' | 'default' | 'default.sm';
   id: string;
   'data-testid'?: string;
 }
@@ -77,6 +77,35 @@ function SelectImpl<
             borderRadius: '5px 0 0 5px',
             borderRightWidth: '0',
             borderColor: colors.outline,
+            backgroundColor: colors.background,
+          }),
+          // the text in control
+          singleValue: (provided) => ({
+            ...provided,
+            color: colors.text,
+          }),
+          indicatorSeparator: () => ({
+            isDisabled: true,
+          }),
+          option: (provided, state) => ({
+            ...provided,
+            backgroundColor: state.isFocused ? colors.highlightBackground : 'transparent',
+            color: state.isFocused ? colors.highlightForeground : colors.text,
+          }),
+          menu: (provided) => ({
+            ...provided,
+            backgroundColor: colors.background,
+            boxShadow: `0 0 0 1px ${colors.border}`,
+            zIndex: 10,
+          }),
+        },
+        sort_form: {
+          control: (provided) => ({
+            ...provided,
+            height: '40px',
+            minHeight: '40px',
+            borderRadius: '2px 0 0 2px',
+            borderRightWidth: '0',
             backgroundColor: colors.background,
           }),
           // the text in control

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -12,6 +12,7 @@ import { makeSearchParams, parseQueryFromUrl } from '@/utils/common/search';
 import { SolrSort, SolrSortField, SortDirection, SortField, SortType } from '@/api/models';
 
 export interface ISortProps<S extends SortType, F extends SortField> {
+  id?: string;
   sort: S;
   options: SortOptionType<F>[];
   name?: string;
@@ -22,7 +23,7 @@ export interface ISortProps<S extends SortType, F extends SortField> {
   leftMargin?: string;
   rightMargin?: string;
   innerSelectProps?: Partial<ISelectProps<SortOptionType<F>>>;
-
+  theme?: 'form' | 'action'; // form to match form style, action to match search results action buttons, default is form
   /**
    * If true will use the native dropdown when no JavaScript,
    * otherwise will use one with same look and feel as JS supported one
@@ -52,6 +53,7 @@ export const Sort = <S extends SortType = SolrSort, F extends SortField = SolrSo
     hideLabel = true,
     fullWidth = false,
     innerSelectProps,
+    theme = 'form',
   } = props;
 
   // split first sort, the rest are just along for the ride
@@ -92,6 +94,7 @@ export const Sort = <S extends SortType = SolrSort, F extends SortField = SolrSo
           sortOptions={options}
           sort={selected}
           onChange={handleSelectionChange}
+          styleTheme={theme === 'form' ? 'sort_form' : 'sort'}
           innerSelectProps={innerSelectProps}
         />
       </Box>
@@ -103,8 +106,9 @@ export const Sort = <S extends SortType = SolrSort, F extends SortField = SolrSo
           icon={<BarsArrowUpIcon width="20px" />}
           aria-label="Sort ascending"
           borderLeftRadius="0"
-          borderRightRadius="5px"
+          borderRightRadius={theme === 'form' ? '2px' : '5px'}
           size="md"
+          colorScheme={theme === 'form' ? 'gray' : 'blue'}
           data-testid="sort-direction-toggle"
         />
       ) : (
@@ -115,8 +119,9 @@ export const Sort = <S extends SortType = SolrSort, F extends SortField = SolrSo
           icon={<BarsArrowDownIcon width="20px" />}
           aria-label="Sort descending"
           borderLeftRadius="0"
-          borderRightRadius="5px"
+          borderRightRadius={theme === 'form' ? '2px' : '5px'}
           size="md"
+          colorScheme={theme === 'form' ? 'gray' : 'blue'}
           data-testid="sort-direction-toggle"
         />
       )}
@@ -138,12 +143,14 @@ const SortSelect = <S extends SortType, F extends SortField>({
   sortOptions,
   onChange,
   hideLabel,
+  styleTheme,
   innerSelectProps,
 }: {
   sort: string;
   sortOptions: SortOptionType<F>[];
   onChange: (val: SortOptionType<F>) => void;
   hideLabel: ISortProps<S, F>['hideLabel'];
+  styleTheme: ISelectProps['stylesTheme'];
   innerSelectProps?: Partial<ISelectProps<SortOptionType<F>>>;
 }) => {
   const selected = sortOptions.find((o) => o.id === sort) ?? sortOptions[0];
@@ -153,7 +160,7 @@ const SortSelect = <S extends SortType, F extends SortField>({
       hideLabel={hideLabel}
       value={selected}
       options={sortOptions}
-      stylesTheme="sort"
+      stylesTheme={styleTheme}
       onChange={onChange}
       data-testid="sort-select"
       id="sort-select"


### PR DESCRIPTION
Condense the classic form so there is less scrolling to get to the search button 
## Before
<img width="950" height="1315" alt="Screenshot 2026-07-27 at 10 41 27 AM" src="https://github.com/user-attachments/assets/3968aec5-e591-4dc3-8959-16cfc212d4dc" />

## After
<img width="953" height="1242" alt="Screenshot 2026-07-27 at 10 41 44 AM" src="https://github.com/user-attachments/assets/a0cf85d7-20a3-4c71-b075-b1805ed15c5a" />
