### PR TITLE
SCIX-900 fix(orcid): auto-expire ORCiD mode after 5 minutes of inactivity

### DIFF
--- a/src/__tests__/orcidPage.test.tsx
+++ b/src/__tests__/orcidPage.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { AppState, useStore } from '@/store';
+import OrcidPage from '../pages/user/orcid';
+
+vi.mock('@/components/Orcid/UserSettings', () => ({ UserSettings: (): null => null }));
+vi.mock('@/components/Orcid/WorksTable', () => ({ WorksTable: (): null => null }));
+
+const orcidActiveSelector = (state: AppState) => state.orcid.active;
+const setOrcidModeSelector = (state: AppState) => state.setOrcidMode;
+
+// Exposes live store state/actions in the DOM so the test can read and
+// drive the store the same way the expiry watcher would, without needing
+// to render the watcher itself.
+const StoreProbe = () => {
+  const active = useStore(orcidActiveSelector);
+  const setOrcidMode = useStore(setOrcidModeSelector);
+  return (
+    <div>
+      <div data-testid="active-probe">{String(active)}</div>
+      <button data-testid="expire-button" onClick={() => setOrcidMode(false)}>
+        simulate expiry
+      </button>
+    </div>
+  );
+};
+
+describe('OrcidPage', () => {
+  test('turns mode on when visiting with mode off', () => {
+    render(
+      <>
+        <OrcidPage />
+        <StoreProbe />
+      </>,
+      { initialStore: { orcid: { active: false, isAuthenticated: false, user: null, lastActivityAt: null } } },
+    );
+
+    expect(screen.getByTestId('active-probe').textContent).toBe('true');
+  });
+
+  test('does not re-enable mode when it turns off while the page stays mounted', async () => {
+    const { user } = render(
+      <>
+        <OrcidPage />
+        <StoreProbe />
+      </>,
+      { initialStore: { orcid: { active: true, isAuthenticated: false, user: null, lastActivityAt: Date.now() } } },
+    );
+
+    expect(screen.getByTestId('active-probe').textContent).toBe('true');
+
+    // simulate the expiry watcher turning mode off mid-visit
+    await user.click(screen.getByTestId('expire-button'));
+
+    expect(screen.getByTestId('active-probe').textContent).toBe('false');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,8 @@ export const ORCID_LOGIN_URL = `${process.env.NEXT_PUBLIC_ORCID_API_URL}/oauth/a
 
 export const ORCID_ADS_SOURCE_NAME = 'Astrophysics Data System';
 export const ORCID_ADS_SOURCE_NAME_SHORT = 'ADS';
+// Sliding-window inactivity timeout for ORCiD mode, in ms.
+export const ORCID_MODE_TIMEOUT = 5 * 60 * 1000;
 export const BRAND_NAME_FULL = 'Science Explorer';
 export const BRAND_NAME_SHORT = 'SciX';
 export const ORCID_BULK_DELETE_CHUNK_SIZE = 4;

--- a/src/lib/orcid/useAddWorks.ts
+++ b/src/lib/orcid/useAddWorks.ts
@@ -1,6 +1,6 @@
 import { AppState, useStore } from '@/store';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { transformADStoOrcid } from '@/lib/orcid/workTransformer';
 import { isValidIOrcidUser } from '@/api/orcid/models';
 import { OrcidHookOptions, OrcidMutationOptions } from '@/lib/orcid/types';
@@ -10,6 +10,7 @@ import { useSearch } from '@/api/search/search';
 
 const orcidUserSelector = (state: AppState) => state.orcid.user;
 const isAuthenticatedSelector = (state: AppState) => state.orcid.isAuthenticated;
+const touchOrcidActivitySelector = (state: AppState) => state.touchOrcidActivity;
 
 export const useAddWorks = (
   options?: OrcidHookOptions<'addWorks'>,
@@ -18,6 +19,7 @@ export const useAddWorks = (
   const qc = useQueryClient();
   const user = useStore(orcidUserSelector);
   const isAuthenticated = useStore(isAuthenticatedSelector);
+  const touchOrcidActivity = useStore(touchOrcidActivitySelector);
   const [bibcodesToAdd, setBibcodesToAdd] = useState<string[]>([]);
   const queryKey = orcidKeys.profile({ user, full: true, update: true });
 
@@ -78,8 +80,16 @@ export const useAddWorks = (
     }
   }, [searchResult]);
 
+  const addWorks = useCallback(
+    (bibcodes: string[]) => {
+      touchOrcidActivity();
+      setBibcodesToAdd(bibcodes);
+    },
+    [touchOrcidActivity],
+  );
+
   return {
-    addWorks: setBibcodesToAdd,
+    addWorks,
     isLoading: isSearchLoading && result.isLoading,
     ...result,
   };

--- a/src/lib/orcid/useOrcid.test.ts
+++ b/src/lib/orcid/useOrcid.test.ts
@@ -1,0 +1,130 @@
+import { act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@/test-utils';
+import { AppState, useStore } from '@/store';
+import { useOrcid, useOrcidExpiryWatcher } from './useOrcid';
+import { ORCID_MODE_TIMEOUT } from '@/config';
+
+const mocks = vi.hoisted(() => ({
+  toast: Object.assign(vi.fn(), { isActive: vi.fn(() => false) }),
+  useRouter: vi.fn(() => ({
+    pathname: '/',
+    query: {},
+    asPath: '/',
+    push: vi.fn(),
+    replace: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn() },
+  })),
+}));
+
+vi.mock('next/router', () => ({ useRouter: mocks.useRouter }));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => mocks.toast,
+  };
+});
+
+const touchOrcidActivitySelector = (state: AppState) => state.touchOrcidActivity;
+
+const renderExpiryWatcher = (lastActivityAt: number | null, active = true) =>
+  renderHook(
+    () => {
+      useOrcidExpiryWatcher();
+      const orcid = useOrcid();
+      const touchOrcidActivity = useStore(touchOrcidActivitySelector);
+      return { ...orcid, touchOrcidActivity };
+    },
+    { initialStore: { orcid: { active, isAuthenticated: false, user: null, lastActivityAt } } },
+  );
+
+describe('useOrcidExpiryWatcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.toast.mockClear();
+    mocks.toast.isActive.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('does not fire before the timeout elapses', () => {
+    const { result } = renderExpiryWatcher(Date.now());
+
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT - 1000);
+    });
+
+    expect(result.current.active).toBe(true);
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  test('turns off orcid mode and shows a toast once the timeout elapses', () => {
+    const { result } = renderExpiryWatcher(Date.now());
+
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT);
+    });
+
+    expect(result.current.active).toBe(false);
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'ORCiD mode turned off due to inactivity' }),
+    );
+  });
+
+  test('sliding window: activity resets the timer', () => {
+    const { result } = renderExpiryWatcher(Date.now());
+
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT - 1000);
+    });
+    expect(result.current.active).toBe(true);
+
+    act(() => {
+      result.current.touchOrcidActivity();
+    });
+
+    // total elapsed time now exceeds the original timeout, but the reset
+    // means the window only started counting again from the touch
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT - 1000);
+    });
+    expect(result.current.active).toBe(true);
+    expect(mocks.toast).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.active).toBe(false);
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+  });
+
+  test('manual toggle-off is unaffected: no expiry toast fires', () => {
+    const { result } = renderExpiryWatcher(Date.now());
+
+    act(() => {
+      result.current.toggleOrcidMode(false);
+    });
+    expect(result.current.active).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT);
+    });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when mode is already off', () => {
+    const { result } = renderExpiryWatcher(null, false);
+
+    act(() => {
+      vi.advanceTimersByTime(ORCID_MODE_TIMEOUT);
+    });
+
+    expect(result.current.active).toBe(false);
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/orcid/useOrcid.ts
+++ b/src/lib/orcid/useOrcid.ts
@@ -135,7 +135,7 @@ export const useOrcidExpiryWatcher = (): void => {
   const active = useStore(activeSelector);
   const lastActivityAt = useStore(lastActivityAtSelector);
   const setOrcidMode = useStore(setOrcidModeSelector);
-  const toast = useToast({ id: 'orcid' });
+  const toast = useToast({ id: 'orcid-expiry' });
 
   useEffect(() => {
     if (!active || lastActivityAt === null) {
@@ -150,7 +150,7 @@ export const useOrcidExpiryWatcher = (): void => {
 
     const timer = setTimeout(() => {
       setOrcidMode(false);
-      if (!toast.isActive('orcid')) {
+      if (!toast.isActive('orcid-expiry')) {
         toast({
           status: 'info',
           title: 'ORCiD mode turned off due to inactivity',

--- a/src/lib/orcid/useOrcid.ts
+++ b/src/lib/orcid/useOrcid.ts
@@ -1,6 +1,6 @@
 import { AppState, useStore } from '@/store';
 import { useIsClient } from '@/lib/useIsClient';
-import { ORCID_LOGIN_URL } from '@/config';
+import { ORCID_LOGIN_URL, ORCID_MODE_TIMEOUT } from '@/config';
 import { useRouter } from 'next/router';
 import { isValidIOrcidUser } from '@/api/orcid/models';
 import { useEffect, useRef, useState } from 'react';
@@ -15,6 +15,7 @@ const isAuthenticatedSelector = (state: AppState) => state.orcid.isAuthenticated
 const orcidUserSelector = (state: AppState) => state.orcid.user;
 const resetSelector = (state: AppState) => state.resetOrcid;
 const setNotificationSelector = (state: AppState) => state.setNotification;
+const lastActivityAtSelector = (state: AppState) => state.orcid.lastActivityAt;
 
 export const useOrcid = () => {
   const router = useRouter();
@@ -69,8 +70,7 @@ export const useOrcid = () => {
           toast({
             status: 'error',
             title: 'Problem connecting with ORCiD',
-            description:
-              'There was an error retrieving your ORCiD profile. Please try again later.',
+            description: 'There was an error retrieving your ORCiD profile. Please try again later.',
           });
 
           // toggle orcid mode off
@@ -123,4 +123,45 @@ export const useOrcid = () => {
     isLoading: nameState.isLoading || profileState.isLoading,
     error,
   };
+};
+
+/**
+ * Drives ORCiD mode's sliding-window expiry. Mount once at the app root —
+ * `useOrcid` runs in multiple components at once, so a per-hook timer here
+ * would fire duplicate toggles and toasts. Stale mode from a past session
+ * is cleared separately (and silently) on store rehydration.
+ */
+export const useOrcidExpiryWatcher = (): void => {
+  const active = useStore(activeSelector);
+  const lastActivityAt = useStore(lastActivityAtSelector);
+  const setOrcidMode = useStore(setOrcidModeSelector);
+  const toast = useToast({ id: 'orcid' });
+
+  useEffect(() => {
+    if (!active || lastActivityAt === null) {
+      return;
+    }
+
+    const remaining = ORCID_MODE_TIMEOUT - (Date.now() - lastActivityAt);
+    if (remaining <= 0) {
+      setOrcidMode(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setOrcidMode(false);
+      if (!toast.isActive('orcid')) {
+        toast({
+          status: 'info',
+          title: 'ORCiD mode turned off due to inactivity',
+        });
+      }
+    }, remaining);
+
+    return () => clearTimeout(timer);
+    // toast intentionally excluded — useToast's return value isn't
+    // referentially stable, and including it would reschedule the timer
+    // every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, lastActivityAt, setOrcidMode]);
 };

--- a/src/lib/orcid/useRemoveWorks.ts
+++ b/src/lib/orcid/useRemoveWorks.ts
@@ -9,6 +9,7 @@ import { orcidKeys, useOrcidGetProfile, useOrcidRemoveWorks } from '@/api/orcid/
 
 const orcidUserSelector = (state: AppState) => state.orcid.user;
 const isAuthenticatedSelector = (state: AppState) => state.orcid.isAuthenticated;
+const touchOrcidActivitySelector = (state: AppState) => state.touchOrcidActivity;
 
 export const useRemoveWorks = (
   mutationOptions: OrcidMutationOptions<'removeWorks'>,
@@ -20,6 +21,7 @@ export const useRemoveWorks = (
   const qc = useQueryClient();
   const user = useStore(orcidUserSelector);
   const isAuthenticated = useStore(isAuthenticatedSelector);
+  const touchOrcidActivity = useStore(touchOrcidActivitySelector);
   const [putcodesToRemove, setPutcodesToRemove] = useState<string[]>([]);
 
   const { data: profile } = useOrcidGetProfile(
@@ -83,9 +85,10 @@ export const useRemoveWorks = (
       if (putcodes.length === 0) {
         throw new Error('Selected works were already unclaimed.');
       }
+      touchOrcidActivity();
       setPutcodesToRemove(putcodes);
     },
-    [profile],
+    [profile, touchOrcidActivity],
   );
 
   useEffect(() => {

--- a/src/lib/orcid/useUpdateWork.ts
+++ b/src/lib/orcid/useUpdateWork.ts
@@ -10,11 +10,13 @@ import { useSearch } from '@/api/search/search';
 import { useOrcidUpdateWork } from '@/api/orcid/orcid';
 
 const orcidUserSelector = (state: AppState) => state.orcid.user;
+const touchOrcidActivitySelector = (state: AppState) => state.touchOrcidActivity;
 export const useUpdateWork = (
   options?: OrcidHookOptions<'updateWork'>,
   mutationOptions?: OrcidMutationOptions<'updateWork'>,
 ) => {
   const user = useStore(orcidUserSelector);
+  const touchOrcidActivity = useStore(touchOrcidActivitySelector);
   const [work, setWork] = useState<IOrcidProfileEntry | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,6 +72,7 @@ export const useUpdateWork = (
 
   const onSetWork = (work: IOrcidProfileEntry) => {
     if (isOrcidProfileEntry(work)) {
+      touchOrcidActivity();
       return setWork(work);
     }
     throw new Error('Invalid work');

--- a/src/pages/user/orcid/index.tsx
+++ b/src/pages/user/orcid/index.tsx
@@ -14,7 +14,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { AppState, useStore } from '@/store';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { BRAND_NAME_FULL } from '@/config';
@@ -42,21 +42,35 @@ const WorksTable = dynamic(
 
 const setOrcidModeSelector = (state: AppState) => state.setOrcidMode;
 const orcidModeActiveSelector = (state: AppState) => state.orcid.active;
+const touchOrcidActivitySelector = (state: AppState) => state.touchOrcidActivity;
 const OrcidPage: NextPage = () => {
   const setOrcidMode = useStore(setOrcidModeSelector);
   const orcidModeActive = useStore(orcidModeActiveSelector);
+  const touchOrcidActivity = useStore(touchOrcidActivitySelector);
   const { isOpen, onClose, getButtonProps } = useDisclosure({
     defaultIsOpen: false,
     id: 'orcid-settings-sidebar',
   });
   const isMobile = useBreakpointValue({ base: true, lg: false });
+  const hasEnabledOnVisitRef = useRef(false);
 
-  // if navigating to this page, turn on orcid mode
+  // Turn on orcid mode for this page visit, or touch activity if it's
+  // already on. Mount-only (ref guard, not [orcidModeActive]) — otherwise
+  // this fires again every time the expiry watcher turns mode off while the
+  // user is sitting on this page, instantly re-enabling it and defeating
+  // the timeout.
   useEffect(() => {
+    if (hasEnabledOnVisitRef.current) {
+      return;
+    }
+    hasEnabledOnVisitRef.current = true;
     if (!orcidModeActive) {
       setOrcidMode(true);
+    } else {
+      touchOrcidActivity();
     }
-  }, [orcidModeActive]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -22,6 +22,7 @@ import {
 import { useGlobalErrorHandler } from './lib/useGlobalErrorHandler';
 import { ShepherdJourneyProvider } from 'react-shepherd';
 import type { AppPageProps } from '@/pages/_app';
+import { useOrcidExpiryWatcher } from '@/lib/orcid/useOrcid';
 
 export const Providers: FC<{ pageProps: AppPageProps }> = ({ children, pageProps }) => {
   const createStore = useCreateStore(pageProps.dehydratedAppState ?? {});
@@ -72,6 +73,7 @@ const Telemetry: FC = () => {
   const paginationSpanRef = useRef<ReturnType<typeof Sentry.startInactiveSpan> | null>(null);
 
   useGlobalErrorHandler();
+  useOrcidExpiryWatcher();
 
   useEffect(() => {
     try {

--- a/src/store/slices/orcid.test.ts
+++ b/src/store/slices/orcid.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createStore } from '@/store/store';
+import { isOrcidActivityStale } from '@/store/slices/orcid';
+import { ORCID_MODE_TIMEOUT } from '@/config';
+import mockOrcidUser from '@/mocks/responses/orcid/exchangeOAuthCode.json';
+
+describe('isOrcidActivityStale', () => {
+  test('is not stale when lastActivityAt is null', () => {
+    expect(isOrcidActivityStale(null)).toBe(false);
+  });
+
+  test('is not stale when within the timeout window', () => {
+    expect(isOrcidActivityStale(Date.now() - (ORCID_MODE_TIMEOUT - 1000))).toBe(false);
+  });
+
+  test('is stale once past the timeout window', () => {
+    expect(isOrcidActivityStale(Date.now() - (ORCID_MODE_TIMEOUT + 1000))).toBe(true);
+  });
+});
+
+describe('orcid slice', () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    store = createStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('setOrcidMode', () => {
+    test('stamps lastActivityAt when turning mode on', () => {
+      const now = Date.now();
+      store.getState().setOrcidMode(true);
+      expect(store.getState().orcid.active).toBe(true);
+      expect(store.getState().orcid.lastActivityAt).toBe(now);
+    });
+
+    test('clears lastActivityAt when turning mode off (manual toggle unaffected by expiry state)', () => {
+      store.getState().setOrcidMode(true);
+      store.getState().setOrcidMode(false);
+      expect(store.getState().orcid.active).toBe(false);
+      expect(store.getState().orcid.lastActivityAt).toBeNull();
+    });
+  });
+
+  describe('touchOrcidActivity', () => {
+    test('resets lastActivityAt while mode is active (sliding window)', () => {
+      store.getState().setOrcidMode(true);
+      const firstTimestamp = store.getState().orcid.lastActivityAt;
+
+      vi.advanceTimersByTime(60_000);
+      store.getState().touchOrcidActivity();
+
+      expect(store.getState().orcid.lastActivityAt).toBeGreaterThan(firstTimestamp);
+    });
+
+    test('is a no-op when mode is off', () => {
+      store.getState().touchOrcidActivity();
+      expect(store.getState().orcid.lastActivityAt).toBeNull();
+    });
+  });
+
+  describe('setOrcidUser', () => {
+    test('activates mode and stamps lastActivityAt for a valid user', () => {
+      const now = Date.now();
+      store.getState().setOrcidUser(mockOrcidUser);
+      expect(store.getState().orcid.active).toBe(true);
+      expect(store.getState().orcid.lastActivityAt).toBe(now);
+    });
+
+    test('deactivates mode and clears lastActivityAt for an invalid user', () => {
+      store.getState().setOrcidUser(mockOrcidUser);
+      // @ts-expect-error - testing with invalid user
+      store.getState().setOrcidUser({});
+      expect(store.getState().orcid.active).toBe(false);
+      expect(store.getState().orcid.lastActivityAt).toBeNull();
+    });
+  });
+
+  describe('resetOrcid', () => {
+    test('clears lastActivityAt along with the rest of orcid state', () => {
+      store.getState().setOrcidUser(mockOrcidUser);
+      store.getState().resetOrcid();
+      expect(store.getState().orcid).toEqual({
+        isAuthenticated: false,
+        user: null,
+        active: false,
+        lastActivityAt: null,
+      });
+    });
+  });
+});

--- a/src/store/slices/orcid.ts
+++ b/src/store/slices/orcid.ts
@@ -1,12 +1,16 @@
 import { StoreSlice } from '@/store';
 import { IOrcidUser } from '@/api/orcid/types';
 import { isValidIOrcidUser } from '@/api/orcid/models';
+import { ORCID_MODE_TIMEOUT } from '@/config';
 
 export interface IORCIDState {
   orcid: {
     isAuthenticated: boolean;
     user: IOrcidUser | null;
     active: boolean;
+    // timestamp (ms) of the last ORCiD activity; drives the sliding-window
+    // inactivity expiry. `null` when mode is off.
+    lastActivityAt: number | null;
   };
 }
 
@@ -14,12 +18,23 @@ export interface IORCIDAction {
   setOrcidUser: (user: IOrcidUser) => void;
   setOrcidMode: (active: boolean) => void;
   resetOrcid: () => void;
+  // resets the inactivity window; no-op when mode is off
+  touchOrcidActivity: () => void;
 }
 
 const initialState: IORCIDState['orcid'] = {
   isAuthenticated: false,
   user: null,
   active: false,
+  lastActivityAt: null,
+};
+
+/** Whether `lastActivityAt` is older than the ORCiD mode timeout. `null` is never stale. */
+export const isOrcidActivityStale = (lastActivityAt: number | null): boolean => {
+  if (lastActivityAt === null) {
+    return false;
+  }
+  return Date.now() - lastActivityAt > ORCID_MODE_TIMEOUT;
 };
 
 export const orcidSlice: StoreSlice<IORCIDState & IORCIDAction> = (set) => ({
@@ -27,17 +42,20 @@ export const orcidSlice: StoreSlice<IORCIDState & IORCIDAction> = (set) => ({
   setOrcidUser: (user) => {
     if (isValidIOrcidUser(user)) {
       return set((state) => ({
-        orcid: { ...state.orcid, user, isAuthenticated: true, active: true },
+        orcid: { ...state.orcid, user, isAuthenticated: true, active: true, lastActivityAt: Date.now() },
       }));
     }
     return set((state) => ({
-      orcid: { ...state.orcid, isAuthenticated: false, user: null, active: false },
+      orcid: { ...state.orcid, isAuthenticated: false, user: null, active: false, lastActivityAt: null },
     }));
   },
   setOrcidMode: (active) => {
     return set((state) => ({
-      orcid: { ...state.orcid, active },
+      orcid: { ...state.orcid, active, lastActivityAt: active ? Date.now() : null },
     }));
   },
   resetOrcid: () => set({ orcid: initialState }),
+  touchOrcidActivity: () => {
+    return set((state) => (state.orcid.active ? { orcid: { ...state.orcid, lastActivityAt: Date.now() } } : state));
+  },
 });

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+import { createStore, mergePersistedState } from '@/store/store';
+import { AppState } from '@/store';
+import { ORCID_MODE_TIMEOUT } from '@/config';
+import mockOrcidUser from '@/mocks/responses/orcid/exchangeOAuthCode.json';
+
+describe('mergePersistedState', () => {
+  test('silently clears stale orcid mode from persisted state', () => {
+    const currentState = createStore().getState();
+    const persistedState = {
+      orcid: {
+        isAuthenticated: true,
+        user: mockOrcidUser,
+        active: true,
+        lastActivityAt: Date.now() - (ORCID_MODE_TIMEOUT + 1000),
+      },
+    };
+
+    const merged = mergePersistedState(persistedState, currentState);
+
+    expect(merged.orcid.active).toBe(false);
+    expect(merged.orcid.lastActivityAt).toBeNull();
+    // rest of orcid state (auth/user) is untouched by expiry cleanup
+    expect(merged.orcid.isAuthenticated).toBe(true);
+    expect(merged.orcid.user).toEqual(mockOrcidUser);
+  });
+
+  test('leaves fresh orcid mode from persisted state alone', () => {
+    const currentState = createStore().getState();
+    const persistedState = {
+      orcid: {
+        isAuthenticated: true,
+        user: mockOrcidUser,
+        active: true,
+        lastActivityAt: Date.now() - 1000,
+      },
+    };
+
+    const merged = mergePersistedState(persistedState, currentState);
+
+    expect(merged.orcid.active).toBe(true);
+    expect(merged.orcid.lastActivityAt).toBe(persistedState.orcid.lastActivityAt);
+  });
+
+  test('leaves inactive persisted orcid mode alone', () => {
+    const currentState = createStore().getState();
+    const persistedState: Partial<AppState> = {
+      orcid: {
+        isAuthenticated: false,
+        user: null,
+        active: false,
+        lastActivityAt: null,
+      },
+    };
+
+    const merged = mergePersistedState(persistedState, currentState);
+
+    expect(merged.orcid.active).toBe(false);
+    expect(merged.orcid.lastActivityAt).toBeNull();
+  });
+
+  test('clears active mode persisted before lastActivityAt existed (missing key)', () => {
+    const currentState = createStore().getState();
+    // legacy shape: no lastActivityAt key at all, as would come from JSON
+    // parsed out of localStorage predating this field
+    const persistedState = {
+      orcid: { isAuthenticated: true, user: mockOrcidUser, active: true },
+    } as unknown as Partial<AppState>;
+
+    const merged = mergePersistedState(persistedState, currentState);
+
+    expect(merged.orcid.active).toBe(false);
+    expect(merged.orcid.lastActivityAt).toBeNull();
+  });
+
+  test('clears active mode with an explicit null lastActivityAt', () => {
+    const currentState = createStore().getState();
+    const persistedState: Partial<AppState> = {
+      orcid: { isAuthenticated: true, user: mockOrcidUser, active: true, lastActivityAt: null },
+    };
+
+    const merged = mergePersistedState(persistedState, currentState);
+
+    expect(merged.orcid.active).toBe(false);
+    expect(merged.orcid.lastActivityAt).toBeNull();
+  });
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,6 +6,7 @@ import { devtools, NamedSet, persist, subscribeWithSelector } from 'zustand/midd
 import {
   appModeSlice,
   docsSlice,
+  isOrcidActivityStale,
   notificationSlice,
   orcidSlice,
   searchSlice,
@@ -18,6 +19,28 @@ import { logger } from '@/logger';
 import { IUserData } from '@/api/user/types';
 
 export const APP_STORAGE_KEY = 'nectar-app-state';
+
+/**
+ * Merges persisted state over the fresh default state on rehydration.
+ * If ORCiD mode was left on and its timestamp is past the timeout,
+ * clear it silently here — this is stale-value cleanup, not an
+ * in-session expiry, so no toast.
+ */
+export const mergePersistedState = (persistedState: Partial<AppState>, currentState: AppState): AppState => {
+  const merged = mergeDeepLeft(persistedState, currentState) as AppState;
+  if (merged.orcid?.active) {
+    // Persisted data from before lastActivityAt existed (or otherwise
+    // malformed) has no usable timestamp — treat that as stale too, or
+    // mode gets stuck on forever since the expiry watcher won't schedule
+    // a timer for a null timestamp.
+    const lastActivityAt = merged.orcid.lastActivityAt;
+    const isStale = typeof lastActivityAt !== 'number' || isOrcidActivityStale(lastActivityAt);
+    if (isStale) {
+      merged.orcid = { ...merged.orcid, active: false, lastActivityAt: null };
+    }
+  }
+  return merged;
+};
 
 export const createStore = (preloadedState: Partial<AppState> = {}) => {
   const state = (set: NamedSet<AppState>, get: GetState<AppState>) => ({
@@ -56,7 +79,7 @@ export const createStore = (preloadedState: Partial<AppState> = {}) => {
             settings: state.settings,
             orcid: state.orcid,
           }),
-          merge: mergeDeepLeft,
+          merge: mergePersistedState,
         }),
         { name: APP_STORAGE_KEY },
       ),

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -86,6 +86,7 @@ const getStateFromPreset = (preset: IProviderOptions['storePreset']): Partial<Ap
           active: true,
           isAuthenticated: true,
           user: mockOrcidUser,
+          lastActivityAt: Date.now(),
         },
       };
   }


### PR DESCRIPTION
ORCiD mode stayed on indefinitely once toggled — no timeout, and it
persists across sessions via localStorage.

1. lastActivityAt on the orcid slice, stamped by toggle-on, claim/
   update/remove work, and /user/orcid visits
2. single root-mounted timer (avoids duplicate timers across the
   several useOrcid instances) turns mode off and toasts on expiry
3. stale mode cleared silently on rehydration, including legacy
   persisted state with no lastActivityAt

<img width="501" height="124" alt="image" src="https://github.com/user-attachments/assets/441fbed6-7957-4510-9622-4e505850ecad" />