### PR TITLE
SCIX-824 fix(theme): prevent dark-mode white flash on prod first paint

### DIFF
--- a/src/color-mode-no-flash.test.ts
+++ b/src/color-mode-no-flash.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { COLOR_MODE_NO_FLASH_CSS } from './color-mode-no-flash';
+import { theme } from './theme';
+
+/**
+ * Extract the declaration block whose selector list mentions the given
+ * color-mode token (e.g. "dark" -> the rule keyed to the dark color-mode
+ * class/attribute that ColorModeScript sets synchronously before hydration).
+ */
+const blockForMode = (css: string, mode: 'dark' | 'light'): string => {
+  const match = css.match(new RegExp(`([^{}]*${mode}[^{}]*)\\{([^}]*)\\}`, 'i'));
+  return match ? match[2] : '';
+};
+
+describe('COLOR_MODE_NO_FLASH_CSS', () => {
+  it('paints the dark theme background for the dark color-mode selector before hydration', () => {
+    const darkBlock = blockForMode(COLOR_MODE_NO_FLASH_CSS, 'dark');
+    const darkBg = theme.colors.gray['800'];
+
+    // The dark rule must set the theme dark background — this is what prevents
+    // the white flash on first paint before emotion injects global styles.
+    const bgMatch = darkBlock.match(/background-color:\s*([^;]+);/i);
+    expect(bgMatch?.[1]?.trim()).toBe(darkBg);
+
+    // Regression guard: the dark background must never resolve to white. Scope
+    // this to the background declaration so a `color: white` text rule is fine.
+    expect(bgMatch?.[1] ?? '').not.toMatch(/#fff\b|#ffffff\b|\bwhite\b/i);
+  });
+});

--- a/src/color-mode-no-flash.ts
+++ b/src/color-mode-no-flash.ts
@@ -1,0 +1,16 @@
+import { theme } from './theme';
+
+// Pre-hydration anti-flash rule: ColorModeScript sets these classes/attrs
+// synchronously before paint, so this CSS (inlined in <Head>) paints the
+// correct background/text color before emotion's global styles load.
+// Values must track `styles.global` in ./theme.ts or they will drift.
+export const COLOR_MODE_NO_FLASH_CSS = `
+  html[data-theme='dark'], body.chakra-ui-dark {
+    background-color: ${theme.colors.gray['800']};
+    color: white;
+  }
+  html[data-theme='light'], body.chakra-ui-light {
+    background-color: white;
+    color: ${theme.colors.gray['700']};
+  }
+`;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,6 @@
 import { ColorModeScript } from '@chakra-ui/react';
 import { theme } from '@/theme';
+import { COLOR_MODE_NO_FLASH_CSS } from '@/color-mode-no-flash';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import { ReactElement } from 'react';
 
@@ -7,7 +8,9 @@ class MyDocument extends Document {
   render(): ReactElement {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <style dangerouslySetInnerHTML={{ __html: COLOR_MODE_NO_FLASH_CSS }} />
+        </Head>
         <body>
           <ColorModeScript type="cookie" initialColorMode={theme.config.initialColorMode} />
           <Main />


### PR DESCRIPTION
On a production build, toggling dark mode then hard-refreshing flashed white before dark mode applied. Chakra's global html/body background is injected client-side by emotion (there is no SSR style extraction), so first paint was browser-white until the JS bundle parsed. This inlines a pre-hydration style, keyed to the color-mode class and data-theme attribute that ColorModeScript sets synchronously, so the correct background paints immediately.

1. Add theme-derived COLOR_MODE_NO_FLASH_CSS mirroring styles.global (bg gray.800/white, text white/gray.700)
2. Inline it in the _document Head, ahead of the blocking ColorModeScript
3. Unit test asserting the dark selector background resolves to the theme dark token, never white

Still needs a manual visual check against a production build (hard-refresh in dark mode). A durable follow-up would be real emotion SSR extraction, which fixes all SSR style FOUC but is a larger change.