### PR TITLE
size up add to library modal for better layout

### DIFF
--- a/src/components/Libraries/AddToLibraryModal.tsx
+++ b/src/components/Libraries/AddToLibraryModal.tsx
@@ -101,7 +101,7 @@ export const AddToLibraryModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={() => onClose(false)} size="3xl">
+    <Modal isOpen={isOpen} onClose={() => onClose(false)} size="5xl">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>


### PR DESCRIPTION
Make add to library modal larger to accommodate long library names

 
<img width="1277" height="1037" alt="Screenshot 2026-07-31 at 10 49 00 AM" src="https://github.com/user-attachments/assets/19bc9e4d-d19d-429a-ba5a-87888441509c" />
